### PR TITLE
Lazy connection support

### DIFF
--- a/PhpAmqpLib/Connection/AMQPLazyConnection.php
+++ b/PhpAmqpLib/Connection/AMQPLazyConnection.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace PhpAmqpLib\Connection;
+
+class AMQPLazyConnection extends AMQPConnection
+{
+    protected $sock = null;
+
+    private $host;
+    private $port;
+    private $user;
+    private $password;
+    private $vhost;
+    private $insist;
+    private $login_method;
+    private $login_response;
+    private $locale;
+    private $connection_timeout;
+    private $read_write_timeout;
+    private $context;
+
+    function __construct(
+        $host,
+        $port,
+        $user,
+        $password,
+        $vhost="/",
+        $insist=false,
+        $login_method="AMQPLAIN",
+        $login_response=null,
+        $locale="en_US",
+        $connection_timeout = 3,
+        $read_write_timeout = 3,
+        $context = null
+    ) {
+        $this->host = $host;
+        $this->port = $port;
+        $this->user = $user;
+        $this->password = $password;
+        $this->vhost = $vhost;
+        $this->insist = $insist;
+        $this->login_method = $login_method;
+        $this->login_response = $login_response;
+        $this->locale = $locale;
+        $this->connection_timeout = $connection_timeout;
+        $this->read_write_timeout = $read_write_timeout;
+        $this->context = $context;
+    }
+
+
+    /**
+     * get socket from current connection
+     *
+     * @deprecated
+     */
+    public function getSocket()
+    {
+        $this->initLazyConnection();
+
+        return $this->sock;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function channel($channel_id = null)
+    {
+        $this->initLazyConnection();
+
+        return parent::channel($channel_id);
+    }
+
+    /**
+     * @return null|\PhpAmqpLib\Wire\IO\AbstractIO
+     */
+    protected function getIO()
+    {
+        $this->initLazyConnection();
+
+        return $this->io;
+    }
+
+    /**
+     * Initialize the lazy connection if not initialized yet
+     */
+    private function initLazyConnection()
+    {
+        if (is_null($this->io)) {
+            parent::__construct(
+                $this->host,
+                $this->port,
+                $this->user,
+                $this->password,
+                $this->vhost,
+                $this->insist,
+                $this->login_method,
+                $this->login_response,
+                $this->locale,
+                $this->connection_timeout,
+                $this->read_write_timeout,
+                $this->context
+            );
+        }
+    }
+
+}

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -18,4 +18,12 @@ class AMQPSocketConnection extends AbstractConnection
 
         parent::__construct($user, $password, $vhost, $insist, $login_method, $login_response, $locale, $io);
     }
+
+    /**
+     * @return null|\PhpAmqpLib\Wire\IO\AbstractIO
+     */
+    protected function getIO()
+    {
+        return $this->io;
+    }
 }

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -37,4 +37,12 @@ class AMQPStreamConnection extends AbstractConnection
         return $this->sock;
     }
 
+    /**
+     * @return null|\PhpAmqpLib\Wire\IO\AbstractIO
+     */
+    protected function getIO()
+    {
+        return $this->io;
+    }
+
 }

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -12,7 +12,7 @@ use PhpAmqpLib\Wire\AMQPWriter;
 use PhpAmqpLib\Wire\AMQPReader;
 use PhpAmqpLib\Wire\IO\AbstractIO;
 
-class AbstractConnection extends AbstractChannel
+abstract class AbstractConnection extends AbstractChannel
 {
     public static $LIBRARY_PROPERTIES = array(
         "library" => array('S', "PHP AMQP Lib"),
@@ -30,6 +30,9 @@ class AbstractConnection extends AbstractChannel
      */
     protected $close_on_destruct = true ;
 
+    /**
+     * @var null|\PhpAmqpLib\Wire\IO\AbstractIO
+     */
     protected $io = null;
 
     public function __construct($user, $password,
@@ -109,7 +112,7 @@ class AbstractConnection extends AbstractChannel
 
     public function select($sec, $usec = 0)
     {
-        return $this->io->select($sec, $usec);
+        return $this->getIO()->select($sec, $usec);
     }
 
     /**
@@ -128,7 +131,7 @@ class AbstractConnection extends AbstractChannel
             MiscHelper::debug_msg("closing socket");
         }
 
-        $this->io->close();
+        $this->getIO()->close();
     }
 
     protected function write($data)
@@ -137,7 +140,7 @@ class AbstractConnection extends AbstractChannel
             MiscHelper::debug_msg("< [hex]:\n" . MiscHelper::hexdump($data, $htmloutput = false, $uppercase = true, $return = true));
         }
 
-        $this->io->write($data);
+        $this->getIO()->write($data);
     }
 
     protected function do_close()
@@ -509,5 +512,10 @@ class AbstractConnection extends AbstractChannel
     {
         return $this->sock;
     }
+
+    /**
+     * @return \PhpAmqpLib\Wire\IO\AbstractIO
+     */
+    protected abstract function getIO();
 
 }


### PR DESCRIPTION
AMQPLazyConnection class that simply extends AMQPConnection. This is really helpful in Symfony RabbitMqBundle (support to be added) in order to avoid a connection to the broker at every single web request (too much expensive in a production environment).

I guess we can also downgrade visibility of many public methods in AbstractConnection and AbstractChannel, achieving a better OOP style. It needs a stronger refactoring.
