### PR TITLE
Fixed the phpdoc of AbstractChannel::dispatch

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -146,7 +146,7 @@ class AbstractChannel
      * @param string $method_sig
      * @param string $args
      * @param $content
-     * @return null|string
+     * @return mixed
      */
     public function dispatch($method_sig, $args, $content)
     {


### PR DESCRIPTION
The return value is not always a string. It depends on the method being dispatched.

See https://github.com/scrutinizer-ci/php-analyzer/issues/420 for an issue caused by this wrong phpdoc
