### PR TITLE
replace write_bit/flush_bits by write_bits

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -378,7 +378,7 @@ class AbstractConnection extends AbstractChannel
         $args = new AMQPWriter();
         $args->write_shortstr($virtual_host);
         $args->write_shortstr($capabilities);
-        $args->write_bit($insist);
+        $args->write_bits(array($insist));
         $this->send_method_frame(array(10, 40), $args);
 
         $wait = array(

--- a/PhpAmqpLib/Helper/Protocol/Protocol080.php
+++ b/PhpAmqpLib/Helper/Protocol/Protocol080.php
@@ -60,7 +60,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_shortstr($virtual_host);
 		$args->write_shortstr($capabilities);
-		$args->write_bit($insist);
+		$args->write_bits(array($insist));
 		return array(10, 40, $args);
 	}
 
@@ -104,7 +104,7 @@ class Protocol080
 
 	public function channelFlow($active) {
 		$args = new AMQPWriter();
-		$args->write_bit($active);
+		$args->write_bits(array($active));
 		return array(20, 20, $args);
 	}
 
@@ -140,11 +140,7 @@ class Protocol080
 	public function accessRequest($realm = '/data', $exclusive = false, $passive = true, $active = true, $write = true, $read = true) {
 		$args = new AMQPWriter();
 		$args->write_shortstr($realm);
-		$args->write_bit($exclusive);
-		$args->write_bit($passive);
-		$args->write_bit($active);
-		$args->write_bit($write);
-		$args->write_bit($read);
+		$args->write_bits(array($exclusive, $passive, $active, $write, $read));
 		return array(30, 10, $args);
 	}
 
@@ -160,11 +156,7 @@ class Protocol080
 		$args->write_short($ticket);
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($type);
-		$args->write_bit($passive);
-		$args->write_bit($durable);
-		$args->write_bit($auto_delete);
-		$args->write_bit($internal);
-		$args->write_bit($nowait);
+		$args->write_bits(array($passive, $durable, $auto_delete, $internal, $nowait));
 		$args->write_table($arguments);
 		return array(40, 10, $args);
 	}
@@ -178,8 +170,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($exchange);
-		$args->write_bit($if_unused);
-		$args->write_bit($nowait);
+		$args->write_bits(array($if_unused, $nowait));
 		return array(40, 20, $args);
 	}
 
@@ -193,11 +184,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
-		$args->write_bit($passive);
-		$args->write_bit($durable);
-		$args->write_bit($exclusive);
-		$args->write_bit($auto_delete);
-		$args->write_bit($nowait);
+		$args->write_bits(array($passive, $durable, $exclusive, $auto_delete, $nowait));
 		$args->write_table($arguments);
 		return array(50, 10, $args);
 	}
@@ -217,7 +204,7 @@ class Protocol080
 		$args->write_shortstr($queue);
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		$args->write_table($arguments);
 		return array(50, 20, $args);
 	}
@@ -231,7 +218,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		return array(50, 30, $args);
 	}
 
@@ -245,9 +232,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
-		$args->write_bit($if_unused);
-		$args->write_bit($if_empty);
-		$args->write_bit($nowait);
+		$args->write_bits(array($if_unused, $if_empty, $nowait));
 		return array(50, 40, $args);
 	}
 
@@ -277,7 +262,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_long($prefetch_size);
 		$args->write_short($prefetch_count);
-		$args->write_bit($global);
+		$args->write_bits(array($global));
 		return array(60, 10, $args);
 	}
 
@@ -291,10 +276,7 @@ class Protocol080
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
 		$args->write_shortstr($consumer_tag);
-		$args->write_bit($no_local);
-		$args->write_bit($no_ack);
-		$args->write_bit($exclusive);
-		$args->write_bit($nowait);
+		$args->write_bits(array($no_local, $no_ack, $exclusive, $nowait);
 		return array(60, 20, $args);
 	}
 
@@ -307,7 +289,7 @@ class Protocol080
 	public function basicCancel($consumer_tag, $nowait = false) {
 		$args = new AMQPWriter();
 		$args->write_shortstr($consumer_tag);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		return array(60, 30, $args);
 	}
 
