### PR TITLE
Replaced all invocations to strlen and substr

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -573,7 +573,7 @@ class AMQPChannel extends AbstractChannel
         $this->send_method_frame(array(60, 40), $args);
 
         $this->connection->send_content($this->channel_id, 60, 0,
-                                        strlen($msg->body),
+                                        mb_strlen($msg->body, 'ASCII'),
                                         $msg->serialize_properties(),
                                         $msg->body);
     }

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -133,13 +133,13 @@ class AbstractChannel
         if($frame_type != 2)
             throw new \Exception("Expecting Content header");
 
-        $payload_reader = new AMQPReader(substr($payload,0,12));
+        $payload_reader = new AMQPReader(mb_substr($payload,0,12,'ASCII'));
         $class_id = $payload_reader->read_short();
         $weight = $payload_reader->read_short();
 
         $body_size = $payload_reader->read_longlong();
         $msg = new AMQPMessage();
-        $msg->load_properties(substr($payload,12));
+        $msg->load_properties(mb_substr($payload,12,mb_strlen($payload,'ASCII')-12));
 
         $body_parts = array();
         $body_received = 0;
@@ -151,7 +151,7 @@ class AbstractChannel
             if($frame_type != 3)
                 throw new \Exception("Expecting Content body, received frame type $frame_type");
             $body_parts[] = $payload;
-            $body_received = bcadd($body_received, strlen($payload));
+            $body_received = bcadd($body_received, mb_strlen($payload,'ASCII'));
         }
 
         $msg->body = implode("",$body_parts);
@@ -229,12 +229,12 @@ class AbstractChannel
             if($frame_type != 1)
                 throw new \Exception("Expecting AMQP method, received frame type: $frame_type");
 
-            if(strlen($payload) < 4)
+            if(mb_strlen($payload,'ASCII') < 4)
                 throw new \Exception("Method frame too short");
 
-            $method_sig_array = unpack("n2", substr($payload,0,4));
+            $method_sig_array = unpack("n2", mb_substr($payload,0,4,'ASCII'));
             $method_sig = "" . $method_sig_array[1] . "," . $method_sig_array[2];
-            $args = new AMQPReader(substr($payload,4));
+            $args = new AMQPReader(mb_substr($payload,4,mb_strlen($payload,'ASCII')-4),'ASCII');
 
             if($this->debug)
             {

--- a/PhpAmqpLib/Connection/AMQPConnection.php
+++ b/PhpAmqpLib/Connection/AMQPConnection.php
@@ -45,7 +45,8 @@ class AMQPConnection extends AbstractChannel
             $login_response = new AMQPWriter();
             $login_response->write_table(array("LOGIN" => array('S',$user),
                                                "PASSWORD" => array('S',$password)));
-            $login_response = substr($login_response->getvalue(),4); //Skip the length
+            $responseValue = $login_response->getvalue();
+            $login_response = mb_substr($responseValue,4,mb_strlen($responseValue,'ASCII'),'ASCII'); //Skip the length
         } else
             $login_response = NULL;
 
@@ -135,7 +136,7 @@ class AMQPConnection extends AbstractChannel
           MiscHelper::debug_msg("< [hex]:\n" . MiscHelper::hexdump($data, $htmloutput = false, $uppercase = true, $return = true));
         }
 
-        $len = strlen($data);
+        $len = mb_strlen($data, 'ASCII');
         while(true)
         {
             if(false === ($written = fwrite($this->sock, $data)))
@@ -148,7 +149,7 @@ class AMQPConnection extends AbstractChannel
             }
             $len = $len - $written;
             if($len>0)
-                $data=substr($data,0-$len);
+                $data=mb_substr($data,0-$len,0-$len,'ASCII');
             else
                 break;
         }
@@ -195,7 +196,7 @@ class AMQPConnection extends AbstractChannel
 
         $pkt->write_octet(2);
         $pkt->write_short($channel);
-        $pkt->write_long(strlen($packed_properties)+12);
+        $pkt->write_long(mb_strlen($packed_properties, 'ASCII')+12);
 
         $pkt->write_short($class_id);
         $pkt->write_short($weight);
