### PR TITLE
Disable heartbeat when closing connection

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -10,6 +10,7 @@ use PhpAmqpLib\Wire\AMQPReader;
 use PhpAmqpLib\Wire\AMQPWriter;
 use PhpAmqpLib\Wire\IO\AbstractIO;
 use PhpAmqpLib\Wire\IO\SocketIO;
+use PhpAmqpLib\Wire\IO\StreamIO;
 
 class AbstractConnection extends AbstractChannel
 {
@@ -614,6 +615,11 @@ class AbstractConnection extends AbstractChannel
      */
     public function close($reply_code = 0, $reply_text = '', $method_sig = array(0, 0))
     {
+        if ($this->io instanceof StreamIO)
+        {
+            $this->io->disableHeartbeat();
+        }
+
         if (!$this->protocolWriter || !$this->isConnected()) {
             return null;
         }

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -417,4 +417,14 @@ class StreamIO extends AbstractIO
         $socket = socket_import_stream($this->sock);
         socket_set_option($socket, SOL_SOCKET, SO_KEEPALIVE, 1);
     }
+
+    /**
+     * @return $this
+     */
+    public function disableHeartbeat()
+    {
+        $this->heartbeat = 0;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Problem:
When closing connection checking for heartbeat it could enter a loop and sometimes it tries to allocate a lot of memory when reading from socket.

Disabling heartbeat on `StreamIO` when closing connection prevents that from happening.

I was unable to reproduce the error with a test and that is why I didn't write one.

PS: The heartbeat value used when error occurs was `10`