### PR TITLE
added a way to attent your own sockets

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -177,7 +177,7 @@ class AbstractChannel
      * Unexpected methods are queued up for later calls to this Python
      * method.
      */
-    public function wait($allowed_methods=NULL)
+    public function wait($allowed_methods=NULL, $non_blocking = false)
     {
         if($allowed_methods)
         {
@@ -260,6 +260,8 @@ class AbstractChannel
               MiscHelper::debug_msg("Queueing for later: $method_sig: " . self::$GLOBAL_METHOD_NAMES[MiscHelper::methodSig($method_sig)]);
             }
             $this->method_queue[] = array($method_sig, $args, $content);
+
+            if($non_blocking) break;
         }
     }
 

--- a/PhpAmqpLib/Connection/AMQPConnection.php
+++ b/PhpAmqpLib/Connection/AMQPConnection.php
@@ -500,4 +500,12 @@ class AMQPConnection extends AbstractChannel
         $this->wait_tune_ok = False;
     }
 
+    /**
+     * get socket from current connection
+     */
+    public function getSocket()
+    {
+        return $this->sock;
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Then to stop the consumer, send to it the `quit` message:
 
     $ php amqp_publisher.php quit
 
+If you need to attent your sockets try non blocking consumer.
+
+    $ php amqp_consumer_non_blocking.php
+
 ## Loading Classes ##
 
 The library uses the [Symfony ClassLoader component](https://github.com/symfony/ClassLoader) in order to use a standard way of class loading.

--- a/demo/amqp_consumer_non_blocking.php
+++ b/demo/amqp_consumer_non_blocking.php
@@ -1,0 +1,85 @@
+<?php
+
+include(__DIR__ . '/config.php');
+use PhpAmqpLib\Connection\AMQPConnection;
+
+$exchange = 'router';
+$queue = 'msgs';
+$consumer_tag = 'consumer';
+
+$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$ch = $conn->channel();
+
+/*
+    The following code is the same both in the consumer and the producer.
+    In this way we are sure we always have a queue to consume from and an
+        exchange where to publish messages.
+*/
+
+/*
+    name: $queue
+    passive: false
+    durable: true // the queue will survive server restarts
+    exclusive: false // the queue can be accessed in other channels
+    auto_delete: false //the queue won't be deleted once the channel is closed.
+*/
+$ch->queue_declare($queue, false, true, false, false);
+
+/*
+    name: $exchange
+    type: direct
+    passive: false
+    durable: true // the exchange will survive server restarts
+    auto_delete: false //the exchange won't be deleted once the channel is closed.
+*/
+
+$ch->exchange_declare($exchange, 'direct', false, true, false);
+
+$ch->queue_bind($queue, $exchange);
+
+function process_message($msg) {
+
+    echo "\n--------\n";
+    echo $msg->body;
+    echo "\n--------\n";
+
+    $msg->delivery_info['channel']->
+        basic_ack($msg->delivery_info['delivery_tag']);
+
+    // Send a message with the string "quit" to cancel the consumer.
+    if ($msg->body === 'quit') {
+        $msg->delivery_info['channel']->
+            basic_cancel($msg->delivery_info['consumer_tag']);
+    }
+}
+
+/*
+    queue: Queue from where to get the messages
+    consumer_tag: Consumer identifier
+    no_local: Don't receive messages published by this consumer.
+    no_ack: Tells the server if the consumer will acknowledge the messages.
+    exclusive: Request exclusive consumer access, meaning only this consumer can access the queue
+    nowait:
+    callback: A PHP Callback
+*/
+
+$ch->basic_consume($queue, $consumer_tag, false, false, false, false, 'process_message');
+
+function shutdown($ch, $conn){
+    $ch->close();
+    $conn->close();
+}
+register_shutdown_function('shutdown', $ch, $conn);
+
+// Loop as long as the channel has callbacks registered
+while(count($ch->callbacks)) {
+    $read   = array($conn->getSocket()); // add here other sockets that you need to attend
+    $write  = NULL;
+    $except = NULL;
+    if (false === ($num_changed_streams = stream_select($read, $write, $except, 60))) {
+        /* Error handling */
+    } elseif ($num_changed_streams > 0) {
+        $ch->wait();
+    }
+}
+?>


### PR DESCRIPTION
Hola Álvaro,

Hemos añadido una forma de poder atender a los sockets de nuestra propia aplicación usando un 'stream_select' dónde añadimos el socket que se usa para conectar con RabbitMQ y nuestros propios sockets.
He añadido un ejemplo de consumidor no bloqueante que muestra la idea.

Saludos y espero verte pronto en algun congreso ;)
