### PR TITLE
Get the array of valid frame types from the protocol constants class

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -509,6 +509,10 @@ class AbstractConnection extends AbstractChannel
             );
 
             $frame_type = $this->wait_frame_reader->read_octet();
+            $class = self::$PROTOCOL_CONSTANTS_CLASS;
+            if (!array_key_exists($frame_type, $class::$FRAME_TYPES)) {
+                throw new AMQPRuntimeException('Invalid frame type ' . $frame_type);
+            }
             $channel = $this->wait_frame_reader->read_short();
             $size = $this->wait_frame_reader->read_long();
 


### PR DESCRIPTION
A neater and more concise fix for #338.

When a frame_type is read from a message, get the list of valid frame types for the protocol version in use, and validate against them, throwing an AMQPRuntimeException if invalid.