### PR TITLE
exit from while if fread return an empty string

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -40,7 +40,7 @@ class StreamIO extends AbstractIO
         $read = 0;
 
         while ($read < $n && !feof($this->sock) &&
-            (false !== ($buf = fread($this->sock, $n - $read)))) {
+            ($buf = fread($this->sock, $n - $read))) {
 
             $read += strlen($buf);
             $res .= $buf;


### PR DESCRIPTION
In case of a read timeout, fread return an empty string and not false.

We need to exit the while loop in this case, if we don't, we loop forever.

Alternatively, we could read the 'timed_out' status from stream_get_meta_data like in the write method.
