### PR TITLE
Optionally enable keepalive on the socket

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -17,9 +17,10 @@ class AMQPSocketConnection extends AbstractConnection
         $login_method = "AMQPLAIN",
         $login_response = null,
         $locale = "en_US",
-        $timeout = 3
+        $timeout = 3,
+        $keepalive = false
     ) {
-        $io = new SocketIO($host, $port, $timeout);
+        $io = new SocketIO($host, $port, $timeout, $keepalive);
 
         parent::__construct($user, $password, $vhost, $insist, $login_method, $login_response, $locale, $io);
     }

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -19,9 +19,10 @@ class AMQPStreamConnection extends AbstractConnection
         $locale = "en_US",
         $connection_timeout = 3,
         $read_write_timeout = 3,
-        $context = null
+        $context = null,
+        $keepalive = false
     ) {
-        $io = new StreamIO($host, $port, $connection_timeout, $read_write_timeout, $context);
+        $io = new StreamIO($host, $port, $connection_timeout, $read_write_timeout, $context, $keepalive);
         $this->sock = $io->get_socket();
 
         parent::__construct($user, $password, $vhost, $insist, $login_method, $login_response, $locale, $io);

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -30,11 +30,12 @@ class SocketIO extends AbstractIO
 
 
 
-    public function __construct($host, $port, $timeout)
+    public function __construct($host, $port, $timeout, $keepalive = false)
     {
         $this->host = $host;
         $this->port = $port;
         $this->timeout = $timeout;
+        $this->keepalive = $keepalive;
     }
 
 
@@ -59,6 +60,10 @@ class SocketIO extends AbstractIO
 
         socket_set_block($this->sock);
         socket_set_option($this->sock, SOL_TCP, TCP_NODELAY, 1);
+
+        if ($this->keepalive) {
+            $this->enable_keepalive();
+        }
     }
 
 
@@ -150,6 +155,15 @@ class SocketIO extends AbstractIO
         $write = null;
         $except = null;
         return socket_select($read, $write, $except, $sec, $usec);
+    }
+
+    protected function enable_keepalive()
+    {
+        if (!defined('SOL_SOCKET') || !defined('SO_KEEPALIVE')) {
+            throw new AMQPIOException("Can not enable keepalive: SOL_SOCKET or SO_KEEPALIVE is not defined");
+        }
+
+        socket_set_option($this->sock, SOL_SOCKET, SO_KEEPALIVE, 1);
     }
 
 }

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -36,19 +36,25 @@ class StreamIO extends AbstractIO
     protected $context;
 
     /**
+     * @var bool
+     */
+    protected $keepalive;
+
+    /**
      * @var resource
      */
     private $sock;
 
 
 
-    public function __construct($host, $port, $connection_timeout, $read_write_timeout, $context = null)
+    public function __construct($host, $port, $connection_timeout, $read_write_timeout, $context = null, $keepalive = false)
     {
         $this->host = $host;
         $this->port = $port;
         $this->connection_timeout = $connection_timeout;
         $this->read_write_timeout = $read_write_timeout;
         $this->context = $context;
+        $this->keepalive = $keepalive;
     }
 
 
@@ -81,9 +87,11 @@ class StreamIO extends AbstractIO
         }
 
         stream_set_blocking($this->sock, 1);
+
+        if ($this->keepalive) {
+            $this->enable_keepalive();
+        }
     }
-
-
 
     /**
      * Reconnect the socket
@@ -184,6 +192,20 @@ class StreamIO extends AbstractIO
         // get status of socket to determine whether or not it has timed out
         $info = stream_get_meta_data($this->sock);
         return $info['timed_out'];
+    }
+
+    protected function enable_keepalive()
+    {
+        if (!function_exists('socket_import_stream')) {
+            throw new AMQPIOException("Can not enable keepalive: function socket_import_stream does not exist");
+        }
+
+        if (!defined('SOL_SOCKET') || !defined('SO_KEEPALIVE')) {
+            throw new AMQPIOException("Can not enable keepalive: SOL_SOCKET or SO_KEEPALIVE is not defined");
+        }
+
+        $socket = socket_import_stream($this->sock);
+        socket_set_option($socket, SOL_SOCKET, SO_KEEPALIVE, 1);
     }
 
 }


### PR DESCRIPTION
Keepalive actively checks that the other end of the connection is still open, and prevents blocking forever on half-open connections.

I didn't enabled this by default because there are a few cases where it can cause the connection to be claused prematurely; e.g. if the other side doesn't support keepalive, or if a router drops keepalive packets.

An exception is thrown if PHP doesn't have support for enabling keepalive (if the user asked for keepalive to be enabled).
