### PR TITLE
Throw InvalidArgumentException instead of dumping to errors log when value type is not found

### DIFF
--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -278,7 +278,7 @@ class AMQPReader
                 break;
             default:
                 // UNKNOWN TYPE
-                error_log("Usupported table field type $fieldType");
+                throw new \RuntimeException("Usupported table field type {$fieldType}");
                 break;
         }
 


### PR DESCRIPTION
Relates to #28
