### PR TITLE
fclose() suppression operator + backward ternary op for channel()

### DIFF
--- a/PhpAmqpLib/Connection/AMQPConnection.php
+++ b/PhpAmqpLib/Connection/AMQPConnection.php
@@ -280,7 +280,7 @@ class AMQPConnection extends AbstractChannel
         if (isset($this->channels[$channel_id])) {
             return $this->channels[$channel_id];
         } else {
-            $channel_id = $channel_id ? $this->get_free_channel_id() : $channel_id;
+            $channel_id = $channel_id ? $channel_id : $this->get_free_channel_id();
             $ch = new AMQPChannel($this->connection, $channel_id);
             $this->channels[$channel_id] =  $ch;
             return $ch;


### PR DESCRIPTION
Wrapped fclose() in is_resource() call. It gets called twice in many instances (BufferedInput closes socket first, then close_socket attempts again). Custom error routines in some frameworks don't check for 0 value in $error_type of set_error_handler indicating @ suppression operator used. This is safer.
