### PR TITLE
remove exception in publish_batch if batch_messages is empty

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -812,8 +812,6 @@ class AMQPChannel extends AbstractChannel
             $this->connection->write($pkt->getvalue());
             $this->batch_messages = array();
 
-        } else {
-            throw new AMQPRuntimeException('calling send_batch before publishing messages via batch_basic_publish');
         }
     }
 


### PR DESCRIPTION
I think it is completely legitimate that batch_messages be empty.

Looking at c37ffff36ac911d3aa82d96e4b322036ff5642d9, with the current behavior, the example would even throw an exception in the case that the latest iteration match if ($i % $batch == 0). Which might be the case with $batch = 10 and $max = 101 if I'm not mistaken.
