### PR TITLE
fixed type typo for cluster_id property

### DIFF
--- a/PhpAmqpLib/Message/AMQPMessage.php
+++ b/PhpAmqpLib/Message/AMQPMessage.php
@@ -23,7 +23,7 @@ class AMQPMessage extends GenericContent
         "type" => "shortstr",
         "user_id" => "shortstr",
         "app_id" => "shortstr",
-        "cluster_id" => "shortst"
+        "cluster_id" => "shortstr"
     );
 
     public function __construct($body = '', $properties = null)


### PR DESCRIPTION
Fixed type typo which resulted in PHP FATAL, if variable was set
"shortst"  => "shortstr"
