### PR TITLE
Enable wait()ing for a fractional number of seconds

### DIFF
--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -80,7 +80,7 @@ class AMQPReader
         }
 
         // wait ..
-        $result = $this->io->select($this->timeout, 0);
+        $result = $this->io->select((int)$this->timeout, (int)(fmod($timeout, 1) * 1000000));
 
         if ($result === false) {
             throw new AMQPRuntimeException(sprintf("An error occurs", $this->timeout));


### PR DESCRIPTION
This patch makes it possible to pass a fractional number of seconds to AMQPChannel::wait(), which is useful if you just want to check if there's a new result and quickly return.
