### PR TITLE
Disconnect - issue #24

### DIFF
--- a/PhpAmqpLib/Connection/AMQPConnection.php
+++ b/PhpAmqpLib/Connection/AMQPConnection.php
@@ -102,9 +102,9 @@ class AMQPConnection extends AbstractChannel
     public function __destruct()
     {
         if (isset($this->input) && $this->input) {
-            // if the connection has gane away then when
-            // close() is called and tries to connect to the server
-            // it will cause a fatal error, so catch error
+            // close() always tries to connect to the server to shutdown 
+            // the connection. If the server has gone away, it will 
+            // throw an error in the connection class, so catch it 
             // and shutdown quietly
             try {
                $this->close();


### PR DESCRIPTION
simple fix for Issue #24.  Adds an empty catch for the destructor in Connection/AMQPConnection.php so that if the connection to the server has gone away, and close() fails, the fatal error is caught, and the calling application has the ability to act accordingly.
