### PR TITLE
Add PHPDocs to Auto-generated Protocol Classes

### DIFF
--- a/PhpAmqpLib/Helper/Protocol/MethodMap080.php
+++ b/PhpAmqpLib/Helper/Protocol/MethodMap080.php
@@ -6,7 +6,9 @@ namespace PhpAmqpLib\Helper\Protocol;
 
 class MethodMap080
 {
-
+    /**
+     * @var array
+     */
     protected $method_map = array(
         '10,10' => 'connection_start',
         '10,11' => 'connection_start_ok',
@@ -103,18 +105,21 @@ class MethodMap080
         '120,41' => 'test_content_ok',
     );
 
-
-
+    /**
+     * @var string
+     * @return string
+     */
     public function get_method($method_sig)
     {
         return $this->method_map[$method_sig];
     }
 
-
-
+    /**
+     * @var string
+     * @return boolean
+     */
     public function valid_method($method_sig)
     {
         return array_key_exists($method_sig, $this->method_map);
     }
-
 }

--- a/PhpAmqpLib/Helper/Protocol/MethodMap091.php
+++ b/PhpAmqpLib/Helper/Protocol/MethodMap091.php
@@ -6,7 +6,9 @@ namespace PhpAmqpLib\Helper\Protocol;
 
 class MethodMap091
 {
-
+    /**
+     * @var array
+     */
     protected $method_map = array(
         '10,10' => 'connection_start',
         '10,11' => 'connection_start_ok',
@@ -74,18 +76,21 @@ class MethodMap091
         '85,11' => 'confirm_select_ok',
     );
 
-
-
+    /**
+     * @var string
+     * @return string
+     */
     public function get_method($method_sig)
     {
         return $this->method_map[$method_sig];
     }
 
-
-
+    /**
+     * @var string
+     * @return boolean
+     */
     public function valid_method($method_sig)
     {
         return array_key_exists($method_sig, $this->method_map);
     }
-
 }

