### PR TITLE
Fix for when the default error handler is not restored

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -120,14 +120,19 @@ class StreamIO extends AbstractIO
 
         set_error_handler(array($this, 'error_handler'));
 
-        $this->sock = stream_socket_client(
-            $remote,
-            $errno,
-            $errstr,
-            $this->connection_timeout,
-            STREAM_CLIENT_CONNECT,
-            $this->context
-        );
+        try {
+            $this->sock = stream_socket_client(
+                $remote,
+                $errno,
+                $errstr,
+                $this->connection_timeout,
+                STREAM_CLIENT_CONNECT,
+                $this->context
+            );
+        } catch (\Exception $e) {
+            restore_error_handler();
+            throw $e;
+        }
 
         restore_error_handler();
 

--- a/tests/Functional/StreamIOTest.php
+++ b/tests/Functional/StreamIOTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional;
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+class StreamIOTest extends \PHPUnit_Framework_TestCase
+{
+    public function testErrorHandlerIsRestoredOnFailedConnection()
+    {
+        // Ignore the notice for this test.
+        error_reporting(~E_NOTICE);
+
+        $exceptionThrown = false;
+        try {
+            new AMQPStreamConnection('google.com', PORT, USER, PASS, VHOST);
+        } catch (\ErrorException $e) {
+            $exceptionThrown = true;
+        }
+        $this->assertTrue($exceptionThrown, 'Custom error handler was not set.');
+
+        $exceptionThrown = false;
+        $arr = array();
+
+        try {
+            $notice = $arr['second-key-that-does-not-exist-and-should-generate-a-notice'];
+        } catch (\Exception $e) {
+            $exceptionThrown = true;
+        }
+        $this->assertFalse($exceptionThrown, 'Default error handler was not restored.');
+
+        // Set error reporting level back
+        error_reporting(E_ALL);
+    }
+}


### PR DESCRIPTION
Should fix: https://github.com/php-amqplib/php-amqplib/issues/378