### PR TITLE
Add Missing DocBlocks and Types

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -644,7 +644,7 @@ class AMQPChannel extends AbstractChannel
      * Confirms a queue definition
      *
      * @param AMQPReader $reader
-     * @return string[]
+     * @return array
      */
     protected function queue_declare_ok($reader)
     {

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -170,7 +170,7 @@ abstract class AbstractChannel
     /**
      * @param string $method_sig
      * @param string $args
-     * @param $content
+     * @param mixed $content
      * @return mixed
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      */
@@ -218,7 +218,7 @@ abstract class AbstractChannel
     }
 
     /**
-     * @param $method_sig
+     * @param string $method_sig
      * @param string $args
      */
     protected function send_method_frame($method_sig, $args = '')
@@ -347,6 +347,10 @@ abstract class AbstractChannel
         }
     }
 
+    /**
+     * @param string $allowed_methods
+     * @return array
+     */
     protected function process_deferred_methods($allowed_methods)
     {
         $dispatch = false;
@@ -368,6 +372,10 @@ abstract class AbstractChannel
         return array('dispatch' => $dispatch, 'queued_method' => $queued_method);
     }
 
+    /**
+     * @param array $queued_method
+     * @return mixed
+     */
     protected function dispatch_deferred_method($queued_method)
     {
         $this->debug->debug_method_signature('Executing queued method: %s', $queued_method[0]);
@@ -376,7 +384,7 @@ abstract class AbstractChannel
     }
 
     /**
-     * @param $frame_type
+     * @param int $frame_type
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      */
     protected function validate_method_frame($frame_type)
@@ -384,11 +392,19 @@ abstract class AbstractChannel
         $this->validate_frame($frame_type, 1, 'AMQP method');
     }
 
+    /**
+     * @param int $frame_type
+     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     */
     protected function validate_header_frame($frame_type)
     {
         $this->validate_frame($frame_type, 2, 'AMQP Content header');
     }
 
+    /**
+     * @param int $frame_type
+     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     */
     protected function validate_body_frame($frame_type)
     {
         $this->validate_frame($frame_type, 3, 'AMQP Content body');
@@ -413,7 +429,7 @@ abstract class AbstractChannel
     }
 
     /**
-     * @param $payload
+     * @param string $payload
      * @throws \PhpAmqpLib\Exception\AMQPOutOfBoundsException
      */
     protected function validate_frame_payload($payload)
@@ -423,6 +439,10 @@ abstract class AbstractChannel
         }
     }
 
+    /**
+     * @param string $payload
+     * @return string
+     */
     protected function build_method_signature($payload)
     {
         $method_sig_array = unpack('n2', mb_substr($payload, 0, 4, 'ASCII'));
@@ -430,6 +450,10 @@ abstract class AbstractChannel
         return sprintf('%s,%s', $method_sig_array[1], $method_sig_array[2]);
     }
 
