### PR TITLE
Fixed UNEXPECTED_FRAME error

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -469,7 +469,7 @@ class AbstractConnection extends AbstractChannel
 
         $pkt->write_octet(0xCE);
 
-        while ($body) {
+        while ($body !== "") {
             $bodyStart = ($this->frame_max - 8);
             $payload = mb_substr($body, 0, $bodyStart, 'ASCII');
             $body = mb_substr($body, $bodyStart, mb_strlen($body, 'ASCII') - $bodyStart, 'ASCII');


### PR DESCRIPTION
If your AMQPMessage body is "0" then the $body evaluates to false. That causes missing body in server request which results in really hard-to-find error "UNEXPECTED_FRAME - expected content body, got non content body frame instead".

This simple patch fixes the problem.
