### PR TITLE
Error handler issue

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -129,7 +129,7 @@ class StreamIO extends AbstractIO
                 STREAM_CLIENT_CONNECT,
                 $this->context
             );
-        } catch (\Exception $e) {
+        } catch (\ErrorException $e) {
             restore_error_handler();
             throw $e;
         }
@@ -204,7 +204,12 @@ class StreamIO extends AbstractIO
             }
 
             set_error_handler(array($this, 'error_handler'));
-            $buffer = fread($this->sock, ($len - $read));
+            try {
+                $buffer = fread($this->sock, ($len - $read));
+            } catch (\ErrorException $e) {
+                restore_error_handler();
+                throw $e;
+            }
             restore_error_handler();
 
             if ($buffer === false) {
@@ -268,7 +273,12 @@ class StreamIO extends AbstractIO
             // This behavior has been observed in OpenSSL dating back to at least
             // September 2002:
             // http://comments.gmane.org/gmane.comp.encryption.openssl.user/4361
-            $buffer = fwrite($this->sock, $data, 8192);
+            try {
+                $buffer = fwrite($this->sock, $data, 8192);
+            } catch (\ErrorException $e) {
+                restore_error_handler();
+                throw $e;
+            }
             restore_error_handler();
 
             if ($buffer === false) {
@@ -397,7 +407,12 @@ class StreamIO extends AbstractIO
         $result = false;
 
         set_error_handler(array($this, 'error_handler'));
-        $result = stream_select($read, $write, $except, $sec, $usec);
+        try {
+            $result = stream_select($read, $write, $except, $sec, $usec);
+        } catch (\ErrorException $e) {
+            restore_error_handler();
+            throw $e;
+        }
         restore_error_handler();
 
         return $result;

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -320,8 +320,6 @@ class StreamIO extends AbstractIO
             return null;
         }
 
-        restore_error_handler();
-
         // raise all other issues to exceptions
         throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
     }


### PR DESCRIPTION
This is a follow-up of #378 and #379. The commit messages should be enough to explain the bugfix.
The only problem is that I don't really know how to test the other three places where the error handler is used: I have no idea how to mock php core functions, and I can't think of a way to reproduce the potential errors. Any suggestion is welcome.