### PR TITLE
Fix for inexplicable segfault

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -624,7 +624,7 @@ class AbstractConnection extends AbstractChannel
             $this->io->disableHeartbeat();
         }
 
-        if (!$this->protocolWriter || !$this->isConnected()) {
+        if (!is_object($this->protocolWriter) || !$this->isConnected()) {
             return null;
         }
 


### PR DESCRIPTION
Hi.
During update to symfony-3.0 I've faced with segfaults inside `php-amqplib` while running `behat` tests.

I'm using php 5.6.19.

Segfault stack trace tail (for 2.6 version of this package) can be found here: https://gist.github.com/avant1/8949be1557674af22f5e217b4a92d3cc

Also I've tried to use `dev-master` version of this package, but segfault is still there.

I've spent some time to localize the problem, and it turned out that direct access to `AbstractConnection::protocolWriter` (like `if (!$this->protocolWriter)`) somehow breaks following code. Maybe there is a bug in PHP.

When I remove this condition part, or replace it with `is_object()` check everything seem to work fine.

I understand, that this fix doesn't change a lot, but this change should not break something too.

I cannot create minimal repeatable example of segfault, so I cannot write failing test for it. That's why this PR does not contain any tests.

Issue php-amqplib/RabbitMqBundle#350 by @jajapaja may be fixed by this PR.
