### PR TITLE
hotfix: continue instead of break from while if fread returns an empty s...

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -40,7 +40,11 @@ class StreamIO extends AbstractIO
         $read = 0;
 
         while ($read < $n && !feof($this->sock) &&
-            ($buf = fread($this->sock, $n - $read))) {
+            (false !== ($buf = fread($this->sock, $n - $read)))) {
+                
+            if ($buf === '') {
+                continue;
+            }
 
             $read += strlen($buf);
             $res .= $buf;


### PR DESCRIPTION
...tring

Introduced in 461961f962ab70c63adfb78215fb66123605da7e

Breaking from the loop is causing the following exception:

```
Consumer failure PhpAmqpLib\Exception\AMQPRuntimeException Exception 'Error reading data. Received 0 instead of expected 7 bytes':
#0 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Wire/AMQPReader.php(128): PhpAmqpLib\Wire\IO\StreamIO->read(7)
#1 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Wire/AMQPReader.php(88): PhpAmqpLib\Wire\AMQPReader->rawread(7)
#2 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Connection/AbstractConnection.php(311): PhpAmqpLib\Wire\AMQPReader->read(7)
#3 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Connection/AbstractConnection.php(344): PhpAmqpLib\Connection\AbstractConnection->wait_frame(0)
#4 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Channel/AbstractChannel.php(121): PhpAmqpLib\Connection\AbstractConnection->wait_channel(1, 0)
#5 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Channel/AbstractChannel.php(229): PhpAmqpLib\Channel\AbstractChannel->next_frame(0)
```

I believe because a string can be a valid data block transferred in and of itself. Merely continuing instead of breaking until the feof() fixes the problem on my version of Rabbit:

RabbitMQ 3.1.5, Erlang R14B04
