### PR TITLE
AMQPReader::wait() throw IOWaitException on stream_select failure

### DIFF
--- a/PhpAmqpLib/Exception/AMQPIOWaitException.php
+++ b/PhpAmqpLib/Exception/AMQPIOWaitException.php
@@ -1,0 +1,6 @@
+<?php
+namespace PhpAmqpLib\Exception;
+
+class AMQPIOWaitException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -5,6 +5,7 @@ use PhpAmqpLib\Exception\AMQPInvalidArgumentException;
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
+use PhpAmqpLib\Exception\AMQPIOWaitException;
 use PhpAmqpLib\Helper\MiscHelper;
 use PhpAmqpLib\Wire\IO\AbstractIO;
 
@@ -110,6 +111,7 @@ class AMQPReader extends AbstractClient
      *
      * AMQPTimeoutException can be raised if the timeout is set
      *
+     * @throws \PhpAmqpLib\Exception\AMQPIOWaitException
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException
      */
     protected function wait()
@@ -123,7 +125,7 @@ class AMQPReader extends AbstractClient
         $result = $this->io->select($sec, $usec);
 
         if ($result === false) {
-            throw new AMQPRuntimeException('A network error occured while awaiting for incoming data');
+            throw new AMQPIOWaitException('A network error occured while awaiting for incoming data');
         }
 
         if ($result === 0) {


### PR DESCRIPTION
A follow-up on this:
https://github.com/videlalvaro/php-amqplib/pull/264
And this:
https://github.com/videlalvaro/php-amqplib/pull/224

amqplib now processes stream_select warning. But it returns false. And AMQPReader throws AMQPRuntimeException.
My implementation did re-run stream_select with getting whatever it returns.

I need to catch an exception when stream_select fails so I can call upon channel wait again, but AMQPRuntimeException is a very general one and filtering exception by its message text is not a good practice.
I propose to throw different exception so you can catch stream_select failure and do something about it. It extends from AMQPRuntimeException so it doesn't break library behavior.