### PR TITLE
Avoid Warning message on rabbit server down and E_STRICT mode

### DIFF
--- a/PhpAmqpLib/Connection/AMQPConnection.php
+++ b/PhpAmqpLib/Connection/AMQPConnection.php
@@ -74,10 +74,10 @@ class AMQPConnection extends AbstractChannel
             //TODO clean up
             if ($context) {
               $remote = sprintf('ssl://%s:%s', $host, $port);
-              $this->sock = stream_socket_client($remote, $errno, $errstr, $connection_timeout, STREAM_CLIENT_CONNECT, $context);
+              $this->sock = @stream_socket_client($remote, $errno, $errstr, $connection_timeout, STREAM_CLIENT_CONNECT, $context);
             } else {
               $remote = sprintf('tcp://%s:%s', $host, $port);
-              $this->sock = stream_socket_client($remote, $errno, $errstr, $connection_timeout, STREAM_CLIENT_CONNECT);
+              $this->sock = @stream_socket_client($remote, $errno, $errstr, $connection_timeout, STREAM_CLIENT_CONNECT);
             }
 
             if (!$this->sock) {


### PR DESCRIPTION
Hi,

After testing this lib in E_STRICT mode PHP 5.4 I found that this gives a warning message when our rabbit server is down. I saw you perform a check if  `$this->sock` is null but before this PHP gives an this annoying warning message.

If you put a silent `@` before stream_socket_client you can remove the warning and continue with the exception working perfectly.

I'd like to add this to your code.

Thank you very much