+    /**
+     * @param string $payload
+     * @return string
+     */
     protected function extract_args($payload)
     {
         return mb_substr($payload, 4, mb_strlen($payload, 'ASCII') - 4, 'ASCII');

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -219,7 +219,7 @@ abstract class AbstractChannel
 
     /**
      * @param string $method_sig
-     * @param string $args
+     * @param AMQPWriter|string $args
      */
     protected function send_method_frame($method_sig, $args = '')
     {
@@ -230,7 +230,7 @@ abstract class AbstractChannel
      * This is here for performance reasons to batch calls to fwrite from basic.publish
      *
      * @param $method_sig
-     * @param string $args
+     * @param AMQPWriter|string $args
      * @param \PhpAmqpLib\Wire\AMQPWriter $pkt
      * @return \PhpAmqpLib\Wire\AMQPWriter
      */

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -218,8 +218,8 @@ abstract class AbstractChannel
     }
 
     /**
-     * @param string $method_sig
-     * @param AMQPWriter|string $args
+     * @param array $method_sig
+     * @param \PhpAmqpLib\Wire\AMQPWriter|string $args
      */
     protected function send_method_frame($method_sig, $args = '')
     {
@@ -229,8 +229,8 @@ abstract class AbstractChannel
     /**
      * This is here for performance reasons to batch calls to fwrite from basic.publish
      *
-     * @param $method_sig
-     * @param AMQPWriter|string $args
+     * @param string[] $method_sig
+     * @param \PhpAmqpLib\Wire\AMQPWriter|string $args
      * @param \PhpAmqpLib\Wire\AMQPWriter $pkt
      * @return \PhpAmqpLib\Wire\AMQPWriter
      */

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -229,7 +229,7 @@ abstract class AbstractChannel
     /**
      * This is here for performance reasons to batch calls to fwrite from basic.publish
      *
-     * @param string[] $method_sig
+     * @param array $method_sig
      * @param \PhpAmqpLib\Wire\AMQPWriter|string $args
      * @param \PhpAmqpLib\Wire\AMQPWriter $pkt
      * @return \PhpAmqpLib\Wire\AMQPWriter

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -348,7 +348,7 @@ abstract class AbstractChannel
     }
 
     /**
-     * @param string $allowed_methods
+     * @param array $allowed_methods
      * @return array
      */
     protected function process_deferred_methods($allowed_methods)

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -170,11 +170,11 @@ abstract class AbstractChannel
     /**
      * @param string $method_sig
      * @param string $args
-     * @param AMQPMessage|null $amqMessage
+     * @param AMQPMessage|null $amqpMessage
      * @return mixed
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      */
-    public function dispatch($method_sig, $args, $amqMessage)
+    public function dispatch($method_sig, $args, $amqpMessage)
     {
         if (!$this->methodMap->valid_method($method_sig)) {
             throw new AMQPRuntimeException(sprintf(
@@ -195,11 +195,11 @@ abstract class AbstractChannel
 
         $this->dispatch_reader->reuse($args);
 
-        if ($amqMessage == null) {
+        if ($amqpMessage == null) {
             return call_user_func(array($this, $amqp_method), $this->dispatch_reader);
         }
 
-        return call_user_func(array($this, $amqp_method), $this->dispatch_reader, $amqMessage);
+        return call_user_func(array($this, $amqp_method), $this->dispatch_reader, $amqpMessage);
     }
 
     /**
@@ -331,15 +331,15 @@ abstract class AbstractChannel
 
             $this->debug->debug_method_signature('> %s', $method_sig);
 
-            $amqMessage = $this->maybe_wait_for_content($method_sig);
+            $amqpMessage = $this->maybe_wait_for_content($method_sig);
 
             if ($this->should_dispatch_method($allowed_methods, $method_sig)) {
-                return $this->dispatch($method_sig, $args, $amqMessage);
+                return $this->dispatch($method_sig, $args, $amqpMessage);
             }
 
             // Wasn't what we were looking for? save it for later
             $this->debug->debug_method_signature('Queueing for later: %s', $method_sig);
-            $this->method_queue[] = array($method_sig, $args, $amqMessage);
+            $this->method_queue[] = array($method_sig, $args, $amqpMessage);
 
             if ($non_blocking) {
                 break;
@@ -480,13 +480,13 @@ abstract class AbstractChannel
     protected function maybe_wait_for_content($method_sig)
     {
         $protocolClass = self::$PROTOCOL_CONSTANTS_CLASS;
-        $amqMessage = null;
+        $amqpMessage = null;
 
         if (in_array($method_sig, $protocolClass::$CONTENT_METHODS)) {
-            $amqMessage = $this->wait_content();
+            $amqpMessage = $this->wait_content();
         }
 
-        return $amqMessage;
+        return $amqpMessage;
     }
 
     /**

--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -41,7 +41,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
     }
 
     /**
-     * @param $options
+     * @param array $options
      * @return resource
      */
     private function create_ssl_context($options)

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -438,7 +438,7 @@ class AbstractConnection extends AbstractChannel
 
     /**
      * @param string $channel
-     * @param string $method_sig
+     * @param array $method_sig
      * @param AMQPWriter|string $args
      * @param null $pkt
      */
@@ -453,7 +453,7 @@ class AbstractConnection extends AbstractChannel
      * Returns a new AMQPWriter or mutates the provided $pkt
      *
      * @param string $channel
-     * @param string[] $method_sig
+     * @param array $method_sig
      * @param AMQPWriter|string $args
      * @param AMQPWriter $pkt
      * @return AMQPWriter

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -439,7 +439,7 @@ class AbstractConnection extends AbstractChannel
     /**
      * @param string $channel
      * @param string $method_sig
-     * @param string $args
+     * @param AMQPWriter|string $args
      * @param null $pkt
      */
     protected function send_channel_method_frame($channel, $method_sig, $args = '', $pkt = null)
@@ -454,7 +454,7 @@ class AbstractConnection extends AbstractChannel
      *
      * @param string $channel
      * @param string[] $method_sig
-     * @param string $args
+     * @param AMQPWriter|string $args
      * @param AMQPWriter $pkt
      * @return AMQPWriter
      */

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -438,7 +438,7 @@ class AbstractConnection extends AbstractChannel
 
     /**
      * @param string $channel
-     * @param $method_sig
+     * @param string $method_sig
      * @param string $args
      * @param null $pkt
      */
@@ -674,6 +674,8 @@ class AbstractConnection extends AbstractChannel
 
     /**
      * Confirm a connection close
+     *
+     * @param AMQPReader $args
      */
     protected function connection_close_ok($args)
     {
@@ -747,6 +749,8 @@ class AbstractConnection extends AbstractChannel
 
     /**
      * Security mechanism response
+     *
+     * @param string $response
      */
     protected function x_secure_ok($response)
     {
@@ -821,9 +825,9 @@ class AbstractConnection extends AbstractChannel
     /**
      * Negotiates connection tuning parameters
      *
-     * @param $channel_max
-     * @param $frame_max
-     * @param $heartbeat
+     * @param int $channel_max
+     * @param int $frame_max
+     * @param int $heartbeat
      */
     protected function x_tune_ok($channel_max, $frame_max, $heartbeat)
     {
@@ -864,6 +868,8 @@ class AbstractConnection extends AbstractChannel
 
     /**
      * Handles connection unblocked notifications
+     *
+     * @param AMQPReader $args
      */
     protected function connection_unblocked(AMQPReader $args)
     {
@@ -894,7 +900,7 @@ class AbstractConnection extends AbstractChannel
     /**
      * Gets the connection status
      *
-     * @return bool
+     * @return boolean
      */
     public function isConnected()
     {
@@ -932,7 +938,7 @@ class AbstractConnection extends AbstractChannel
     /**
      * Should the connection be attempted during construction?
      *
-     * @return bool
+     * @return boolean
      */
     public function connectOnConstruct()
     {

--- a/PhpAmqpLib/Exception/AMQPException.php
+++ b/PhpAmqpLib/Exception/AMQPException.php
@@ -25,7 +25,7 @@ class AMQPException extends \Exception
     /**
      * @param string $reply_code
      * @param int $reply_text
-     * @param \Exception $method_sig
+     * @param array $method_sig
      */
     public function __construct($reply_code, $reply_text, $method_sig)
     {

--- a/PhpAmqpLib/Exception/AMQPProtocolException.php
+++ b/PhpAmqpLib/Exception/AMQPProtocolException.php
@@ -22,7 +22,7 @@ class AMQPProtocolException extends \Exception implements AMQPExceptionInterface
     /**
      * @param string $reply_code
      * @param int $reply_text
-     * @param \Exception $method_sig
+     * @param array $method_sig
      */
     public function __construct($reply_code, $reply_text, $method_sig)
     {

--- a/PhpAmqpLib/Helper/DebugHelper.php
+++ b/PhpAmqpLib/Helper/DebugHelper.php
@@ -3,21 +3,36 @@ namespace PhpAmqpLib\Helper;
 
 class DebugHelper
 {
+    /**
+     * @var bool
+     */
     protected $debug;
 
+    /**
+     * @var string
+     */
     protected $PROTOCOL_CONSTANTS_CLASS;
 
+    /**
+     * @param string $PROTOCOL_CONSTANTS_CLASS
+     */
     public function __construct($PROTOCOL_CONSTANTS_CLASS) {
         $this->debug = defined('AMQP_DEBUG') ? AMQP_DEBUG : false;
         $this->PROTOCOL_CONSTANTS_CLASS = $PROTOCOL_CONSTANTS_CLASS;
     }
 
+    /**
+     * @param string $msg
+     */
     public function debug_msg($msg) {
         if ($this->debug) {
             $this->print_msg($msg);
         }
     }
 
+    /**
+     * @param array $allowed_methods
+     */
     public function debug_allowed_methods($allowed_methods) {
         if ($allowed_methods) {
             $msg = 'waiting for ' . implode(', ', $allowed_methods);
@@ -27,10 +42,17 @@ class DebugHelper
         $this->debug_msg($msg);
     }
 
+    /**
+     * @param string $method_sig
+     */
     public function debug_method_signature1($method_sig) {
         $this->debug_method_signature('< %s:', $method_sig);
     }
 
+    /**
+     * @param string $msg
+     * @param string $method_sig
+     */
     public function debug_method_signature($msg, $method_sig) {
         if ($this->debug) {
             $protocolClass = $this->PROTOCOL_CONSTANTS_CLASS;
@@ -42,6 +64,9 @@ class DebugHelper
         }
     }
 
+    /**
+     * @param string $data
+     */
     public function debug_hexdump($data) {
         if ($this->debug) {
             $this->debug_msg(sprintf(
@@ -52,6 +77,13 @@ class DebugHelper
         }
     }
 
+    /**
+     * @param int $version_major
+     * @param int $version_minor
+     * @param array $server_properties
+     * @param array $mechanisms
+     * @param array $locales
+     */
     public function debug_connection_start($version_major, $version_minor, $server_properties, $mechanisms, $locales) {
         if ($this->debug) {
             $this->debug_msg(sprintf(
@@ -65,6 +97,9 @@ class DebugHelper
         }
     }
 
+    /**
+     * @param string $s
+     */
     protected function print_msg($s) {
         echo $s . PHP_EOL;
     }

--- a/PhpAmqpLib/Helper/DebugHelper.php
+++ b/PhpAmqpLib/Helper/DebugHelper.php
@@ -4,7 +4,7 @@ namespace PhpAmqpLib\Helper;
 class DebugHelper
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected $debug;
 

--- a/PhpAmqpLib/Helper/DebugHelper.php
+++ b/PhpAmqpLib/Helper/DebugHelper.php
@@ -4,7 +4,7 @@ namespace PhpAmqpLib\Helper;
 class DebugHelper
 {
     /**
-     * @var bool
+     * @var boolean
      */
     protected $debug;
 

--- a/PhpAmqpLib/Helper/MiscHelper.php
+++ b/PhpAmqpLib/Helper/MiscHelper.php
@@ -55,7 +55,7 @@ class MiscHelper
      * @param bool $htmloutput Set to false for non-HTML output
      * @param bool $uppercase Set to true for uppercase hex
      * @param bool $return Set to true to return the dump
-     * @return string
+     * @return string|null
      */
     public static function hexdump($data, $htmloutput = true, $uppercase = false, $return = false)
     {

--- a/PhpAmqpLib/Helper/MiscHelper.php
+++ b/PhpAmqpLib/Helper/MiscHelper.php
@@ -4,7 +4,7 @@ namespace PhpAmqpLib\Helper;
 class MiscHelper
 {
     /**
-     * @param $a
+     * @param string|array $a
      * @return string
      */
     public static function methodSig($a)
@@ -17,7 +17,7 @@ class MiscHelper
     }
 
     /**
-     * @param $bytes
+     * @param string $bytes
      */
     public static function saveBytes($bytes)
     {
@@ -31,7 +31,7 @@ class MiscHelper
      * decimal part mutliplied by 10^6. Useful for some PHP stream functions that need seconds and microseconds as
      * different arguments
      *
-     * @param $number
+     * @param int|float $number
      * @return array
      */
     public static function splitSecondsMicroseconds($number)
@@ -120,7 +120,7 @@ class MiscHelper
     }
 
     /**
-     * @param $table
+     * @param array $table
      * @return string
      */
     public static function dump_table($table)

--- a/PhpAmqpLib/Helper/Protocol/MethodMap080.php
+++ b/PhpAmqpLib/Helper/Protocol/MethodMap080.php
@@ -106,7 +106,7 @@ class MethodMap080
     );
 
     /**
-     * @var string $method_sig
+     * @var array $method_sig
      * @return string
      */
     public function get_method($method_sig)
@@ -115,7 +115,7 @@ class MethodMap080
     }
 
     /**
-     * @var string $method_sig
+     * @var array $method_sig
      * @return boolean
      */
     public function valid_method($method_sig)

--- a/PhpAmqpLib/Helper/Protocol/MethodMap080.php
+++ b/PhpAmqpLib/Helper/Protocol/MethodMap080.php
@@ -116,7 +116,7 @@ class MethodMap080
 
     /**
      * @var string $method_sig
-     * @return bool
+     * @return boolean
      */
     public function valid_method($method_sig)
     {

--- a/PhpAmqpLib/Helper/Protocol/MethodMap080.php
+++ b/PhpAmqpLib/Helper/Protocol/MethodMap080.php
@@ -106,7 +106,7 @@ class MethodMap080
     );
 
     /**
-     * @var array $method_sig
+     * @var string $method_sig
      * @return string
      */
     public function get_method($method_sig)
@@ -115,7 +115,7 @@ class MethodMap080
     }
 
     /**
-     * @var array $method_sig
+     * @var string $method_sig
      * @return boolean
      */
     public function valid_method($method_sig)

--- a/PhpAmqpLib/Helper/Protocol/MethodMap091.php
+++ b/PhpAmqpLib/Helper/Protocol/MethodMap091.php
@@ -87,7 +87,7 @@ class MethodMap091
 
     /**
      * @var string $method_sig
-     * @return bool
+     * @return boolean
      */
     public function valid_method($method_sig)
     {

--- a/PhpAmqpLib/Helper/Protocol/Protocol080.php
+++ b/PhpAmqpLib/Helper/Protocol/Protocol080.php
@@ -1238,7 +1238,6 @@ class Protocol080
     }
 
     /**
-
      * @return array
      */
     public function testContent()

--- a/PhpAmqpLib/Message/AMQPMessage.php
+++ b/PhpAmqpLib/Message/AMQPMessage.php
@@ -108,7 +108,7 @@ class AMQPMessage extends GenericContent
     }
 
     /**
-     * @param boolean $is_truncated
+     * @param bool $is_truncated
      * @return AMQPMessage
      */
     public function setIsTruncated($is_truncated)

--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -235,7 +235,7 @@ abstract class AMQPAbstractCollection implements \Iterator
 
     /**
      * @param mixed $val
-     * @param integer $type
+     * @param int $type
      * @return array|bool|\DateTime|null
      */
     protected function decodeValue($val, $type)
@@ -390,7 +390,7 @@ abstract class AMQPAbstractCollection implements \Iterator
     }
 
     /**
-     * @param integer $type
+     * @param int $type
      * @return string
      */
     final public static function getSymbolForDataType($type)

--- a/PhpAmqpLib/Wire/AMQPArray.php
+++ b/PhpAmqpLib/Wire/AMQPArray.php
@@ -5,6 +5,9 @@ namespace PhpAmqpLib\Wire;
 class AMQPArray extends AMQPAbstractCollection
 {
 
+    /**
+     * @param array|null $data
+     */
     public function __construct(array $data = null)
     {
         parent::__construct(empty($data) ? null : array_values($data));

--- a/PhpAmqpLib/Wire/AMQPDecimal.php
+++ b/PhpAmqpLib/Wire/AMQPDecimal.php
@@ -23,8 +23,8 @@ class AMQPDecimal
     protected $e;
 
     /**
-     * @param $n
-     * @param $e
+     * @param int $n
+     * @param int $e
      * @throws \PhpAmqpLib\Exception\AMQPOutOfBoundsException
      */
     public function __construct($n, $e)

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -96,7 +96,7 @@ class AMQPReader extends AbstractClient
     }
 
     /**
-     * @param $n
+     * @param int $n
      * @return string
      */
     public function read($n)
@@ -137,7 +137,7 @@ class AMQPReader extends AbstractClient
     }
 
     /**
-     * @param $n
+     * @param int $n
      * @return string
      * @throws \RuntimeException
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException

--- a/PhpAmqpLib/Wire/AMQPTable.php
+++ b/PhpAmqpLib/Wire/AMQPTable.php
@@ -18,7 +18,7 @@ class AMQPTable extends AMQPAbstractCollection
     /**
      * @param string $key
      * @param mixed $val
-     * @param integer $type
+     * @param int|null $type
      */
     public function set($key, $val, $type = null)
     {

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -87,6 +87,8 @@ class AMQPWriter extends AbstractClient
 
     /**
      * Get what's been encoded so far.
+     *
+     * @return string
      */
     public function getvalue()
     {
@@ -100,6 +102,10 @@ class AMQPWriter extends AbstractClient
 
     /**
      * Write a plain PHP string, with no special encoding.
+     *
+     * @param string $s
+     *
+     * @return $this
      */
     public function write($s)
     {
@@ -113,7 +119,7 @@ class AMQPWriter extends AbstractClient
      * (deprecated, use write_bits instead)
      *
      * @deprecated
-     * @param $b
+     * @param bool $b
      * @return $this
      */
     public function write_bit($b)
@@ -131,7 +137,7 @@ class AMQPWriter extends AbstractClient
     /**
      * Write multiple bits as an octet
      *
-     * @param boolean[] $bits
+     * @param bool[] $bits
      * @return $this
      */
     public function write_bits($bits)
@@ -151,7 +157,7 @@ class AMQPWriter extends AbstractClient
     /**
      * Write an integer as an unsigned 8-bit value
      *
-     * @param $n
+     * @param int $n
      * @return $this
      * @throws \PhpAmqpLib\Exception\AMQPInvalidArgumentException
      */
@@ -166,6 +172,10 @@ class AMQPWriter extends AbstractClient
         return $this;
     }
 
+    /**
+     * @param int $n
+     * @return $this
+     */
     public function write_signed_octet($n)
     {
         if (($n < -128) || ($n > 127)) {
@@ -180,7 +190,7 @@ class AMQPWriter extends AbstractClient
     /**
      * Write an integer as an unsigned 16-bit value
      *
-     * @param $n
+     * @param int $n
      * @return $this
      * @throws \PhpAmqpLib\Exception\AMQPInvalidArgumentException
      */
@@ -195,6 +205,10 @@ class AMQPWriter extends AbstractClient
         return $this;
     }
 
+    /**
+     * @param int $n
+     * @return $this
+     */
     public function write_signed_short($n)
     {
         if (($n < -32768) || ($n > 32767)) {
@@ -209,7 +223,7 @@ class AMQPWriter extends AbstractClient
     /**
      * Write an integer as an unsigned 32-bit value
      *
-     * @param $n
+     * @param int $n
      * @return $this
      */
     public function write_long($n)
@@ -228,7 +242,7 @@ class AMQPWriter extends AbstractClient
     }
 
     /**
-     * @param $n
+     * @param int $n
      * @return $this
      */
     private function write_signed_long($n)
@@ -246,7 +260,7 @@ class AMQPWriter extends AbstractClient
     /**
      * Write an integer as an unsigned 64-bit value
      *
-     * @param $n
+     * @param int $n
      * @return $this
      */
     public function write_longlong($n)
@@ -277,6 +291,10 @@ class AMQPWriter extends AbstractClient
         return $this;
     }
 
+    /**
+     * @param int $n
+     * @return $this
+     */
     public function write_signed_longlong($n)
     {
         if ((bcadd($n, PHP_INT_MAX, 0) >= -1) && (bcadd($n, -PHP_INT_MAX, 0) <= 0)) {
@@ -305,7 +323,7 @@ class AMQPWriter extends AbstractClient
     }
 
     /**
-     * @param int $n
+     * @param int|string $n
      * @return integer[]
      */
     private function splitIntoQuads($n)
@@ -319,7 +337,7 @@ class AMQPWriter extends AbstractClient
      * Write a string up to 255 bytes long after encoding.
      * Assume UTF-8 encoding
      *
-     * @param $s
+     * @param string $s
      * @return $this
      * @throws \PhpAmqpLib\Exception\AMQPInvalidArgumentException
      */
@@ -339,7 +357,7 @@ class AMQPWriter extends AbstractClient
     /**
      * Write a string up to 2**32 bytes long.  Assume UTF-8 encoding
      *
-     * @param $s
+     * @param string $s
      * @return $this
      */
     public function write_longstr($s)
@@ -378,7 +396,7 @@ class AMQPWriter extends AbstractClient
     /**
      * Write unix time_t value as 64 bit timestamp
      *
-     * @param $v
+     * @param int $v
      * @return $this
      */
     public function write_timestamp($v)
@@ -393,7 +411,7 @@ class AMQPWriter extends AbstractClient
      * values are (type,value) tuples.
      *
      * @param AMQPTable|array $d Instance of AMQPTable or PHP array WITH format hints (unlike write_array())
-     * @return self
+     * @return $this
      * @throws \PhpAmqpLib\Exception\AMQPInvalidArgumentException
      */
     public function write_table($d)
@@ -416,6 +434,9 @@ class AMQPWriter extends AbstractClient
 
     /**
      * for compat with method mapping used by AMQPMessage
+     *
+     * @param AMQPTable|array
+     * @return $this
      */
     public function write_table_object($d)
     {

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -4,13 +4,13 @@ namespace PhpAmqpLib\Wire\IO;
 abstract class AbstractIO
 {
     /**
-     * @param $n
+     * @param int $n
      * @return mixed
      */
     abstract public function read($n);
 
     /**
-     * @param $data
+     * @param string $data
      * @return mixed
      */
     abstract public function write($data);
@@ -21,8 +21,8 @@ abstract class AbstractIO
     abstract public function close();
 
     /**
-     * @param $sec
-     * @param $usec
+     * @param int $sec
+     * @param int $usec
      * @return mixed
      */
     abstract public function select($sec, $usec);

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -83,7 +83,7 @@ class SocketIO extends AbstractIO
     }
 
     /**
-     * @param $n
+     * @param int $n
      * @return mixed|string
      * @throws \PhpAmqpLib\Exception\AMQPIOException
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
@@ -120,7 +120,7 @@ class SocketIO extends AbstractIO
     }
 
     /**
-     * @param $data
+     * @param string $data
      * @return mixed|void
      * @throws \PhpAmqpLib\Exception\AMQPIOException
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
@@ -168,8 +168,8 @@ class SocketIO extends AbstractIO
     }
 
     /**
-     * @param $sec
-     * @param $usec
+     * @param int $sec
+     * @param int $usec
      * @return int|mixed
      */
     public function select($sec, $usec)

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -187,7 +187,7 @@ class StreamIO extends AbstractIO
     }
 
     /**
-     * @param $len
+     * @param int $len
      * @throws \PhpAmqpLib\Exception\AMQPIOException
      * @return mixed|string
      */
@@ -244,7 +244,7 @@ class StreamIO extends AbstractIO
     }
 
     /**
-     * @param $data
+     * @param string $data
      * @return mixed|void
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException
@@ -387,8 +387,8 @@ class StreamIO extends AbstractIO
     }
 
     /**
-     * @param $sec
-     * @param $usec
+     * @param int $sec
+     * @param int $usec
      * @return int|mixed
      */
     public function select($sec, $usec)


### PR DESCRIPTION
* Added missing doc blocks
* Added missing parameter/return types in doc blocks.

Most integer parameter types were hinted using `int` rather than `integer`, and booleans as `bool` rather than `boolean`. I changed any `boolean` types to `bool` and `integer` types to `int` to stay consistent.