### PR TITLE
Fix: avoid losing message meta-data because of weak type evaluation

### DIFF
--- a/PhpAmqpLib/Wire/GenericContent.php
+++ b/PhpAmqpLib/Wire/GenericContent.php
@@ -169,25 +169,24 @@ abstract class GenericContent
         $raw_bytes = new AMQPWriter();
 
         foreach ($this->prop_types as $key => $prototype) {
-            if (isset($this->properties[$key])) {
-                $val = $this->properties[$key];
-            } else {
-                $val = null;
+            $val = isset($this->properties[$key]) ? $this->properties[$key] : null;
+
+            if ($val === null) {
+                $shift -= 1;
+                continue;
             }
 
-            if ($val != null) {
-                if ($shift == 0) {
-                    $flags[] = $flag_bits;
-                    $flag_bits = 0;
-                    $shift = 15;
-                }
-
-                $flag_bits |= (1 << $shift);
-                if ($prototype != "bit") {
-                    $raw_bytes->{'write_' . $prototype}($val);
-                }
-
+            if ($shift === 0) {
+                $flags[] = $flag_bits;
+                $flag_bits = 0;
+                $shift = 15;
             }
+
+            $flag_bits |= (1 << $shift);
+            if ($prototype != 'bit') {
+                $raw_bytes->{'write_' . $prototype}($val);
+            }
+
             $shift -= 1;
         }
 

--- a/tests/Unit/Message/AMQPMessageTest.php
+++ b/tests/Unit/Message/AMQPMessageTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace PhpAmqpLib\Tests\Unit\Message;
+
+use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Wire\AMQPReader;
+
+class AMQPMessageTest extends \PHPUnit_Framework_TestCase
+{
+    public function propertiesDataProvider()
+    {
+        return array(
+            array(array('priority' => 1, 'timestamp' => time()), array('priority' => 1, 'timestamp' => time())),
+            array(array('message_id' => '5414cfa74899a'), array('message_id' => '5414cfa74899a')),
+            array(array('message_id' => 0), array('message_id' => 0)),
+            array(array(), array('timestamp' => null)),
+            array(array(), array('priority' => null)),
+            array(array('priority' => 0), array('priority' => 0)),
+            array(array('priority' => false), array('priority' => false)),
+            array(array('priority' => '0'), array('priority' => '0')),
+            array(array('application_headers' => array('x-foo' => array('S', ''))), array('application_headers' => array('x-foo' => array('S', '')))),
+            array(array('application_headers' => array('x-foo' => array('S', null))), array('application_headers' => array('x-foo' => array('S', null)))),
+            array(array('application_headers' => array('x-foo' => array('I', 0))), array('application_headers' => array('x-foo' => array('I', 0)))),
+            array(array('application_headers' => array('x-foo' => array('I', true))), array('application_headers' => array('x-foo' => array('I', true)))),
+            array(array('application_headers' => array('x-foo' => array('I', '0'))), array('application_headers' => array('x-foo' => array('I', '0')))),
+            array(array('application_headers' => array('x-foo' => array('A', array()))), array('application_headers' => array('x-foo' => array('A', array())))),
+            array(array('application_headers' => array('x-foo' => array('A', array()))), array('application_headers' => array('x-foo' => array('A', array(null))))),
+        );
+    }
+
+    /**
+     * @dataProvider propertiesDataProvider
+     */
+    public function testSerializeProperties(array $expected, array $properties)
+    {
+        /** @var AMQPReader $reader */
+        $reader = new AMQPReader(null);
+        /** @var AMQPMessage $message */
+        $message = new AMQPMessage('', $properties);
+        /** @var string $encodedData */
+        $encodedData = $message->serialize_properties();
+
+        // Bypasses the network part and injects the encoded data into the reader
+        $reader->reuse($encodedData);
+        // Injects the reader into the message
+        $message->load_properties($reader);
+
+        $this->assertEquals($expected, $message->get_properties());
+    }
+}


### PR DESCRIPTION
I got frustrated when I set my `AMQPMessage` `priority` meta-data to `0` and not having it back when consuming my message in my worker.

As the `basic_consume` can handle both positive and negative priorities, I figured out that message could too. Even I know message priority for for now just a placeholder.

Maybe there is an explicit reason for this but maybe not so here's my contribution.
