### PR TITLE
ext-bcmath is a requirement of php-amqplib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-bcmath": "*"
     },
     "autoload": {
         "psr-0": {"PhpAmqpLib": ""}


### PR DESCRIPTION
I started getting an odd error on an old CentOS box when I installed PHP 5.4 on it (described here: https://github.com/tnc/php-amqplib/issues/14). Turns out my installation of PHP 5.4 didn't have php54w-bcmath installed by default, so I installed it and it fixed this issue. The issue would've been easier to discover if php-amqplib's composer.json required the extension ;)
