### PR TITLE
Signals not handled when the queue is empty

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -45,6 +45,10 @@ class StreamIO extends AbstractIO
      */
     private $sock;
 
+    /**
+     * @var bool
+     */
+    private $canDispatchPcntlSignal;
 
 
     public function __construct($host, $port, $connection_timeout, $read_write_timeout, $context = null, $keepalive = false)
@@ -55,6 +59,8 @@ class StreamIO extends AbstractIO
         $this->read_write_timeout = $read_write_timeout;
         $this->context = $context;
         $this->keepalive = $keepalive;
+        $this->canDispatchPcntlSignal = extension_loaded('pcntl') && function_exists('pcntl_signal_dispatch')
+            && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true);
     }
 
 
@@ -108,12 +114,10 @@ class StreamIO extends AbstractIO
     {
         $res = '';
         $read = 0;
-        $canDispatchPcntlSignal = extension_loaded('pcntl') && function_exists('pcntl_signal_dispatch')
-            && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true);
 
         while ($read < $n && !feof($this->sock) && (false !== ($buf = fread($this->sock, $n - $read)))) {
             if ($buf === '') {
-                if ($canDispatchPcntlSignal) {
+                if ($this->canDispatchPcntlSignal) {
                     pcntl_signal_dispatch();
                 }
                 continue;

--- a/README.md
+++ b/README.md
@@ -138,6 +138,45 @@ $msg->setBody($body2);
 $ch->basic_publish($msg, $exchange);
 ```
 
+##UNIX Signals##
+
+If you have installed [PCNTL extension](http://www.php.net/manual/en/book.pcntl.php) dispatching of signal will be handled when consumer is not processing message.
+
+```php
+$pcntlHandler = function ($signal) {
+    switch ($signal) {
+        case \SIGTERM:
+        case \SIGUSR1:
+        case \SIGINT:
+            // some stuff before stop consumer e.g. delete lock etc
+            exit(0);
+            break;
+        case \SIGHUP:
+            // some stuff to restart consumer
+            break;
+        default:
+            // do nothing
+    }
+};
+
+declare(ticks = 1) {
+    pcntl_signal(\SIGTERM, $pcntlHandler);
+    pcntl_signal(\SIGINT,  $pcntlHandler);
+    pcntl_signal(\SIGUSR1, $pcntlHandler);
+    pcntl_signal(\SIGHUP,  $pcntlHandler);
+}
+```
+
+To disable this feature just define constant `AMQP_WITHOUT_SIGNALS` as `true`
+
+```php
+<?php
+define('AMQP_WITHOUT_SIGNALS', true);
+
+... more code
+
+```
+
 ## Debugging ##
 
 If you want to know what's going on at a protocol level then add the following constant to your code:


### PR DESCRIPTION
I can offer quick solution related to videlalvaro/RabbitMqBundle#178
It couldn't slowdown worker too much.
