### PR TITLE
Throw an exception if would allocate too much memory for a frame

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -198,6 +198,10 @@ class StreamIO extends AbstractIO
                 throw new AMQPRuntimeException('Broken pipe or closed connection');
             }
 
+            if (($len - $read) > 8 * (1024 * 1024)) {
+                throw new AMQPRuntimeException('Trying to allocate 8M, aborting');
+            }
+
             set_error_handler(array($this, 'error_handler'));
             $buffer = fread($this->sock, ($len - $read));
             restore_error_handler();


### PR DESCRIPTION
As in my comment on #322, the broker can send a message that causes the client to allocate memory to read a 1.25GB frame, usually causing an out of memory error.

This tries to mitigate this by throwing an exception if more than 8MB of memory would be allocated, allowing the client to better negotiate a reconnection.