--- a/PhpAmqpLib/Helper/Protocol/Protocol080.php
+++ b/PhpAmqpLib/Helper/Protocol/Protocol080.php
@@ -9,1252 +9,1252 @@ use PhpAmqpLib\Wire\AMQPReader;
 
 class Protocol080
 {
-
     /**
+     * @param integer $version_major
+     * @param integer $version_minor
+     * @param mixed $server_properties
+     * @param string $mechanisms
+     * @param string $locales
      * @return array
      */
     public function connectionStart($version_major = 0, $version_minor = 8, $server_properties, $mechanisms = 'PLAIN', $locales = 'en_US')
     {
-        $args = new AMQPWriter();
-        $args->write_octet($version_major);
-        $args->write_octet($version_minor);
-        $args->write_table(empty($server_properties) ? array() : $server_properties);
-        $args->write_longstr($mechanisms);
-        $args->write_longstr($locales);
-        return array(10, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_octet($version_major);
+        $writer->write_octet($version_minor);
+        $writer->write_table(empty($server_properties) ? array() : $server_properties);
+        $writer->write_longstr($mechanisms);
+        $writer->write_longstr($locales);
+        return array(10, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionStartOk($args)
+    public static function connectionStartOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_table();
-        $ret[] = $args->read_shortstr();
-        $ret[] = $args->read_longstr();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_table();
+        $response[] = $reader->read_shortstr();
+        $response[] = $reader->read_longstr();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param string $challenge
      * @return array
      */
     public function connectionSecure($challenge)
     {
-        $args = new AMQPWriter();
-        $args->write_longstr($challenge);
-        return array(10, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longstr($challenge);
+        return array(10, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionSecureOk($args)
+    public static function connectionSecureOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longstr();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $channel_max
+     * @param integer $frame_max
+     * @param integer $heartbeat
      * @return array
      */
     public function connectionTune($channel_max = 0, $frame_max = 0, $heartbeat = 0)
     {
-        $args = new AMQPWriter();
-        $args->write_short($channel_max);
-        $args->write_long($frame_max);
-        $args->write_short($heartbeat);
-        return array(10, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($channel_max);
+        $writer->write_long($frame_max);
+        $writer->write_short($heartbeat);
+        return array(10, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionTuneOk($args)
+    public static function connectionTuneOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_short();
-        $ret[] = $args->read_long();
-        $ret[] = $args->read_short();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_short();
+        $response[] = $reader->read_long();
+        $response[] = $reader->read_short();
+        return $response;
     }
 
-
-
     /**
+     * @param string $virtual_host
+     * @param string $capabilities
+     * @param boolean $insist
      * @return array
      */
     public function connectionOpen($virtual_host = '/', $capabilities = '', $insist = false)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($virtual_host);
-        $args->write_shortstr($capabilities);
-        $args->write_bits(array($insist));
-        return array(10, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($virtual_host);
+        $writer->write_shortstr($capabilities);
+        $writer->write_bits(array($insist));
+        return array(10, 40, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionOpenOk($args)
+    public static function connectionOpenOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param string $host
+     * @param string $known_hosts
      * @return array
      */
     public function connectionRedirect($host, $known_hosts = '')
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($host);
-        $args->write_shortstr($known_hosts);
-        return array(10, 50, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($host);
+        $writer->write_shortstr($known_hosts);
+        return array(10, 50, $writer);
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param integer $class_id
+     * @param integer $method_id
      * @return array
      */
     public function connectionClose($reply_code, $reply_text = '', $class_id, $method_id)
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_short($class_id);
-        $args->write_short($method_id);
-        return array(10, 60, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_short($class_id);
+        $writer->write_short($method_id);
+        return array(10, 60, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionCloseOk($args)
+    public static function connectionCloseOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param string $out_of_band
      * @return array
      */
     public function channelOpen($out_of_band = '')
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($out_of_band);
-        return array(20, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($out_of_band);
+        return array(20, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function channelOpenOk($args)
+    public static function channelOpenOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param boolean $active
      * @return array
      */
     public function channelFlow($active)
     {
-        $args = new AMQPWriter();
-        $args->write_bits(array($active));
-        return array(20, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_bits(array($active));
+        return array(20, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function channelFlowOk($args)
+    public static function channelFlowOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_bit();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_bit();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param array $details
      * @return array
      */
     public function channelAlert($reply_code, $reply_text = '', $details = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_table(empty($details) ? array() : $details);
-        return array(20, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_table(empty($details) ? array() : $details);
+        return array(20, 30, $writer);
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param integer $class_id
+     * @param integer $method_id
      * @return array
      */
     public function channelClose($reply_code, $reply_text = '', $class_id, $method_id)
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_short($class_id);
-        $args->write_short($method_id);
-        return array(20, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_short($class_id);
+        $writer->write_short($method_id);
+        return array(20, 40, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function channelCloseOk($args)
+    public static function channelCloseOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param string $realm
+     * @param boolean $exclusive
+     * @param boolean $passive
+     * @param boolean $active
+     * @param boolean $write
+     * @param boolean $read
      * @return array
      */
     public function accessRequest($realm = '/data', $exclusive = false, $passive = true, $active = true, $write = true, $read = true)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($realm);
-        $args->write_bits(array($exclusive, $passive, $active, $write, $read));
-        return array(30, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($realm);
+        $writer->write_bits(array($exclusive, $passive, $active, $write, $read));
+        return array(30, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function accessRequestOk($args)
+    public static function accessRequestOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_short();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_short();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $exchange
+     * @param string $type
+     * @param boolean $passive
+     * @param boolean $durable
+     * @param boolean $auto_delete
+     * @param boolean $internal
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function exchangeDeclare($ticket = 1, $exchange, $type = 'direct', $passive = false, $durable = false, $auto_delete = false, $internal = false, $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($type);
-        $args->write_bits(array($passive, $durable, $auto_delete, $internal, $nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(40, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($type);
+        $writer->write_bits(array($passive, $durable, $auto_delete, $internal, $nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(40, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function exchangeDeclareOk($args)
+    public static function exchangeDeclareOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $exchange
+     * @param boolean $if_unused
+     * @param boolean $nowait
      * @return array
      */
     public function exchangeDelete($ticket = 1, $exchange, $if_unused = false, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($exchange);
-        $args->write_bits(array($if_unused, $nowait));
-        return array(40, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($exchange);
+        $writer->write_bits(array($if_unused, $nowait));
+        return array(40, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function exchangeDeleteOk($args)
+    public static function exchangeDeleteOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param boolean $passive
+     * @param boolean $durable
+     * @param boolean $exclusive
+     * @param boolean $auto_delete
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function queueDeclare($ticket = 1, $queue = '', $passive = false, $durable = false, $exclusive = false, $auto_delete = false, $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_bits(array($passive, $durable, $exclusive, $auto_delete, $nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(50, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_bits(array($passive, $durable, $exclusive, $auto_delete, $nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(50, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queueDeclareOk($args)
+    public static function queueDeclareOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        $ret[] = $args->read_long();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        $response[] = $reader->read_long();
+        $response[] = $reader->read_long();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param string $exchange
+     * @param string $routing_key
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function queueBind($ticket = 1, $queue = '', $exchange, $routing_key = '', $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_bits(array($nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(50, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_bits(array($nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(50, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queueBindOk($args)
+    public static function queueBindOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param boolean $nowait
      * @return array
      */
     public function queuePurge($ticket = 1, $queue = '', $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_bits(array($nowait));
-        return array(50, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_bits(array($nowait));
+        return array(50, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queuePurgeOk($args)
+    public static function queuePurgeOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_long();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param boolean $if_unused
+     * @param boolean $if_empty
+     * @param boolean $nowait
      * @return array
      */
     public function queueDelete($ticket = 1, $queue = '', $if_unused = false, $if_empty = false, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_bits(array($if_unused, $if_empty, $nowait));
-        return array(50, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_bits(array($if_unused, $if_empty, $nowait));
+        return array(50, 40, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queueDeleteOk($args)
+    public static function queueDeleteOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_long();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param string $exchange
+     * @param string $routing_key
+     * @param array $arguments
      * @return array
      */
     public function queueUnbind($ticket = 1, $queue = '', $exchange, $routing_key = '', $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(50, 50, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(50, 50, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queueUnbindOk($args)
+    public static function queueUnbindOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $prefetch_size
+     * @param integer $prefetch_count
+     * @param boolean $global
      * @return array
      */
     public function basicQos($prefetch_size = 0, $prefetch_count = 0, $global = false)
     {
-        $args = new AMQPWriter();
-        $args->write_long($prefetch_size);
-        $args->write_short($prefetch_count);
-        $args->write_bits(array($global));
-        return array(60, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_long($prefetch_size);
+        $writer->write_short($prefetch_count);
+        $writer->write_bits(array($global));
+        return array(60, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicQosOk($args)
+    public static function basicQosOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param string $consumer_tag
+     * @param boolean $no_local
+     * @param boolean $no_ack
+     * @param boolean $exclusive
+     * @param boolean $nowait
      * @return array
      */
     public function basicConsume($ticket = 1, $queue = '', $consumer_tag = '', $no_local = false, $no_ack = false, $exclusive = false, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_shortstr($consumer_tag);
-        $args->write_bits(array($no_local, $no_ack, $exclusive, $nowait));
-        return array(60, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_bits(array($no_local, $no_ack, $exclusive, $nowait));
+        return array(60, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicConsumeOk($args)
+    public static function basicConsumeOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param string $consumer_tag
+     * @param boolean $nowait
      * @return array
      */
     public function basicCancel($consumer_tag, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($consumer_tag);
-        $args->write_bits(array($nowait));
-        return array(60, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_bits(array($nowait));
+        return array(60, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicCancelOk($args)
+    public static function basicCancelOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $exchange
+     * @param string $routing_key
+     * @param boolean $mandatory
+     * @param boolean $immediate
      * @return array
      */
     public function basicPublish($ticket = 1, $exchange = '', $routing_key = '', $mandatory = false, $immediate = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_bits(array($mandatory, $immediate));
-        return array(60, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_bits(array($mandatory, $immediate));
+        return array(60, 40, $writer);
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param string $exchange
+     * @param string $routing_key
      * @return array
      */
     public function basicReturn($reply_code, $reply_text = '', $exchange, $routing_key)
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        return array(60, 50, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        return array(60, 50, $writer);
     }
 
-
-
     /**
+     * @param string $consumer_tag
+     * @param integer $delivery_tag
+     * @param boolean $redelivered
+     * @param string $exchange
+     * @param string $routing_key
      * @return array
      */
     public function basicDeliver($consumer_tag, $delivery_tag, $redelivered = false, $exchange, $routing_key)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($consumer_tag);
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($redelivered));
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        return array(60, 60, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($redelivered));
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        return array(60, 60, $writer);
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param boolean $no_ack
      * @return array
      */
     public function basicGet($ticket = 1, $queue = '', $no_ack = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_bits(array($no_ack));
-        return array(60, 70, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_bits(array($no_ack));
+        return array(60, 70, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicGetOk($args)
+    public static function basicGetOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longlong();
-        $ret[] = $args->read_bit();
-        $ret[] = $args->read_shortstr();
-        $ret[] = $args->read_shortstr();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longlong();
+        $response[] = $reader->read_bit();
+        $response[] = $reader->read_shortstr();
+        $response[] = $reader->read_shortstr();
+        $response[] = $reader->read_long();
+        return $response;
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicGetEmpty($args)
+    public static function basicGetEmpty(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $delivery_tag
+     * @param boolean $multiple
      * @return array
      */
     public function basicAck($delivery_tag = 0, $multiple = false)
     {
-        $args = new AMQPWriter();
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($multiple));
-        return array(60, 80, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($multiple));
+        return array(60, 80, $writer);
     }
 
-
-
     /**
+     * @param integer $delivery_tag
+     * @param boolean $requeue
      * @return array
      */
     public function basicReject($delivery_tag, $requeue = true)
     {
-        $args = new AMQPWriter();
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($requeue));
-        return array(60, 90, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($requeue));
+        return array(60, 90, $writer);
     }
 
-
-
     /**
+     * @param boolean $requeue
      * @return array
      */
     public function basicRecoverAsync($requeue = false)
     {
-        $args = new AMQPWriter();
-        $args->write_bits(array($requeue));
-        return array(60, 100, $args);
+        $writer = new AMQPWriter();
+        $writer->write_bits(array($requeue));
+        return array(60, 100, $writer);
     }
 
-
-
     /**
+     * @param boolean $requeue
      * @return array
      */
     public function basicRecover($requeue = false)
     {
-        $args = new AMQPWriter();
-        $args->write_bits(array($requeue));
-        return array(60, 110, $args);
+        $writer = new AMQPWriter();
+        $writer->write_bits(array($requeue));
+        return array(60, 110, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicRecoverOk($args)
+    public static function basicRecoverOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $prefetch_size
+     * @param integer $prefetch_count
+     * @param boolean $global
      * @return array
      */
     public function fileQos($prefetch_size = 0, $prefetch_count = 0, $global = false)
     {
-        $args = new AMQPWriter();
-        $args->write_long($prefetch_size);
-        $args->write_short($prefetch_count);
-        $args->write_bits(array($global));
-        return array(70, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_long($prefetch_size);
+        $writer->write_short($prefetch_count);
+        $writer->write_bits(array($global));
+        return array(70, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function fileQosOk($args)
+    public static function fileQosOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param string $consumer_tag
+     * @param boolean $no_local
+     * @param boolean $no_ack
+     * @param boolean $exclusive
+     * @param boolean $nowait
      * @return array
      */
     public function fileConsume($ticket = 1, $queue = '', $consumer_tag = '', $no_local = false, $no_ack = false, $exclusive = false, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_shortstr($consumer_tag);
-        $args->write_bits(array($no_local, $no_ack, $exclusive, $nowait));
-        return array(70, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_bits(array($no_local, $no_ack, $exclusive, $nowait));
+        return array(70, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function fileConsumeOk($args)
+    public static function fileConsumeOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param string $consumer_tag
+     * @param boolean $nowait
      * @return array
      */
     public function fileCancel($consumer_tag, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($consumer_tag);
-        $args->write_bits(array($nowait));
-        return array(70, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_bits(array($nowait));
+        return array(70, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function fileCancelOk($args)
+    public static function fileCancelOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param string $identifier
+     * @param integer $content_size
      * @return array
      */
     public function fileOpen($identifier, $content_size)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($identifier);
-        $args->write_longlong($content_size);
-        return array(70, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($identifier);
+        $writer->write_longlong($content_size);
+        return array(70, 40, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function fileOpenOk($args)
+    public static function fileOpenOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longlong();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longlong();
+        return $response;
     }
 
-
-
     /**
+
      * @return array
      */
     public function fileStage()
     {
-        $args = new AMQPWriter();
-        return array(70, 50, $args);
+        $writer = new AMQPWriter();
+        return array(70, 50, $writer);
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $exchange
+     * @param string $routing_key
+     * @param boolean $mandatory
+     * @param boolean $immediate
+     * @param string $identifier
      * @return array
      */
     public function filePublish($ticket = 1, $exchange = '', $routing_key = '', $mandatory = false, $immediate = false, $identifier)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_bits(array($mandatory, $immediate));
-        $args->write_shortstr($identifier);
-        return array(70, 60, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_bits(array($mandatory, $immediate));
+        $writer->write_shortstr($identifier);
+        return array(70, 60, $writer);
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param string $exchange
+     * @param string $routing_key
      * @return array
      */
     public function fileReturn($reply_code = 200, $reply_text = '', $exchange, $routing_key)
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        return array(70, 70, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        return array(70, 70, $writer);
     }
 
-
-
     /**
+     * @param string $consumer_tag
+     * @param integer $delivery_tag
+     * @param boolean $redelivered
+     * @param string $exchange
+     * @param string $routing_key
+     * @param string $identifier
      * @return array
      */
     public function fileDeliver($consumer_tag, $delivery_tag, $redelivered = false, $exchange, $routing_key, $identifier)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($consumer_tag);
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($redelivered));
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_shortstr($identifier);
-        return array(70, 80, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($redelivered));
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_shortstr($identifier);
+        return array(70, 80, $writer);
     }
 
-
-
     /**
+     * @param integer $delivery_tag
+     * @param boolean $multiple
      * @return array
      */
     public function fileAck($delivery_tag = 0, $multiple = false)
     {
-        $args = new AMQPWriter();
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($multiple));
-        return array(70, 90, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($multiple));
+        return array(70, 90, $writer);
     }
 
-
-
     /**
+     * @param integer $delivery_tag
+     * @param boolean $requeue
      * @return array
      */
     public function fileReject($delivery_tag, $requeue = true)
     {
-        $args = new AMQPWriter();
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($requeue));
-        return array(70, 100, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($requeue));
+        return array(70, 100, $writer);
     }
 
-
-
     /**
+     * @param integer $prefetch_size
+     * @param integer $prefetch_count
+     * @param integer $consume_rate
+     * @param boolean $global
      * @return array
      */
     public function streamQos($prefetch_size = 0, $prefetch_count = 0, $consume_rate = 0, $global = false)
     {
-        $args = new AMQPWriter();
-        $args->write_long($prefetch_size);
-        $args->write_short($prefetch_count);
-        $args->write_long($consume_rate);
-        $args->write_bits(array($global));
-        return array(80, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_long($prefetch_size);
+        $writer->write_short($prefetch_count);
+        $writer->write_long($consume_rate);
+        $writer->write_bits(array($global));
+        return array(80, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function streamQosOk($args)
+    public static function streamQosOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param string $consumer_tag
+     * @param boolean $no_local
+     * @param boolean $exclusive
+     * @param boolean $nowait
      * @return array
      */
     public function streamConsume($ticket = 1, $queue = '', $consumer_tag = '', $no_local = false, $exclusive = false, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_shortstr($consumer_tag);
-        $args->write_bits(array($no_local, $exclusive, $nowait));
-        return array(80, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_bits(array($no_local, $exclusive, $nowait));
+        return array(80, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function streamConsumeOk($args)
+    public static function streamConsumeOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param string $consumer_tag
+     * @param boolean $nowait
      * @return array
      */
     public function streamCancel($consumer_tag, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($consumer_tag);
-        $args->write_bits(array($nowait));
-        return array(80, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_bits(array($nowait));
+        return array(80, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function streamCancelOk($args)
+    public static function streamCancelOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $exchange
+     * @param string $routing_key
+     * @param boolean $mandatory
+     * @param boolean $immediate
      * @return array
      */
     public function streamPublish($ticket = 1, $exchange = '', $routing_key = '', $mandatory = false, $immediate = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_bits(array($mandatory, $immediate));
-        return array(80, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_bits(array($mandatory, $immediate));
+        return array(80, 40, $writer);
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param string $exchange
+     * @param string $routing_key
      * @return array
      */
     public function streamReturn($reply_code = 200, $reply_text = '', $exchange, $routing_key)
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        return array(80, 50, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        return array(80, 50, $writer);
     }
 
-
-
     /**
+     * @param string $consumer_tag
+     * @param integer $delivery_tag
+     * @param string $exchange
+     * @param string $queue
      * @return array
      */
     public function streamDeliver($consumer_tag, $delivery_tag, $exchange, $queue)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($consumer_tag);
-        $args->write_longlong($delivery_tag);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($queue);
-        return array(80, 60, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_longlong($delivery_tag);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($queue);
+        return array(80, 60, $writer);
     }
 
-
-
     /**
+
      * @return array
      */
     public function txSelect()
     {
-        $args = new AMQPWriter();
-        return array(90, 10, $args);
+        $writer = new AMQPWriter();
+        return array(90, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function txSelectOk($args)
+    public static function txSelectOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+
      * @return array
      */
     public function txCommit()
     {
-        $args = new AMQPWriter();
-        return array(90, 20, $args);
+        $writer = new AMQPWriter();
+        return array(90, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function txCommitOk($args)
+    public static function txCommitOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+
      * @return array
      */
     public function txRollback()
     {
-        $args = new AMQPWriter();
-        return array(90, 30, $args);
+        $writer = new AMQPWriter();
+        return array(90, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function txRollbackOk($args)
+    public static function txRollbackOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+
      * @return array
      */
     public function dtxSelect()
     {
-        $args = new AMQPWriter();
-        return array(100, 10, $args);
+        $writer = new AMQPWriter();
+        return array(100, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function dtxSelectOk($args)
+    public static function dtxSelectOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param string $dtx_identifier
      * @return array
      */
     public function dtxStart($dtx_identifier)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($dtx_identifier);
-        return array(100, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($dtx_identifier);
+        return array(100, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function dtxStartOk($args)
+    public static function dtxStartOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param mixed $meta_data
      * @return array
      */
     public function tunnelRequest($meta_data)
     {
-        $args = new AMQPWriter();
-        $args->write_table(empty($meta_data) ? array() : $meta_data);
-        return array(110, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_table(empty($meta_data) ? array() : $meta_data);
+        return array(110, 10, $writer);
     }
 
-
-
     /**
+     * @param mixed $integer_1
+     * @param integer $integer_2
+     * @param integer $integer_3
+     * @param integer $integer_4
+     * @param mixed $operation
      * @return array
      */
     public function testInteger($integer_1, $integer_2, $integer_3, $integer_4, $operation)
     {
-        $args = new AMQPWriter();
-        $args->write_octet($integer_1);
-        $args->write_short($integer_2);
-        $args->write_long($integer_3);
-        $args->write_longlong($integer_4);
-        $args->write_octet($operation);
-        return array(120, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_octet($integer_1);
+        $writer->write_short($integer_2);
+        $writer->write_long($integer_3);
+        $writer->write_longlong($integer_4);
+        $writer->write_octet($operation);
+        return array(120, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function testIntegerOk($args)
+    public static function testIntegerOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longlong();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longlong();
+        return $response;
     }
 
-
-
     /**
+     * @param string $string_1
+     * @param string $string_2
+     * @param mixed $operation
      * @return array
      */
     public function testString($string_1, $string_2, $operation)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($string_1);
-        $args->write_longstr($string_2);
-        $args->write_octet($operation);
-        return array(120, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($string_1);
+        $writer->write_longstr($string_2);
+        $writer->write_octet($operation);
+        return array(120, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function testStringOk($args)
+    public static function testStringOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longstr();
+        return $response;
     }
 
-
-
     /**
+     * @param mixed $table
+     * @param mixed $integer_op
+     * @param mixed $string_op
      * @return array
      */
     public function testTable($table, $integer_op, $string_op)
     {
-        $args = new AMQPWriter();
-        $args->write_table(empty($table) ? array() : $table);
-        $args->write_octet($integer_op);
-        $args->write_octet($string_op);
-        return array(120, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_table(empty($table) ? array() : $table);
+        $writer->write_octet($integer_op);
+        $writer->write_octet($string_op);
+        return array(120, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function testTableOk($args)
+    public static function testTableOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longlong();
-        $ret[] = $args->read_longstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longlong();
+        $response[] = $reader->read_longstr();
+        return $response;
     }
 
-
-
     /**
+
      * @return array
      */
     public function testContent()
     {
-        $args = new AMQPWriter();
-        return array(120, 40, $args);
+        $writer = new AMQPWriter();
+        return array(120, 40, $writer);
     }
-
-
 
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function testContentOk($args)
+    public static function testContentOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_long();
+        return $response;
     }
-
 }

--- a/PhpAmqpLib/Helper/Protocol/Protocol091.php
+++ b/PhpAmqpLib/Helper/Protocol/Protocol091.php
@@ -9,862 +9,858 @@ use PhpAmqpLib\Wire\AMQPReader;
 
 class Protocol091
 {
-
     /**
+     * @param integer $version_major
+     * @param integer $version_minor
+     * @param mixed $server_properties
+     * @param string $mechanisms
+     * @param string $locales
      * @return array
      */
     public function connectionStart($version_major = 0, $version_minor = 9, $server_properties, $mechanisms = 'PLAIN', $locales = 'en_US')
     {
-        $args = new AMQPWriter();
-        $args->write_octet($version_major);
-        $args->write_octet($version_minor);
-        $args->write_table(empty($server_properties) ? array() : $server_properties);
-        $args->write_longstr($mechanisms);
-        $args->write_longstr($locales);
-        return array(10, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_octet($version_major);
+        $writer->write_octet($version_minor);
+        $writer->write_table(empty($server_properties) ? array() : $server_properties);
+        $writer->write_longstr($mechanisms);
+        $writer->write_longstr($locales);
+        return array(10, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionStartOk($args)
+    public static function connectionStartOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_table();
-        $ret[] = $args->read_shortstr();
-        $ret[] = $args->read_longstr();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_table();
+        $response[] = $reader->read_shortstr();
+        $response[] = $reader->read_longstr();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param string $challenge
      * @return array
      */
     public function connectionSecure($challenge)
     {
-        $args = new AMQPWriter();
-        $args->write_longstr($challenge);
-        return array(10, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longstr($challenge);
+        return array(10, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionSecureOk($args)
+    public static function connectionSecureOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longstr();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $channel_max
+     * @param integer $frame_max
+     * @param integer $heartbeat
      * @return array
      */
     public function connectionTune($channel_max = 0, $frame_max = 0, $heartbeat = 0)
     {
-        $args = new AMQPWriter();
-        $args->write_short($channel_max);
-        $args->write_long($frame_max);
-        $args->write_short($heartbeat);
-        return array(10, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($channel_max);
+        $writer->write_long($frame_max);
+        $writer->write_short($heartbeat);
+        return array(10, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionTuneOk($args)
+    public static function connectionTuneOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_short();
-        $ret[] = $args->read_long();
-        $ret[] = $args->read_short();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_short();
+        $response[] = $reader->read_long();
+        $response[] = $reader->read_short();
+        return $response;
     }
 
-
-
     /**
+     * @param string $virtual_host
+     * @param string $capabilities
+     * @param boolean $insist
      * @return array
      */
     public function connectionOpen($virtual_host = '/', $capabilities = '', $insist = false)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($virtual_host);
-        $args->write_shortstr($capabilities);
-        $args->write_bits(array($insist));
-        return array(10, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($virtual_host);
+        $writer->write_shortstr($capabilities);
+        $writer->write_bits(array($insist));
+        return array(10, 40, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionOpenOk($args)
+    public static function connectionOpenOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param integer $class_id
+     * @param integer $method_id
      * @return array
      */
     public function connectionClose($reply_code, $reply_text = '', $class_id, $method_id)
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_short($class_id);
-        $args->write_short($method_id);
-        return array(10, 50, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_short($class_id);
+        $writer->write_short($method_id);
+        return array(10, 50, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionCloseOk($args)
+    public static function connectionCloseOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param string $reason
      * @return array
      */
     public function connectionBlocked($reason = '')
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($reason);
-        return array(10, 60, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($reason);
+        return array(10, 60, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function connectionUnblocked($args)
+    public static function connectionUnblocked(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param string $out_of_band
      * @return array
      */
     public function channelOpen($out_of_band = '')
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($out_of_band);
-        return array(20, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($out_of_band);
+        return array(20, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function channelOpenOk($args)
+    public static function channelOpenOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longstr();
+        return $response;
     }
 
-
-
     /**
+     * @param boolean $active
      * @return array
      */
     public function channelFlow($active)
     {
-        $args = new AMQPWriter();
-        $args->write_bits(array($active));
-        return array(20, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_bits(array($active));
+        return array(20, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function channelFlowOk($args)
+    public static function channelFlowOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_bit();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_bit();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param integer $class_id
+     * @param integer $method_id
      * @return array
      */
     public function channelClose($reply_code, $reply_text = '', $class_id, $method_id)
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_short($class_id);
-        $args->write_short($method_id);
-        return array(20, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_short($class_id);
+        $writer->write_short($method_id);
+        return array(20, 40, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function channelCloseOk($args)
+    public static function channelCloseOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param string $realm
+     * @param boolean $exclusive
+     * @param boolean $passive
+     * @param boolean $active
+     * @param boolean $write
+     * @param boolean $read
      * @return array
      */
     public function accessRequest($realm = '/data', $exclusive = false, $passive = true, $active = true, $write = true, $read = true)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($realm);
-        $args->write_bits(array($exclusive, $passive, $active, $write, $read));
-        return array(30, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($realm);
+        $writer->write_bits(array($exclusive, $passive, $active, $write, $read));
+        return array(30, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function accessRequestOk($args)
+    public static function accessRequestOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_short();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_short();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $exchange
+     * @param string $type
+     * @param boolean $passive
+     * @param boolean $durable
+     * @param boolean $auto_delete
+     * @param boolean $internal
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function exchangeDeclare($ticket = 0, $exchange, $type = 'direct', $passive = false, $durable = false, $auto_delete = false, $internal = false, $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($type);
-        $args->write_bits(array($passive, $durable, $auto_delete, $internal, $nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(40, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($type);
+        $writer->write_bits(array($passive, $durable, $auto_delete, $internal, $nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(40, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function exchangeDeclareOk($args)
+    public static function exchangeDeclareOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $exchange
+     * @param boolean $if_unused
+     * @param boolean $nowait
      * @return array
      */
     public function exchangeDelete($ticket = 0, $exchange, $if_unused = false, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($exchange);
-        $args->write_bits(array($if_unused, $nowait));
-        return array(40, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($exchange);
+        $writer->write_bits(array($if_unused, $nowait));
+        return array(40, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function exchangeDeleteOk($args)
+    public static function exchangeDeleteOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $destination
+     * @param string $source
+     * @param string $routing_key
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function exchangeBind($ticket = 0, $destination, $source, $routing_key = '', $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($destination);
-        $args->write_shortstr($source);
-        $args->write_shortstr($routing_key);
-        $args->write_bits(array($nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(40, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($destination);
+        $writer->write_shortstr($source);
+        $writer->write_shortstr($routing_key);
+        $writer->write_bits(array($nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(40, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function exchangeBindOk($args)
+    public static function exchangeBindOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $destination
+     * @param string $source
+     * @param string $routing_key
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function exchangeUnbind($ticket = 0, $destination, $source, $routing_key = '', $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($destination);
-        $args->write_shortstr($source);
-        $args->write_shortstr($routing_key);
-        $args->write_bits(array($nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(40, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($destination);
+        $writer->write_shortstr($source);
+        $writer->write_shortstr($routing_key);
+        $writer->write_bits(array($nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(40, 40, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function exchangeUnbindOk($args)
+    public static function exchangeUnbindOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param boolean $passive
+     * @param boolean $durable
+     * @param boolean $exclusive
+     * @param boolean $auto_delete
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function queueDeclare($ticket = 0, $queue = '', $passive = false, $durable = false, $exclusive = false, $auto_delete = false, $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_bits(array($passive, $durable, $exclusive, $auto_delete, $nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(50, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_bits(array($passive, $durable, $exclusive, $auto_delete, $nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(50, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queueDeclareOk($args)
+    public static function queueDeclareOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        $ret[] = $args->read_long();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        $response[] = $reader->read_long();
+        $response[] = $reader->read_long();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param string $exchange
+     * @param string $routing_key
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function queueBind($ticket = 0, $queue = '', $exchange, $routing_key = '', $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_bits(array($nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(50, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_bits(array($nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(50, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queueBindOk($args)
+    public static function queueBindOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param boolean $nowait
      * @return array
      */
     public function queuePurge($ticket = 0, $queue = '', $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_bits(array($nowait));
-        return array(50, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_bits(array($nowait));
+        return array(50, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queuePurgeOk($args)
+    public static function queuePurgeOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_long();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param boolean $if_unused
+     * @param boolean $if_empty
+     * @param boolean $nowait
      * @return array
      */
     public function queueDelete($ticket = 0, $queue = '', $if_unused = false, $if_empty = false, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_bits(array($if_unused, $if_empty, $nowait));
-        return array(50, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_bits(array($if_unused, $if_empty, $nowait));
+        return array(50, 40, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queueDeleteOk($args)
+    public static function queueDeleteOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_long();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param string $exchange
+     * @param string $routing_key
+     * @param array $arguments
      * @return array
      */
     public function queueUnbind($ticket = 0, $queue = '', $exchange, $routing_key = '', $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(50, 50, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(50, 50, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function queueUnbindOk($args)
+    public static function queueUnbindOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $prefetch_size
+     * @param integer $prefetch_count
+     * @param boolean $global
      * @return array
      */
     public function basicQos($prefetch_size = 0, $prefetch_count = 0, $global = false)
     {
-        $args = new AMQPWriter();
-        $args->write_long($prefetch_size);
-        $args->write_short($prefetch_count);
-        $args->write_bits(array($global));
-        return array(60, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_long($prefetch_size);
+        $writer->write_short($prefetch_count);
+        $writer->write_bits(array($global));
+        return array(60, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicQosOk($args)
+    public static function basicQosOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param string $consumer_tag
+     * @param boolean $no_local
+     * @param boolean $no_ack
+     * @param boolean $exclusive
+     * @param boolean $nowait
+     * @param array $arguments
      * @return array
      */
     public function basicConsume($ticket = 0, $queue = '', $consumer_tag = '', $no_local = false, $no_ack = false, $exclusive = false, $nowait = false, $arguments = array())
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_shortstr($consumer_tag);
-        $args->write_bits(array($no_local, $no_ack, $exclusive, $nowait));
-        $args->write_table(empty($arguments) ? array() : $arguments);
-        return array(60, 20, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_bits(array($no_local, $no_ack, $exclusive, $nowait));
+        $writer->write_table(empty($arguments) ? array() : $arguments);
+        return array(60, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicConsumeOk($args)
+    public static function basicConsumeOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param string $consumer_tag
+     * @param boolean $nowait
      * @return array
      */
     public function basicCancel($consumer_tag, $nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($consumer_tag);
-        $args->write_bits(array($nowait));
-        return array(60, 30, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_bits(array($nowait));
+        return array(60, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicCancelOk($args)
+    public static function basicCancelOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $exchange
+     * @param string $routing_key
+     * @param boolean $mandatory
+     * @param boolean $immediate
      * @return array
      */
     public function basicPublish($ticket = 0, $exchange = '', $routing_key = '', $mandatory = false, $immediate = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        $args->write_bits(array($mandatory, $immediate));
-        return array(60, 40, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        $writer->write_bits(array($mandatory, $immediate));
+        return array(60, 40, $writer);
     }
 
-
-
     /**
+     * @param integer $reply_code
+     * @param string $reply_text
+     * @param string $exchange
+     * @param string $routing_key
      * @return array
      */
     public function basicReturn($reply_code, $reply_text = '', $exchange, $routing_key)
     {
-        $args = new AMQPWriter();
-        $args->write_short($reply_code);
-        $args->write_shortstr($reply_text);
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        return array(60, 50, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($reply_code);
+        $writer->write_shortstr($reply_text);
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        return array(60, 50, $writer);
     }
 
-
-
     /**
+     * @param string $consumer_tag
+     * @param integer $delivery_tag
+     * @param boolean $redelivered
+     * @param string $exchange
+     * @param string $routing_key
      * @return array
      */
     public function basicDeliver($consumer_tag, $delivery_tag, $redelivered = false, $exchange, $routing_key)
     {
-        $args = new AMQPWriter();
-        $args->write_shortstr($consumer_tag);
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($redelivered));
-        $args->write_shortstr($exchange);
-        $args->write_shortstr($routing_key);
-        return array(60, 60, $args);
+        $writer = new AMQPWriter();
+        $writer->write_shortstr($consumer_tag);
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($redelivered));
+        $writer->write_shortstr($exchange);
+        $writer->write_shortstr($routing_key);
+        return array(60, 60, $writer);
     }
 
-
-
     /**
+     * @param integer $ticket
+     * @param string $queue
+     * @param boolean $no_ack
      * @return array
      */
     public function basicGet($ticket = 0, $queue = '', $no_ack = false)
     {
-        $args = new AMQPWriter();
-        $args->write_short($ticket);
-        $args->write_shortstr($queue);
-        $args->write_bits(array($no_ack));
-        return array(60, 70, $args);
+        $writer = new AMQPWriter();
+        $writer->write_short($ticket);
+        $writer->write_shortstr($queue);
+        $writer->write_bits(array($no_ack));
+        return array(60, 70, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicGetOk($args)
+    public static function basicGetOk(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_longlong();
-        $ret[] = $args->read_bit();
-        $ret[] = $args->read_shortstr();
-        $ret[] = $args->read_shortstr();
-        $ret[] = $args->read_long();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_longlong();
+        $response[] = $reader->read_bit();
+        $response[] = $reader->read_shortstr();
+        $response[] = $reader->read_shortstr();
+        $response[] = $reader->read_long();
+        return $response;
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicGetEmpty($args)
+    public static function basicGetEmpty(AMQPReader $reader)
     {
-        $ret = array();
-        $ret[] = $args->read_shortstr();
-        return $ret;
+        $response = array();
+        $response[] = $reader->read_shortstr();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $delivery_tag
+     * @param boolean $multiple
      * @return array
      */
     public function basicAck($delivery_tag = 0, $multiple = false)
     {
-        $args = new AMQPWriter();
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($multiple));
-        return array(60, 80, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($multiple));
+        return array(60, 80, $writer);
     }
 
-
-
     /**
+     * @param integer $delivery_tag
+     * @param boolean $requeue
      * @return array
      */
     public function basicReject($delivery_tag, $requeue = true)
     {
-        $args = new AMQPWriter();
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($requeue));
-        return array(60, 90, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($requeue));
+        return array(60, 90, $writer);
     }
 
-
-
     /**
+     * @param boolean $requeue
      * @return array
      */
     public function basicRecoverAsync($requeue = false)
     {
-        $args = new AMQPWriter();
-        $args->write_bits(array($requeue));
-        return array(60, 100, $args);
+        $writer = new AMQPWriter();
+        $writer->write_bits(array($requeue));
+        return array(60, 100, $writer);
     }
 
-
-
     /**
+     * @param boolean $requeue
      * @return array
      */
     public function basicRecover($requeue = false)
     {
-        $args = new AMQPWriter();
-        $args->write_bits(array($requeue));
-        return array(60, 110, $args);
+        $writer = new AMQPWriter();
+        $writer->write_bits(array($requeue));
+        return array(60, 110, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function basicRecoverOk($args)
+    public static function basicRecoverOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param integer $delivery_tag
+     * @param boolean $multiple
+     * @param boolean $requeue
      * @return array
      */
     public function basicNack($delivery_tag = 0, $multiple = false, $requeue = true)
     {
-        $args = new AMQPWriter();
-        $args->write_longlong($delivery_tag);
-        $args->write_bits(array($multiple, $requeue));
-        return array(60, 120, $args);
+        $writer = new AMQPWriter();
+        $writer->write_longlong($delivery_tag);
+        $writer->write_bits(array($multiple, $requeue));
+        return array(60, 120, $writer);
     }
 
-
-
     /**
+
      * @return array
      */
     public function txSelect()
     {
-        $args = new AMQPWriter();
-        return array(90, 10, $args);
+        $writer = new AMQPWriter();
+        return array(90, 10, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function txSelectOk($args)
+    public static function txSelectOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+
      * @return array
      */
     public function txCommit()
     {
-        $args = new AMQPWriter();
-        return array(90, 20, $args);
+        $writer = new AMQPWriter();
+        return array(90, 20, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function txCommitOk($args)
+    public static function txCommitOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+
      * @return array
      */
     public function txRollback()
     {
-        $args = new AMQPWriter();
-        return array(90, 30, $args);
+        $writer = new AMQPWriter();
+        return array(90, 30, $writer);
     }
 
-
-
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function txRollbackOk($args)
+    public static function txRollbackOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
 
-
-
     /**
+     * @param boolean $nowait
      * @return array
      */
     public function confirmSelect($nowait = false)
     {
-        $args = new AMQPWriter();
-        $args->write_bits(array($nowait));
-        return array(85, 10, $args);
+        $writer = new AMQPWriter();
+        $writer->write_bits(array($nowait));
+        return array(85, 10, $writer);
     }
-
-
 
     /**
-     * @param AMQPReader $args
+     * @param AMQPReader $reader
      * @return array
      */
-    public static function confirmSelectOk($args)
+    public static function confirmSelectOk(AMQPReader $reader)
     {
-        $ret = array();
-        return $ret;
+        $response = array();
+        return $response;
     }
-
 }

--- a/PhpAmqpLib/Helper/Protocol/Wait080.php
+++ b/PhpAmqpLib/Helper/Protocol/Wait080.php
@@ -6,7 +6,9 @@ namespace PhpAmqpLib\Helper\Protocol;
 
 class Wait080
 {
-
+    /**
+     * @var array
+     */
     protected $wait = array(
         'connection.start' => '10,10',
         'connection.start_ok' => '10,11',
@@ -103,11 +105,12 @@ class Wait080
         'test.content_ok' => '120,41',
     );
 
-
-
+    /**
+     * @var string
+     * @return string
+     */
     public function get_wait($method)
     {
         return $this->wait[$method];
     }
-
 }

--- a/PhpAmqpLib/Helper/Protocol/Wait091.php
+++ b/PhpAmqpLib/Helper/Protocol/Wait091.php
@@ -6,7 +6,9 @@ namespace PhpAmqpLib\Helper\Protocol;
 
 class Wait091
 {
-
+    /**
+     * @var array
+     */
     protected $wait = array(
         'connection.start' => '10,10',
         'connection.start_ok' => '10,11',
@@ -74,11 +76,12 @@ class Wait091
         'confirm.select_ok' => '85,11',
     );
 
-
-
+    /**
+     * @var string
+     * @return string
+     */
     public function get_wait($method)
     {
         return $this->wait[$method];
     }
-
 }

--- a/PhpAmqpLib/Wire/Constants080.php
+++ b/PhpAmqpLib/Wire/Constants080.php
@@ -6,9 +6,14 @@ namespace PhpAmqpLib\Wire;
 
 class Constants080
 {
-
+    /**
+     * @var string
+     */
     public static $AMQP_PROTOCOL_HEADER = "AMQP\x01\x01\x08\x00";
 
+    /**
+     * @var array
+     */
     public static $FRAME_TYPES = array(
         1 => 'FRAME-METHOD',
         2 => 'FRAME-HEADER',
@@ -23,6 +28,9 @@ class Constants080
         501 => 'FRAME-ERROR',
     );
 
+    /**
+     * @var array
+     */
     public static $CONTENT_METHODS = array(
         0 => '60,40',
         1 => '60,50',
@@ -38,11 +46,17 @@ class Constants080
         11 => '120,41',
     );
 
+    /**
+     * @var array
+     */
     public static $CLOSE_METHODS = array(
         0 => '10,60',
         1 => '20,40',
     );
 
+    /**
+     * @var array
+     */
     public static $GLOBAL_METHOD_NAMES = array(
         '10,10' => 'Connection.start',
         '10,11' => 'Connection.start_ok',
@@ -138,5 +152,4 @@ class Constants080
         '120,40' => 'Test.content',
         '120,41' => 'Test.content_ok',
     );
-
 }

--- a/PhpAmqpLib/Wire/Constants091.php
+++ b/PhpAmqpLib/Wire/Constants091.php
@@ -6,9 +6,14 @@ namespace PhpAmqpLib\Wire;
 
 class Constants091
 {
-
+    /**
+     * @var string
+     */
     public static $AMQP_PROTOCOL_HEADER = "AMQP\x00\x00\x09\x01";
 
+    /**
+     * @var array
+     */
     public static $FRAME_TYPES = array(
         1 => 'FRAME-METHOD',
         2 => 'FRAME-HEADER',
@@ -19,6 +24,9 @@ class Constants091
         501 => 'FRAME-ERROR',
     );
 
+    /**
+     * @var array
+     */
     public static $CONTENT_METHODS = array(
         0 => '60,40',
         1 => '60,50',
@@ -26,11 +34,17 @@ class Constants091
         3 => '60,71',
     );
 
+    /**
+     * @var array
+     */
     public static $CLOSE_METHODS = array(
         0 => '10,50',
         1 => '20,40',
     );
 
+    /**
+     * @var array
+     */
     public static $GLOBAL_METHOD_NAMES = array(
         '10,10' => 'Connection.start',
         '10,11' => 'Connection.start_ok',
@@ -97,5 +111,4 @@ class Constants091
         '85,10' => 'Confirm.select',
         '85,11' => 'Confirm.select_ok',
     );
-
 }


### PR DESCRIPTION
I also updated some variables from `$args` to the appropriate `$reader` and `$writer` for clarity.

The only thing that _might_ break backwards compatibility is adding the `AMQPReader` and `AMQPWriter` type-hint to some of the method definitions.  That would only come into effect though, if users are extending and overwriting those methods (which I doubt people would do right?)