### PR TITLE
Require mbstring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ext-bcmath": "*"
+        "ext-bcmath": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
When it is not installed a `PHP Fatal error:  Call to undefined function PhpAmqpLib\Wire\mb_strlen() in app/vendor/videlalvaro/php-amqplib/PhpAmqpLib/Wire/AMQPReader.php on line 80` is raised.
