### PR TITLE
Allow timeouts with better precision than seconds

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -27,7 +27,7 @@ class StreamIO extends AbstractIO
             throw new AMQPRuntimeException("Error Connecting to server($errno): $errstr ");
         }
 
-        if(!stream_set_timeout($this->sock, $read_write_timeout)) {
+        if(!stream_set_timeout($this->sock, floor($read_write_timeout), ($read_write_timeout - floor($read_write_timeout)) * 1000000)) {
             throw new AMQPIOException("Timeout could not be set");
         }
 


### PR DESCRIPTION
PHP stream api is a bit _weird_ and expects an integer as the second stream_set_timeout parameter. This allows float values in timeouts

The patch was originally made by @davegardnerisme at https://github.com/davegardnerisme/php-amqplib and is used at Hailo. 

Probably worth considering adding it to the main repo?