@@ -322,8 +304,7 @@ class Protocol080
 		$args->write_short($ticket);
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
-		$args->write_bit($mandatory);
-		$args->write_bit($immediate);
+		$args->write_bits(array($mandatory, $immediate));
 		return array(60, 40, $args);
 	}
 
@@ -340,7 +321,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_shortstr($consumer_tag);
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($redelivered);
+		$args->write_bits(array($redelivered));
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
 		return array(60, 60, $args);
@@ -350,7 +331,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
-		$args->write_bit($no_ack);
+		$args->write_bits(array($no_ack));
 		return array(60, 70, $args);
 	}
 
@@ -373,26 +354,26 @@ class Protocol080
 	public function basicAck($delivery_tag = 0, $multiple = false) {
 		$args = new AMQPWriter();
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($multiple);
+		$args->write_bits(array($multiple));
 		return array(60, 80, $args);
 	}
 
 	public function basicReject($delivery_tag, $requeue = true) {
 		$args = new AMQPWriter();
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($requeue);
+		$args->write_bits(array($requeue));
 		return array(60, 90, $args);
 	}
 
 	public function basicRecoverAsync($requeue = false) {
 		$args = new AMQPWriter();
-		$args->write_bit($requeue);
+		$args->write_bits(array($requeue));
 		return array(60, 100, $args);
 	}
 
 	public function basicRecover($requeue = false) {
 		$args = new AMQPWriter();
-		$args->write_bit($requeue);
+		$args->write_bits(array($requeue));
 		return array(60, 110, $args);
 	}
 
@@ -405,7 +386,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_long($prefetch_size);
 		$args->write_short($prefetch_count);
-		$args->write_bit($global);
+		$args->write_bits(array($global));
 		return array(70, 10, $args);
 	}
 
@@ -419,10 +400,7 @@ class Protocol080
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
 		$args->write_shortstr($consumer_tag);
-		$args->write_bit($no_local);
-		$args->write_bit($no_ack);
-		$args->write_bit($exclusive);
-		$args->write_bit($nowait);
+		$args->write_bits(array($no_local, $no_ack, $exclusive, $nowait));
 		return array(70, 20, $args);
 	}
 
@@ -435,7 +413,7 @@ class Protocol080
 	public function fileCancel($consumer_tag, $nowait = false) {
 		$args = new AMQPWriter();
 		$args->write_shortstr($consumer_tag);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		return array(70, 30, $args);
 	}
 
@@ -468,8 +446,7 @@ class Protocol080
 		$args->write_short($ticket);
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
-		$args->write_bit($mandatory);
-		$args->write_bit($immediate);
+		$args->write_bits(array($mandatory, $immediate));
 		$args->write_shortstr($identifier);
 		return array(70, 60, $args);
 	}
@@ -487,7 +464,7 @@ class Protocol080
 		$args = new AMQPWriter();
 		$args->write_shortstr($consumer_tag);
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($redelivered);
+		$args->write_bits(array($redelivered));
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
 		$args->write_shortstr($identifier);
@@ -497,14 +474,14 @@ class Protocol080
 	public function fileAck($delivery_tag = 0, $multiple = false) {
 		$args = new AMQPWriter();
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($multiple);
+		$args->write_bits(array($multiple));
 		return array(70, 90, $args);
 	}
 
 	public function fileReject($delivery_tag, $requeue = true) {
 		$args = new AMQPWriter();
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($requeue);
+		$args->write_bits(array($requeue));
 		return array(70, 100, $args);
 	}
 
@@ -513,7 +490,7 @@ class Protocol080
 		$args->write_long($prefetch_size);
 		$args->write_short($prefetch_count);
 		$args->write_long($consume_rate);
-		$args->write_bit($global);
+		$args->write_bits(array($global));
 		return array(80, 10, $args);
 	}
 
@@ -527,9 +504,7 @@ class Protocol080
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
 		$args->write_shortstr($consumer_tag);
