### PR TITLE
Add simple reconnect logic to AbstractConnection and AbstractIO

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -39,19 +39,30 @@ class AbstractConnection extends AbstractChannel
                                 $locale="en_US",
                                 AbstractIO $io)
     {
-    	// save the params for the use of __clone
+        // save the params for the use of __clone
         $this->construct_params = func_get_args();
 
+        $this->vhost = $vhost;
+        $this->insist = $insist;
+        $this->loginMethod = $login_method;
+        $this->loginResponse = $login_response;
+        $this->locale = $locale;
+        $this->io = $io;
+
         if ($user && $password) {
-            $login_response = new AMQPWriter();
-            $login_response->write_table(array("LOGIN" => array('S',$user),
+            $this->loginResponse = new AMQPWriter();
+            $this->loginResponse->write_table(array("LOGIN" => array('S',$user),
                 "PASSWORD" => array('S',$password)));
-            $login_response = substr($login_response->getvalue(),4); //Skip the length
+            $this->loginResponse = substr($this->loginResponse->getvalue(),4); //Skip the length
         } else {
-            $login_response = null;
+            $this->loginResponse = null;
         }
 
-        $d = self::$LIBRARY_PROPERTIES;
+        $this->connect();
+    }
+
+    private function connect()
+    {
         while (true) {
             $this->channels = array();
             // The connection object itself is treated as channel 0
@@ -60,12 +71,11 @@ class AbstractConnection extends AbstractChannel
             $this->channel_max = 65535;
             $this->frame_max = 131072;
 
-            $this->io = $io;
             $this->input = new AMQPReader(null, $this->io);
 
             $this->write($this->amqp_protocol_header);
             $this->wait(array($this->waitHelper->get_wait('connection.start')));
-            $this->x_start_ok($d, $login_method, $login_response, $locale);
+            $this->x_start_ok(self::$LIBRARY_PROPERTIES, $this->loginMethod, $this->loginResponse, $this->locale);
 
             $this->wait_tune_ok = true;
             while ($this->wait_tune_ok) {
@@ -75,7 +85,7 @@ class AbstractConnection extends AbstractChannel
                 ));
             }
 
-            $host = $this->x_open($vhost,"", $insist);
+            $host = $this->x_open($this->vhost,"", $this->insist);
             if (!$host) {
                 return; // we weren't redirected
             }
@@ -84,6 +94,22 @@ class AbstractConnection extends AbstractChannel
             $this->close_socket();
         }
     }
+
+    /**
+     * Reconnect using the original connection settings, this will not recreate any channels that had were established previously
+     */
+    public function reconnect()
+    {
+        try {
+            // Try to close the AMQP connection
+            $this->close();
+        } catch (\Exception $e) {/* Ignore closing errors */}
+
+        // Reconnect the socket/stream then AMQP
+        $this->io->reconnect();
+        $this->connect();
+    }
+
     /**
      * cloning will use the old properties to make a new connection to the same server
      */
@@ -162,7 +188,7 @@ class AbstractConnection extends AbstractChannel
     }
 
     public function send_content($channel, $class_id, $weight, $body_size,
-                        $packed_properties, $body)
+                                 $packed_properties, $body)
     {
         $pkt = new AMQPWriter();
 
@@ -219,8 +245,8 @@ class AbstractConnection extends AbstractChannel
 
         if ($this->debug) {
             $PROTOCOL_CONSTANTS_CLASS = self::$PROTOCOL_CONSTANTS_CLASS;
-                MiscHelper::debug_msg("< " . MiscHelper::methodSig($method_sig) . ": " .
-                           $PROTOCOL_CONSTANTS_CLASS::$GLOBAL_METHOD_NAMES[MiscHelper::methodSig($method_sig)]);
+            MiscHelper::debug_msg("< " . MiscHelper::methodSig($method_sig) . ": " .
+            $PROTOCOL_CONSTANTS_CLASS::$GLOBAL_METHOD_NAMES[MiscHelper::methodSig($method_sig)]);
         }
 
     }
@@ -270,7 +296,7 @@ class AbstractConnection extends AbstractChannel
             // Not the channel we were looking for.  Queue this frame
             //for later, when the other channel is looking for frames.
             array_push($this->channels[$frame_channel]->frame_queue,
-                       array($frame_type, $payload));
+                array($frame_type, $payload));
 
             // If we just queued up a method for channel 0 (the Connection
             // itself) it's probably a close method in reaction to some
@@ -312,8 +338,8 @@ class AbstractConnection extends AbstractChannel
         $this->send_method_frame(array($class_id, $method_id), $args);
 
         return $this->wait(array(
-                $this->waitHelper->get_wait('connection.close_ok')
-            ));
+            $this->waitHelper->get_wait('connection.close_ok')
+        ));
     }
 
     public static function dump_table($table)
@@ -397,7 +423,7 @@ class AbstractConnection extends AbstractChannel
     {
         $this->known_hosts = $args->read_shortstr();
         if ($this->debug) {
-          MiscHelper::debug_msg("Open OK! known_hosts: " . $this->known_hosts);
+            MiscHelper::debug_msg("Open OK! known_hosts: " . $this->known_hosts);
         }
 
         return null;
@@ -412,7 +438,7 @@ class AbstractConnection extends AbstractChannel
         $host = $args->read_shortstr();
         $this->known_hosts = $args->read_shortstr();
         if ($this->debug) {
-          MiscHelper::debug_msg("Redirected to [". $host . "], known_hosts [" . $this->known_hosts . "]" );
+            MiscHelper::debug_msg("Redirected to [". $host . "], known_hosts [" . $this->known_hosts . "]" );
         }
 
         return $host;
@@ -448,12 +474,12 @@ class AbstractConnection extends AbstractChannel
         $this->locales = explode(" ", $args->read_longstr());
 
         if ($this->debug) {
-          MiscHelper::debug_msg(sprintf("Start from server, version: %d.%d, properties: %s, mechanisms: %s, locales: %s",
-                            $this->version_major,
-                            $this->version_minor,
-                            self::dump_table($this->server_properties),
-                            implode(', ', $this->mechanisms),
-                            implode(', ', $this->locales)));
+            MiscHelper::debug_msg(sprintf("Start from server, version: %d.%d, properties: %s, mechanisms: %s, locales: %s",
+                $this->version_major,
+                $this->version_minor,
+                self::dump_table($this->server_properties),
+                implode(', ', $this->mechanisms),
+                implode(', ', $this->locales)));
         }
 
     }

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -11,4 +11,6 @@ abstract class AbstractIO
     abstract public function close();
 
     abstract public function select($sec, $usec);
+
+    abstract public function reconnect();
 }


### PR DESCRIPTION
I separated out the connect logic into its own private method, and added a reconnect method. I ran through several scenarios with it while testing, including load balancer connection closing. I would love to see some sort of reconnect logic make it into this library!