@@ -208,13 +209,13 @@ class AMQPConnection extends AbstractChannel
 
         while($body)
         {
-            $payload = substr($body,0, $this->frame_max-8);
-            $body = substr($body,$this->frame_max-8);
+            $payload = mb_substr($body,0, $this->frame_max-8,'ASCII');
+            $body = mb_substr($body,$this->frame_max-8,mb_strlen($body,'ASCII')-($this->frame_max-8),'ASCII');
             $pkt = new AMQPWriter();
 
             $pkt->write_octet(3);
             $pkt->write_short($channel);
-            $pkt->write_long(strlen($payload));
+            $pkt->write_long(mb_strlen($payload, 'ASCII'));
 
             $pkt->write($payload);
 
@@ -233,7 +234,7 @@ class AMQPConnection extends AbstractChannel
 
         $pkt->write_octet(1);
         $pkt->write_short($channel);
-        $pkt->write_long(strlen($args)+4);  // 4 = length of class_id and method_id
+        $pkt->write_long(mb_strlen($args, 'ASCII')+4);  // 4 = length of class_id and method_id
         // in payload
 
         $pkt->write_short($method_sig[0]); // class_id

--- a/PhpAmqpLib/Helper/MiscHelper.php
+++ b/PhpAmqpLib/Helper/MiscHelper.php
@@ -47,7 +47,7 @@ class MiscHelper
         $ascii  = '';
         $dump   = ($htmloutput === true) ? '<pre>' : '';
         $offset = 0;
-        $len    = strlen($data);
+        $len    = mb_strlen($data,'ASCII');
 
         // Upper or lower case hexidecimal
         $x = ($uppercase === false) ? 'x' : 'X';

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -56,21 +56,21 @@ class AMQPReader
             while($read < $n && !feof($this->sock->real_sock()) &&
                   (false !== ($buf = fread($this->sock->real_sock(), $n - $read))))
             {
-                $read += strlen($buf);
+                $read += mb_strlen($buf,'ASCII');
                 $res .= $buf;
             }
 
-            if(strlen($res)!=$n)
+            if(mb_strlen($res,'ASCII')!=$n)
                 throw new \Exception("Error reading data. Recevived " .
-                                     strlen($res) . " instead of expected $n bytes");
+                                     mb_strlen($res,'ASCII') . " instead of expected $n bytes");
             $this->offset += $n;
         } else
         {
-            if(strlen($this->str) < $n)
+            if(mb_strlen($this->str,'ASCII') < $n)
                 throw new \Exception("Error reading data. Requested $n bytes while string buffer has only " .
-                                     strlen($this->str));
-            $res = substr($this->str,0,$n);
-            $this->str = substr($this->str,$n);
+                                     mb_strlen($this->str,'ASCII'));
+            $res = mb_substr($this->str,0,$n,'ASCII');
+            $this->str = mb_substr($this->str,$n,mb_strlen($this->str,'ASCII')-$n,'ASCII');
             $this->offset += $n;
         }
         return $res;

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -156,9 +156,9 @@ class AMQPWriter
     public function write_shortstr($s)
     {
         $this->flushbits();
-        if(strlen($s) > 255)
+        if(mb_strlen($s,'ASCII') > 255)
             throw new \InvalidArgumentException('String too long');
-        $this->write_octet(strlen($s));
+        $this->write_octet(mb_strlen($s,'ASCII'));
         $this->out .= $s;
         return $this;
     }
@@ -170,7 +170,7 @@ class AMQPWriter
     public function write_longstr($s)
     {
         $this->flushbits();
-        $this->write_long(strlen($s));
+        $this->write_long(mb_strlen($s,'ASCII'));
         $this->out .= $s;
         return $this;
     }
@@ -222,7 +222,7 @@ class AMQPWriter
             }
         }
         $table_data = $table_data->getvalue();
-        $this->write_long(strlen($table_data));
+        $this->write_long(mb_strlen($table_data,'ASCII'));
         $this->write($table_data);
         return $this;
     }

--- a/PhpAmqpLib/Wire/BufferedInput.php
+++ b/PhpAmqpLib/Wire/BufferedInput.php
@@ -20,7 +20,7 @@ class BufferedInput
 
     public function read($n)
     {
-        if ($this->offset >= strlen($this->buffer))
+        if ($this->offset >= mb_strlen($this->buffer,'ASCII'))
         {
             if (!($rv = $this->populate_buffer()))
             {
@@ -38,7 +38,7 @@ class BufferedInput
 
     private function read_buffer($n)
     {
-        $n = min($n, strlen($this->buffer) - $this->offset);
+        $n = min($n, mb_strlen($this->buffer,'ASCII') - $this->offset);
         if ($n === 0)
         {
             // substr("", 0, 0) => FALSE, which screws up read loops that are
@@ -46,7 +46,7 @@ class BufferedInput
             // case when the buffer is empty/used up.
             return "";
         }
-        $block = substr($this->buffer, $this->offset, $n);
+        $block = mb_substr($this->buffer, $this->offset, $n, 'ASCII');
         $this->offset += $n;
         return $block;
     }

--- a/benchmark/file_publish.php
+++ b/benchmark/file_publish.php
@@ -25,7 +25,7 @@ function generate_random_content($bytes)
         $max = $bytes;
         while($len < $max-1) {
             $buffer .= fgets($handle, $max-$len);
-            $len = strlen($buffer);
+            $len = mb_strlen($buffer,'ASCII');
         }
         fclose($handle);
     }


### PR DESCRIPTION
This modifications are to make the library compatible with environments in which php has been configured to override string functions with the correspondent mb_string ones (i.e. to force the internal encoding to UTF-8).
