### PR TITLE
use PHP's pack function to handle write_long

### DIFF
--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -141,7 +141,7 @@ class AMQPWriter
     public function write_long($n)
     {
         $this->flushbits();
-        $this->out .= implode("", AMQPWriter::chrbytesplit($n,4));
+        $this->out .= pack('N', $n);
 
         return $this;
     }


### PR DESCRIPTION
Using the library to process thousands of messages and profiling the execution time, I realized that AMQPWriter::chrbytesplit was a huge pain point.

In the case of write_long, looks that we can simply use PHP's pack function, which is straightforward and faster.

But maybe AMQPWriter::chrbytesplit was here for a good reason. If so please tell why :-)
