### PR TITLE
Fix frame_queue LIFO to FIFO

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -118,7 +118,7 @@ class AbstractChannel
         }
 
         if(!empty($this->frame_queue)) {
-            return array_pop($this->frame_queue);
+            return array_shift($this->frame_queue);
         }
 
         return $this->connection->wait_channel($this->channel_id);


### PR DESCRIPTION
Wrong frame order caused an error "Expecting AMQP method, received frame type: 3"
