### PR TITLE
hotfix: alternative for "Received 0 instead of expected 7 bytes"

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -226,7 +226,13 @@ class AbstractChannel
 
         // No deferred methods?  wait for new ones
         while (true) {
-            $frm = $this->next_frame($timeout);
+            try {
+                $frm = $this->next_frame($timeout);
+            } catch (AMQPRuntimeException $e) {
+                // nothing to do, empty response body
+                break;
+            }
+            
             $frame_type = $frm[0];
             $payload = $frm[1];
 


### PR DESCRIPTION
For the following error:

```
Consumer failure PhpAmqpLib\Exception\AMQPRuntimeException Exception 'Error reading data. Received 0 instead of expected 7 bytes':
#0 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Wire/AMQPReader.php(128): PhpAmqpLib\Wire\IO\StreamIO->read(7)
#1 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Wire/AMQPReader.php(88): PhpAmqpLib\Wire\AMQPReader->rawread(7)
#2 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Connection/AbstractConnection.php(311): PhpAmqpLib\Wire\AMQPReader->read(7)
#3 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Connection/AbstractConnection.php(344): PhpAmqpLib\Connection\AbstractConnection->wait_frame(0)
#4 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Channel/AbstractChannel.php(121): PhpAmqpLib\Connection\AbstractConnection->wait_channel(1, 0)
#5 /my/path/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Channel/AbstractChannel.php(229): PhpAmqpLib\Channel\AbstractChannel->next_frame(0)
```

I have another pull request at https://github.com/videlalvaro/php-amqplib/pull/119 which reverses the 461961f962ab70c63adfb78215fb66123605da7e commit but fixes the problem for me.

This also fixes the problem for me as an alternative without having to reverse that commit.
