### PR TITLE
Kp/fix socket io timeout issues

### DIFF
--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -62,8 +62,7 @@ class SocketIO extends AbstractIO
 
             $sent = socket_write($this->sock, $data, $len);
             if ($sent === false) {
-                $errorNo = socket_last_error($this->sock);
-                throw new AMQPIOException ("Error sending data. Last SocketError: ".socket_strerror($errorNo));
+                throw new AMQPIOException ("Error sending data. Last SocketError: ".socket_strerror(socket_last_error()));
             }
             // Check if the entire message has been sent
             if ($sent < $len) {


### PR DESCRIPTION
we've seen our deployment get stuck in infinite loops on socket io.  These error checks prevent an infinite loop when the socket is null or when the socket_read returns false before the read is finished.
