### PR TITLE
Add wait_for_pending_acks_returns

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -1459,6 +1459,28 @@ class AMQPChannel extends AbstractChannel
         }
     }
 
+    /**
+     * Waits for pending acks, nacks and returns from the server. If there are no pending acks, the method returns immediately.
+     *
+     * @param int $timeout If set to value > 0 the method will wait at most $timeout seconds for pending acks.
+     */
+    public function wait_for_pending_acks_returns($timeout = 0)
+    {
+        $functions = array(
+            $this->waitHelper->get_wait('basic.ack'),
+            $this->waitHelper->get_wait('basic.nack'),
+            $this->waitHelper->get_wait('basic.return'),
+        );
+
+        while (count($this->published_messages) !== 0) {
+            if ($timeout > 0) {
+                $this->wait($functions, true, $timeout);
+            } else {
+                $this->wait($functions);
+            }
+        }
+    }
+
 
 
     /**

--- a/demo/amqp_publisher_with_confirms_mandatory.php
+++ b/demo/amqp_publisher_with_confirms_mandatory.php
@@ -1,0 +1,72 @@
+<?php
+
+use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+
+include(__DIR__ . '/config.php');
+
+$exchange = 'someExchange';
+
+$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$ch = $conn->channel();
+
+$ch->set_ack_handler(
+    function (AMQPMessage $message) {
+        echo "Message acked with content " . $message->body . PHP_EOL;
+    }
+);
+
+$ch->set_nack_handler(
+    function (AMQPMessage $message) {
+        echo "Message nacked with content " . $message->body . PHP_EOL;
+    }
+);
+
+$ch->set_return_listener(
+    function ($reply_code, $reply_text, $exchange, $routing_key, AMQPMessage $message) {
+        echo "Message returned with content " . $message->body . PHP_EOL;
+    }
+);
+
+/*
+ * bring the channel into publish confirm mode.
+ * if you would call $ch->tx_select() befor or after you brought the channel into this mode
+ * the next call to $ch->wait() would result in an exception as the publish confirm mode and transactions
+ * are mutually exclusive
+ */
+$ch->confirm_select();
+
+/*
+    name: $exchange
+    type: fanout
+    passive: false // don't check is an exchange with the same name exists
+    durable: false // the exchange won't survive server restarts
+    auto_delete: true //the exchange will be deleted once the channel is closed.
+*/
+
+$ch->exchange_declare($exchange, 'fanout', false, false, true);
+
+$i = 1;
+$msg = new AMQPMessage($i, array('content_type' => 'text/plain'));
+$ch->basic_publish($msg, $exchange, null, true);
+
+/*
+ * watching the amqp debug output you can see that the server will ack the message with delivery tag 1 and the
+ * multiple flag probably set to false
+ */
+
+$ch->wait_for_pending_acks_returns();
+
+while ($i <= 11) {
+    $msg = new AMQPMessage($i++, array('content_type' => 'text/plain'));
+    $ch->basic_publish($msg, $exchange, null, true);
+}
+
+/*
+ * you do not have to wait for pending acks after each message sent. in fact it will be much more efficient
+ * to wait for as many messages to be acked as possible.
+ */
+$ch->wait_for_pending_acks_returns();
+
+$ch->close();
+$conn->close();


### PR DESCRIPTION
I am publishing messages with `mandatory=true` and need to be able to handle the `basic.return` when messages cannot be routed.

I created a new method to not break anything for existing users.
