### PR TITLE
Adding client and server heartbeat monitoring for streams.

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -28,7 +28,9 @@ class AMQPSSLConnection extends AMQPStreamConnection
             isset($options['locale']) ? $options['locale'] : "en_US",
             isset($options['connection_timeout']) ? $options['connection_timeout'] : 3,
             isset($options['read_write_timeout']) ? $options['read_write_timeout'] : 3,
-            $ssl_context
+            $ssl_context,
+            isset($options['keepalive']) ? $options['keepalive'] : false,
+            isset($options['heartbeat']) ? $options['heartbeat'] : 0
         );
     }
 

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -20,12 +20,13 @@ class AMQPStreamConnection extends AbstractConnection
         $connection_timeout = 3,
         $read_write_timeout = 3,
         $context = null,
-        $keepalive = false
+        $keepalive = false,
+        $heartbeat = 0
     ) {
-        $io = new StreamIO($host, $port, $connection_timeout, $read_write_timeout, $context, $keepalive);
+        $io = new StreamIO($host, $port, $connection_timeout, $read_write_timeout, $context, $keepalive, $heartbeat);
         $this->sock = $io->get_socket();
 
-        parent::__construct($user, $password, $vhost, $insist, $login_method, $login_response, $locale, $io);
+        parent::__construct($user, $password, $vhost, $insist, $login_method, $login_response, $locale, $io, $heartbeat);
 
         // save the params for the use of __clone, this will overwrite the parent
         $this->construct_params = func_get_args();


### PR DESCRIPTION
Heartbeats allow the server and client to be notified if the connection is broken. If either doesn't receive a heartbeat for more than 2x the proposed time the connection will be closed. It's a good idea to set the read_write_timeout to 2x the heartbeat so your socket will be open.

heartbeat = 0 // disabled
heartbeat = null // use server proposed
heartbeat = 30 // use client proposed value of 30 seconds
