### PR TITLE
catch Throwable

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -108,6 +108,9 @@ class AMQPChannel extends AbstractChannel
         } catch (\Exception $e) {
             $this->close();
             throw $e;
+        } catch (\Throwable $e) {
+            $this->close();
+            throw $e;
         }
     }
 

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -230,6 +230,11 @@ class AbstractConnection extends AbstractChannel
             $this->setIsConnected(false);
             $this->closeChannels();
             throw $e; // Rethrow exception
+        } catch (\Throwable $e) {
+            // Something went wrong, set the connection status
+            $this->setIsConnected(false);
+            $this->closeChannels();
+            throw $e; // Rethrow exception
         }
     }
 
@@ -272,6 +277,8 @@ class AbstractConnection extends AbstractChannel
                 $this->close();
             }
         } catch (\Exception $e) {
+            // Nothing here
+        } catch (\Throwable $e) {
             // Nothing here
         }
     }
@@ -930,6 +937,8 @@ class AbstractConnection extends AbstractChannel
             try {
                 $channel->close();
             } catch (\Exception $e) {
+                /* Ignore closing errors */
+            } catch (\Throwable $e) {
                 /* Ignore closing errors */
             }
         }


### PR DESCRIPTION
Half of those cases could be solved with `finally`, but since this lib supports 5.3 it has to be done like this.

Also, if at some places it doesn't make sense to catch `Throwable`, let me know, I'll change it. Makes sense to me to add it to all the places in this PR.
