### PR TITLE
Add dev-master branch alias to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": {"PhpAmqpLib": ""}
     },
-    "license": "LGPL-2.1"
+    "license": "LGPL-2.1",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.4-dev"
+        }
+    }
 }


### PR DESCRIPTION
This change allows me to require `~2.4.0@dev` and the users of my integration of this lib will get stable version `2.4.*`, but when developing, my builds will be done agains master branch of this library, which means I'll know about every compatibility break, or behaviour change, even before you tag the library, allowing me to act on them even before the target user's app might get broken.

The only think I'm not sure about is, that where the alias should be `2.4-dev` or `2.5-dev`. I would appreciate feedback from somebody more skilled with composer.