-		$args->write_bit($no_local);
-		$args->write_bit($exclusive);
-		$args->write_bit($nowait);
+		$args->write_bits(array($no_local, $exclusive, $nowait));
 		return array(80, 20, $args);
 	}
 
@@ -542,7 +517,7 @@ class Protocol080
 	public function streamCancel($consumer_tag, $nowait = false) {
 		$args = new AMQPWriter();
 		$args->write_shortstr($consumer_tag);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		return array(80, 30, $args);
 	}
 
@@ -557,8 +532,7 @@ class Protocol080
 		$args->write_short($ticket);
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
-		$args->write_bit($mandatory);
-		$args->write_bit($immediate);
+		$args->write_bits(array($mandatory, $immediate));
 		return array(80, 40, $args);
 	}
 

--- a/PhpAmqpLib/Helper/Protocol/Protocol091.php
+++ b/PhpAmqpLib/Helper/Protocol/Protocol091.php
@@ -60,7 +60,7 @@ class Protocol091
 		$args = new AMQPWriter();
 		$args->write_shortstr($virtual_host);
 		$args->write_shortstr($capabilities);
-		$args->write_bit($insist);
+		$args->write_bits(array($insist));
 		return array(10, 40, $args);
 	}
 
@@ -98,7 +98,7 @@ class Protocol091
 
 	public function channelFlow($active) {
 		$args = new AMQPWriter();
-		$args->write_bit($active);
+		$args->write_bits(array($active));
 		return array(20, 20, $args);
 	}
 
@@ -125,11 +125,7 @@ class Protocol091
 	public function accessRequest($realm = '/data', $exclusive = false, $passive = true, $active = true, $write = true, $read = true) {
 		$args = new AMQPWriter();
 		$args->write_shortstr($realm);
-		$args->write_bit($exclusive);
-		$args->write_bit($passive);
-		$args->write_bit($active);
-		$args->write_bit($write);
-		$args->write_bit($read);
+		$args->write_bits(array($exclusive, $passive, $active, $write, $read));
 		return array(30, 10, $args);
 	}
 
@@ -145,11 +141,7 @@ class Protocol091
 		$args->write_short($ticket);
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($type);
-		$args->write_bit($passive);
-		$args->write_bit($durable);
-		$args->write_bit($auto_delete);
-		$args->write_bit($internal);
-		$args->write_bit($nowait);
+		$args->write_bits(array($passive, $durable, $auto_delete, $internal, $nowait));
 		$args->write_table($arguments);
 		return array(40, 10, $args);
 	}
@@ -163,8 +155,7 @@ class Protocol091
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($exchange);
-		$args->write_bit($if_unused);
-		$args->write_bit($nowait);
+		$args->write_bits(array($if_unused, $nowait));
 		return array(40, 20, $args);
 	}
 
@@ -180,7 +171,7 @@ class Protocol091
 		$args->write_shortstr($destination);
 		$args->write_shortstr($source);
 		$args->write_shortstr($routing_key);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		$args->write_table($arguments);
 		return array(40, 30, $args);
 	}
@@ -197,7 +188,7 @@ class Protocol091
 		$args->write_shortstr($destination);
 		$args->write_shortstr($source);
 		$args->write_shortstr($routing_key);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		$args->write_table($arguments);
 		return array(40, 40, $args);
 	}
@@ -212,11 +203,7 @@ class Protocol091
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
-		$args->write_bit($passive);
-		$args->write_bit($durable);
-		$args->write_bit($exclusive);
-		$args->write_bit($auto_delete);
-		$args->write_bit($nowait);
+		$args->write_bits(array($passive, $durable, $exclusive, $auto_delete, $nowait));
 		$args->write_table($arguments);
 		return array(50, 10, $args);
 	}
@@ -236,7 +223,7 @@ class Protocol091
 		$args->write_shortstr($queue);
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		$args->write_table($arguments);
 		return array(50, 20, $args);
 	}
@@ -250,7 +237,7 @@ class Protocol091
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		return array(50, 30, $args);
 	}
 
