### PR TITLE
Do not throw Exception in rawread due to long running consumers exiting ...

### DIFF
--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -54,12 +54,6 @@ class AMQPReader
             while ($read < $n && !feof($this->sock->real_sock()) &&
                     (false !== ($buf = fread($this->sock->real_sock(), $n - $read)))) {
 
-                // get status of socket to determine whether or not it has timed out
-                $info = stream_get_meta_data($this->sock->real_sock());
-                if($info['timed_out']) {
-                    throw new \Exception('Error reading data. Socket connection timed out');
-                }
-
                 $read += strlen($buf);
                 $res .= $buf;
             }


### PR DESCRIPTION
Merging of https://github.com/videlalvaro/php-amqplib/pull/56 introduced issue where long running consumers exit upon a message not being received within specified timeout period.  This is undesired behavior and this PR patches that while a better solution can be explored.
