### PR TITLE
Re-enable heartbeats after reconnection

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -215,6 +215,11 @@ class AbstractConnection extends AbstractChannel
 
                 $host = $this->x_open($this->vhost, '', $this->insist);
                 if (!$host) {
+                    //Reconnected
+                    if ($this->io instanceof StreamIO)
+                    {
+                        $this->getIO()->reenableHeartbeat();
+                    }
                     return null; // we weren't redirected
                 }
 

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -42,6 +42,9 @@ class StreamIO extends AbstractIO
     /** @var array */
     protected $last_error;
 
+    /** @var int */
+    private $initial_heartbeat;
+
     /** @var resource */
     private $sock;
 
@@ -81,6 +84,7 @@ class StreamIO extends AbstractIO
         $this->context = $context;
         $this->keepalive = $keepalive;
         $this->heartbeat = $heartbeat;
+        $this->initial_heartbeat = $heartbeat;
         $this->canSelectNull = true;
         $this->canDispatchPcntlSignal = $this->isPcntlSignalEnabled();
 
@@ -456,6 +460,16 @@ class StreamIO extends AbstractIO
     public function disableHeartbeat()
     {
         $this->heartbeat = 0;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function reenableHeartbeat()
+    {
+        $this->heartbeat = $this->initial_heartbeat;
 
         return $this;
     }


### PR DESCRIPTION
I found that if a consumer with client heartbeats enabled loses and re-establishes the connection it will not send client heartbeats, causing the server to eventually force a disconnect (I am using AMQPStreamConnection / StreamIO).

This is because StreamIO::disableHeartbeat is called on close(), setting StreamIO::heartbeat to 0, disabling the sending of client heartbeats.

However the matching value AMQPStreamConnection::heartbeat is not altered, so the connection.tune / connection.tune_ok messages still define a client heartbeat, so the server is expecting one.

This PR adds a StreamIO::reenableHeartbeat method which is called after successful reconnection and sets the StreamIO::heartbeat value back to what it was set to in the constructor.
