### PR TITLE
Expose connection socket to client

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -140,6 +140,10 @@ class AbstractChannel
         return $this->channel_id;
     }
 
+    public function getConnection()
+    {
+        return $this->connection;
+    }
 
 
     /**

--- a/PhpAmqpLib/Connection/AMQPLazyConnection.php
+++ b/PhpAmqpLib/Connection/AMQPLazyConnection.php
@@ -14,7 +14,7 @@ class AMQPLazyConnection extends AMQPConnection
     {
         $this->connect();
 
-        return $this->sock;
+        return parent::getSocket();
     }
 
 

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -24,7 +24,6 @@ class AMQPStreamConnection extends AbstractConnection
         $heartbeat = 0
     ) {
         $io = new StreamIO($host, $port, $connection_timeout, $read_write_timeout, $context, $keepalive, $heartbeat);
-        $this->sock = $io->get_socket();
 
         parent::__construct($user, $password, $vhost, $insist, $login_method, $login_response, $locale, $io, $heartbeat);
 

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -106,11 +106,6 @@ class AbstractConnection extends AbstractChannel
     protected $locale;
 
     /**
-     * @var SocketIO
-     */
-    protected $sock = null;
-
-    /**
      * @var int
      */
     protected $channel_max = 65535;
@@ -919,7 +914,7 @@ class AbstractConnection extends AbstractChannel
      */
     public function getSocket()
     {
-        return $this->sock;
+        return $this->io->getSocket();
     }
 
 

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -27,4 +27,7 @@ abstract class AbstractIO
 
     abstract public function reconnect();
 
+
+
+    abstract public function getSocket();
 }

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -68,6 +68,13 @@ class SocketIO extends AbstractIO
 
 
 
+    public function getSocket()
+    {
+        return $this->sock;
+    }
+
+
+
     /**
      * Reconnect the socket
      */

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -243,6 +243,13 @@ class StreamIO extends AbstractIO
 
 
 
+    public function getSocket()
+    {
+        return $this->get_socket();
+    }
+
+
+
     public function select($sec, $usec)
     {
         $read = array($this->sock);


### PR DESCRIPTION
This PR exposes the server socket to the client through `getSocket` methods on `Connection` instances and a `getConnection` method on `Channel` instances.

A use case for this is when you want to customise how you wait for data on the socket, like the example given in `demo/amqp_consumer_non_blocking.php`. These changes will allow you to call `Connection::getSocket` or `Channel::getConnection::getSocket` to retrieve the current socket, and should hopefully be agnostic of the connection and IO type in use.

Please let me know if this can be done a better way!

M
