### PR TITLE
rewrite write_longlong

### DIFF
--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -162,7 +162,17 @@ class AMQPWriter
     public function write_longlong($n)
     {
         $this->flushbits();
-        $this->out .= implode("", AMQPWriter::chrbytesplit($n,8));
+
+        // if PHP_INT_MAX is big enough for that
+        // (always on 64 bits, with smaller values in 32 bits)
+        if ($n <= PHP_INT_MAX) {
+            // trick explained in http://www.php.net/manual/fr/function.pack.php#109328
+            $n1 = ($n & 0xffffffff00000000) >> 32;
+            $n2 = ($n & 0x00000000ffffffff);
+            $this->out .= pack('NN', $n1, $n2);
+        } else {
+            $this->out .= implode("", AMQPWriter::chrbytesplit($n, 8));
+        }
 
         return $this;
     }


### PR DESCRIPTION
Similar to #104, we can avoid chrbytesplit/bytesplit on 64bits platform, or with the smaller values.

With bigger values like 994294967296, unit test was failing on a 32 bits platform.

This is why we test if $n <= PHP_INT_MAX before using the optimised code.
