### PR TITLE
[WAITING] Create abstract Object class

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -6,6 +6,7 @@ use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
 use PhpAmqpLib\Helper\MiscHelper;
+use PhpAmqpLib\Helper\Object;
 use PhpAmqpLib\Helper\Protocol\MethodMap080;
 use PhpAmqpLib\Helper\Protocol\MethodMap091;
 use PhpAmqpLib\Helper\Protocol\Protocol080;
@@ -15,7 +16,7 @@ use PhpAmqpLib\Helper\Protocol\Wait091;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPReader;
 
-class AbstractChannel
+class AbstractChannel extends Object
 {
 
     public static $PROTOCOL_CONSTANTS_CLASS;

--- a/PhpAmqpLib/Exception/AMQPMemberAccessException.php
+++ b/PhpAmqpLib/Exception/AMQPMemberAccessException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpAmqpLib\Exception;
+
+class AMQPMemberAccessException extends \LogicException implements AMQPExceptionInterface
+{
+
+}

--- a/PhpAmqpLib/Helper/Object.php
+++ b/PhpAmqpLib/Helper/Object.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PhpAmqpLib\Helper;
+
+use Kdyby;
+use Nette;
+use PhpAmqpLib\Exception\AMQPMemberAccessException;
+
+
+
+abstract class Object
+{
+
+    public function __call($name, $arguments)
+    {
+        throw new AMQPMemberAccessException("Method " . get_called_class() . "::{$name}() is not implemented");
+    }
+
+
+
+    public function &__get($name)
+    {
+        throw new AMQPMemberAccessException("Property " . get_called_class() . "::\${$name} is not defined");
+    }
+
+
+
+    public function __set($name, $value)
+    {
+        throw new AMQPMemberAccessException("Property " . get_called_class() . "::\${$name} is not defined");
+    }
+
+
+
+    public function __isset($name)
+    {
+        throw new AMQPMemberAccessException("Property " . get_called_class() . "::\${$name} is not defined");
+    }
+
+
+
+    public function __unset($name)
+    {
+        throw new AMQPMemberAccessException("Property " . get_called_class() . "::\${$name} is not defined");
+    }
+
+}

--- a/PhpAmqpLib/Wire/AMQPDecimal.php
+++ b/PhpAmqpLib/Wire/AMQPDecimal.php
@@ -3,6 +3,7 @@
 namespace PhpAmqpLib\Wire;
 
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
+use PhpAmqpLib\Helper\Object;
 
 /**
  * AMQP protocol decimal value.
@@ -15,7 +16,7 @@ use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
  * business values such as currency rates and amounts. The
  * 'decimals' octet is not signed.
  */
-class AMQPDecimal
+class AMQPDecimal extends Object
 {
 
     public function __construct($n, $e)

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -6,6 +6,7 @@ use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Helper\MiscHelper;
+use PhpAmqpLib\Helper\Object;
 use PhpAmqpLib\Wire\IO\AbstractIO;
 
 
@@ -14,7 +15,7 @@ use PhpAmqpLib\Wire\IO\AbstractIO;
  *
  * TODO : split this class: AMQPStreamReader and a AMQPBufferReader
  */
-class AMQPReader
+class AMQPReader extends Object
 {
 
     const BIT = 1;

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -4,8 +4,9 @@ namespace PhpAmqpLib\Wire;
 
 use PhpAmqpLib\Exception\AMQPInvalidArgumentException;
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
+use PhpAmqpLib\Helper\Object;
 
-class AMQPWriter
+class AMQPWriter extends Object
 {
 
     public function __construct()

--- a/PhpAmqpLib/Wire/GenericContent.php
+++ b/PhpAmqpLib/Wire/GenericContent.php
@@ -3,12 +3,13 @@
 namespace PhpAmqpLib\Wire;
 
 use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Helper\Object;
 
 /**
  * Abstract base class for AMQP content.  Subclasses should override
  * the PROPERTIES attribute.
  */
-abstract class GenericContent
+abstract class GenericContent extends Object
 {
 
     /**

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -2,7 +2,9 @@
 
 namespace PhpAmqpLib\Wire\IO;
 
-abstract class AbstractIO
+use PhpAmqpLib\Helper\Object;
+
+abstract class AbstractIO extends Object
 {
 
     abstract public function read($n);


### PR DESCRIPTION
... that prevents from using undefined properties.

As you can see, the tests fail horribly due to undefined properties, that should have been defined. After you merge #172, I'll rebase it and then you'll see the tests passing. And from now on, there will be no undeclared properties.
