### PR TITLE
Add PHP sockets extension to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,13 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ext-bcmath": "*",
-        "ext-sockets": "*"
+        "ext-bcmath": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
+    },
+    "suggest": {
+        "ext-sockets": "Use AMQPSocketConnection"
     },
     "autoload": {
         "psr-0": {"PhpAmqpLib": ""}


### PR DESCRIPTION
Hi,

I'm new to the library so forgive me if this has already been covered.

I ran into trouble running the benchmark because the sockets extension was not enabled by default on my PHP build. Should it be in `require` or maybe just in `suggest`? In my opinion it should be in there somwhere.

I also added `composer.lock` to `.gitignore`.

M