@@ -264,9 +251,7 @@ class Protocol091
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
-		$args->write_bit($if_unused);
-		$args->write_bit($if_empty);
-		$args->write_bit($nowait);
+		$args->write_bits(array($if_unused, $if_empty, $nowait));
 		return array(50, 40, $args);
 	}
 
@@ -296,7 +281,7 @@ class Protocol091
 		$args = new AMQPWriter();
 		$args->write_long($prefetch_size);
 		$args->write_short($prefetch_count);
-		$args->write_bit($global);
+		$args->write_bits(array($global));
 		return array(60, 10, $args);
 	}
 
@@ -311,10 +296,7 @@ class Protocol091
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
 		$args->write_shortstr($consumer_tag);
-		$args->write_bit($no_local);
-		$args->write_bit($no_ack);
-		$args->write_bit($exclusive);
-		$args->write_bit($nowait);
+		$args->write_bits(array($no_local, $no_ack, $exclusive, $nowait));
 		$args->write_table($arguments);
 		return array(60, 20, $args);
 	}
@@ -328,7 +310,7 @@ class Protocol091
 	public function basicCancel($consumer_tag, $nowait = false) {
 		$args = new AMQPWriter();
 		$args->write_shortstr($consumer_tag);
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		return array(60, 30, $args);
 	}
 
@@ -343,8 +325,7 @@ class Protocol091
 		$args->write_short($ticket);
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
-		$args->write_bit($mandatory);
-		$args->write_bit($immediate);
+		$args->write_bits(array($mandatory, $immediate));
 		return array(60, 40, $args);
 	}
 
@@ -361,7 +342,7 @@ class Protocol091
 		$args = new AMQPWriter();
 		$args->write_shortstr($consumer_tag);
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($redelivered);
+		$args->write_bits(array($redelivered));
 		$args->write_shortstr($exchange);
 		$args->write_shortstr($routing_key);
 		return array(60, 60, $args);
@@ -371,7 +352,7 @@ class Protocol091
 		$args = new AMQPWriter();
 		$args->write_short($ticket);
 		$args->write_shortstr($queue);
-		$args->write_bit($no_ack);
+		$args->write_bits(array($no_ack));
 		return array(60, 70, $args);
 	}
 
@@ -394,26 +375,26 @@ class Protocol091
 	public function basicAck($delivery_tag = 0, $multiple = false) {
 		$args = new AMQPWriter();
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($multiple);
+		$args->write_bits(array($multiple));
 		return array(60, 80, $args);
 	}
 
 	public function basicReject($delivery_tag, $requeue = true) {
 		$args = new AMQPWriter();
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($requeue);
+		$args->write_bits(array($requeue));
 		return array(60, 90, $args);
 	}
 
 	public function basicRecoverAsync($requeue = false) {
 		$args = new AMQPWriter();
-		$args->write_bit($requeue);
+		$args->write_bits(array($requeue));
 		return array(60, 100, $args);
 	}
 
 	public function basicRecover($requeue = false) {
 		$args = new AMQPWriter();
-		$args->write_bit($requeue);
+		$args->write_bits(array($requeue));
 		return array(60, 110, $args);
 	}
 
@@ -425,8 +406,7 @@ class Protocol091
 	public function basicNack($delivery_tag = 0, $multiple = false, $requeue = true) {
 		$args = new AMQPWriter();
 		$args->write_longlong($delivery_tag);
-		$args->write_bit($multiple);
-		$args->write_bit($requeue);
+		$args->write_bits(array($multiple, $requeue));
 		return array(60, 120, $args);
 	}
 
@@ -462,7 +442,7 @@ class Protocol091
 
 	public function confirmSelect($nowait = false) {
 		$args = new AMQPWriter();
-		$args->write_bit($nowait);
+		$args->write_bits(array($nowait));
 		return array(85, 10, $args);
 	}
 

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -62,7 +62,8 @@ class AMQPWriter
      */
     public function getvalue()
     {
-        $this->flushbits();
+        /* temporarily needed for compatibility with write_bit unit tests */
+        if ($this->bitcount) $this->flushbits();
 
         return $this->out;
     }
