### PR TITLE
Fixed AMQPWriter::write_table() unexpectedly defaulting to array type

### DIFF
--- a/PhpAmqpLib/Tests/Unit/Wire/AMQPWriterTest.php
+++ b/PhpAmqpLib/Tests/Unit/Wire/AMQPWriterTest.php
@@ -33,4 +33,28 @@ class AMQPWriterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $out);
     }
+
+    public function testWriteTable()
+    {
+        $this->_writer->write_table(array(
+            'x-foo' => ['S', 'bar'],
+            'x-bar' => ['A', ['baz', 'qux']],
+        ));
+
+        $out = $this->_writer->getvalue();
+
+
+        $expected = "\x00\x00\x00)\x05x-fooS\x00\x00\x00\x03bar\x05x-barA\x00\x00\x00\x10S\x00\x00\x00\x03bazS\x00\x00\x00\x03qux";
+
+        $this->assertEquals($expected, $out);
+    }
+
+    public function testWriteTableThrowsExceptionOnInvalidType()
+    {
+        $this->setExpectedException('InvalidArgumentException', "Invalid type '_'");
+
+        $this->_writer->write_table(array(
+            'x-foo' => ['_', 'bar'],
+        ));
+    }
 }

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -270,9 +270,11 @@ class AMQPWriter
             } elseif ($ftype=='F') {
                 $table_data->write('F');
                 $table_data->write_table($v);
-            } elseif ($ftype = 'A') {
+            } elseif ($ftype=='A') {
                 $table_data->write('A');
                 $table_data->write_array($v);
+            } else {
+                throw new \InvalidArgumentException(sprintf("Invalid type '%s'", $ftype));
             }
         }
 


### PR DESCRIPTION
This fixes a typo in AMQPWriter::write_table() causing the method to default to the array type:

https://github.com/arnaud-lb/php-amqplib/blob/f24260aff0551abd928c397407f3c1a728595788/PhpAmqpLib/Wire/AMQPWriter.php#L261

The PR replaces this unexpected assignment by an equality test; and throws an exception if the type is not handled.
