### PR TITLE
Add additional AMQP data types (t, l)

### DIFF
--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -261,6 +261,12 @@ class AMQPReader
                 $n = $this->read_signed_long();
                 $val = new AMQPDecimal($n, $e);
                 break;
+            case 't':
+                $val = $this->read_octet();
+                break;
+            case 'l':
+                $val = $this->read_longlong();
+                break;
             case 'T': // Timestamp
                 $val = $this->read_timestamp();
                 break;


### PR DESCRIPTION
While working with x-federated exchange and trying to consume messages thought RabbitMQBundle found that "t" and "l" data types seems to be required.