@@ -72,7 +73,6 @@ class AMQPWriter
      */
     public function write($s)
     {
-        $this->flushbits();
         $this->out .= $s;
 
         return $this;
@@ -80,6 +80,7 @@ class AMQPWriter
 
     /**
      * Write a boolean value.
+     * (deprecated, use write_bits instead)
      */
     public function write_bit($b)
     {
@@ -106,6 +107,23 @@ class AMQPWriter
     }
 
     /**
+     * Write multiple bits as an octet.
+     */
+    public function write_bits($bits)
+    {
+        $value = 0;
+
+        foreach ($bits as $n => $bit) {
+            $bit = $bit ? 1 : 0;
+            $value |= ($bit << $n);
+        }
+
+        $this->out .= chr($value);
+
+        return $this;
+    }
+
+    /**
      * Write an integer as an unsigned 8-bit value.
      */
     public function write_octet($n)
@@ -114,7 +132,6 @@ class AMQPWriter
             throw new \InvalidArgumentException('Octet out of range 0..255');
         }
 
-        $this->flushbits();
         $this->out .= chr($n);
 
         return $this;
@@ -129,7 +146,6 @@ class AMQPWriter
             throw new \InvalidArgumentException('Octet out of range 0..65535');
         }
 
-        $this->flushbits();
         $this->out .= pack('n', $n);
 
         return $this;
@@ -140,7 +156,6 @@ class AMQPWriter
      */
     public function write_long($n)
     {
-        $this->flushbits();
         $this->out .= pack('N', $n);
 
         return $this;
@@ -148,7 +163,6 @@ class AMQPWriter
 
     private function write_signed_long($n)
     {
-        $this->flushbits();
         // although format spec for 'N' mentions unsigned
         // it will deal with sinned integers as well. tested.
         $this->out .= pack('N', $n);
@@ -161,8 +175,6 @@ class AMQPWriter
      */
     public function write_longlong($n)
     {
-        $this->flushbits();
-
         // if PHP_INT_MAX is big enough for that
         // (always on 64 bits, with smaller values in 32 bits)
         if ($n <= PHP_INT_MAX) {
@@ -183,7 +195,6 @@ class AMQPWriter
      */
     public function write_shortstr($s)
     {
-        $this->flushbits();
         if (strlen($s) > 255) {
             throw new \InvalidArgumentException('String too long');
         }
@@ -200,7 +211,6 @@ class AMQPWriter
      */
     public function write_longstr($s)
     {
-        $this->flushbits();
         $this->write_long(strlen($s));
         $this->out .= $s;
 
@@ -217,7 +227,6 @@ class AMQPWriter
      */
     public function write_array($a)
     {
-        $this->flushbits();
         $data = new AMQPWriter();
 
         foreach ($a as $v) {
@@ -260,7 +269,6 @@ class AMQPWriter
     */
     public function write_table($d)
     {
-        $this->flushbits();
         $table_data = new AMQPWriter();
         foreach ($d as $k=>$va) {
             list($ftype,$v) = $va;


### PR DESCRIPTION
While reviewing performance, I identified the flushbits method as a bottleneck.

It's only used to group bits - written by several successive call to write_bit - in one octet.

Performance can be enhanced by testing if there is something to flush before each call to flushbits:

```
if ($this->bitcount) $this->flushbits();
```

But why not simply avoid it and just use a 'write_bits' method everywhere instead. 'write_bits' would directly write several bits grouped as one octet.

Performance without patch:

```
  1 000 messages =>    671,328 microsecs total /    101,430 microsecs for flushbits (35,124 calls)
 10 000 messages =>  6,802,054 microsecs total /  1,051,109 microsecs for flushbits (350,124 calls)
100 000 messages => 67,375,810 microsecs total / 10,245,146 microsecs for flushbits (3,500,124 calls)
```

Performance with patch (write_bits):

```
  1 000 messages =>    525,496 microsecs total
 10 000 messages =>  5,225,029 microsecs total
100 000 messages => 54,134,866 microsecs total
```
