### PR TITLE
Check for valid socket resource before closing the AMQP connection

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -303,17 +303,20 @@ class AbstractConnection extends AbstractChannel
      */
     public function close($reply_code=0, $reply_text="", $method_sig=array(0, 0))
     {
-        list($class_id, $method_id, $args) = $this->protocolWriter->connectionClose(
-            $reply_code,
-            $reply_text,
-            $method_sig[0],
-            $method_sig[1]
-        );
-        $this->send_method_frame(array($class_id, $method_id), $args);
+        // IO must be connected before closing the AMQP connection
+        if ($this->io->isConnected()) {
+            list($class_id, $method_id, $args) = $this->protocolWriter->connectionClose(
+                $reply_code,
+                $reply_text,
+                $method_sig[0],
+                $method_sig[1]
+            );
+            $this->send_method_frame(array($class_id, $method_id), $args);
 
-        return $this->wait(array(
-                $this->waitHelper->get_wait('connection.close_ok')
-            ));
+            return $this->wait(array(
+                    $this->waitHelper->get_wait('connection.close_ok')
+                ));
+        }
     }
 
     public static function dump_table($table)

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -11,4 +11,6 @@ abstract class AbstractIO
     abstract public function close();
 
     abstract public function select($sec, $usec);
+
+    abstract public function isConnected();
 }

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -80,4 +80,12 @@ class SocketIO extends AbstractIO
         $except = null;
         return socket_select($read, $write, $except, $sec, $usec);
     }
+
+    /**
+     * Check to see if the socket is valid
+     */
+    public function isConnected()
+    {
+        return is_resource($this->sock);
+    }
 }

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -100,4 +100,12 @@ class StreamIO extends AbstractIO
         $except = null;
         return stream_select($read, $write, $except, $sec, $usec);
     }
+
+    /**
+     * Check to see if the socket is valid
+     */
+    public function isConnected()
+    {
+        return is_resource($this->sock);
+    }
 }


### PR DESCRIPTION
During the course of development, I ran into a situation where my code was trying to close the AMQPConnection multiple times. Besides this being poorly coded on my end, I thought it would be useful to check for a valid socket before trying to close the AMQP connection to RabbitMQ.
