### PR TITLE
bring heartbeat support to socket connection

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -6,19 +6,19 @@ use PhpAmqpLib\Wire\IO\SocketIO;
 class AMQPSocketConnection extends AbstractConnection
 {
     /**
-     * @param string    $host
-     * @param int       $port
-     * @param string    $user
-     * @param string    $password
-     * @param string    $vhost
-     * @param bool      $insist
-     * @param string    $login_method
-     * @param null      $login_response
-     * @param string    $locale
-     * @param float|int $timeout
-     * @param bool      $keepalive
-     * @param int       $read_write_timeout
-     * @param int       $heartbeat
+     * @param string $host
+     * @param int $port
+     * @param string $user
+     * @param string $password
+     * @param string $vhost
+     * @param bool $insist
+     * @param string $login_method
+     * @param null $login_response
+     * @param string $locale
+     * @param float $read_timeout
+     * @param bool $keepalive
+     * @param int $write_timeout
+     * @param int $heartbeat
      */
     public function __construct(
         $host,
@@ -30,12 +30,12 @@ class AMQPSocketConnection extends AbstractConnection
         $login_method = 'AMQPLAIN',
         $login_response = null,
         $locale = 'en_US',
-        $timeout = 3,
+        $read_timeout = 3,
         $keepalive = false,
-        $read_write_timeout = 3,
+        $write_timeout = 3,
         $heartbeat = 0
     ) {
-        $io = new SocketIO($host, $port, $read_write_timeout, $keepalive, $timeout, $heartbeat);
+        $io = new SocketIO($host, $port, $read_timeout, $keepalive, $write_timeout, $heartbeat);
 
         parent::__construct(
             $user,

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -16,8 +16,8 @@ class AMQPSocketConnection extends AbstractConnection
      * @param null      $login_response
      * @param string    $locale
      * @param float|int $timeout
-     * @param int       $read_write_timeout
      * @param bool      $keepalive
+     * @param int       $read_write_timeout
      * @param int       $heartbeat
      */
     public function __construct(
@@ -31,11 +31,11 @@ class AMQPSocketConnection extends AbstractConnection
         $login_response = null,
         $locale = 'en_US',
         $timeout = 3,
-        $read_write_timeout = 3,
         $keepalive = false,
+        $read_write_timeout = 3,
         $heartbeat = 0
     ) {
-        $io = new SocketIO($host, $port, $timeout, $read_write_timeout, $heartbeat, $keepalive);
+        $io = new SocketIO($host, $port, $timeout, $keepalive, $read_write_timeout, $heartbeat);
 
         parent::__construct(
             $user,

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -35,7 +35,7 @@ class AMQPSocketConnection extends AbstractConnection
         $read_write_timeout = 3,
         $heartbeat = 0
     ) {
-        $io = new SocketIO($host, $port, $timeout, $keepalive, $read_write_timeout, $heartbeat);
+        $io = new SocketIO($host, $port, $read_write_timeout, $keepalive, $timeout, $heartbeat);
 
         parent::__construct(
             $user,

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -6,17 +6,19 @@ use PhpAmqpLib\Wire\IO\SocketIO;
 class AMQPSocketConnection extends AbstractConnection
 {
     /**
-     * @param string $host
-     * @param int $port
-     * @param string $user
-     * @param string $password
-     * @param string $vhost
-     * @param bool $insist
-     * @param string $login_method
-     * @param null $login_response
-     * @param string $locale
-     * @param float $timeout
-     * @param bool $keepalive
+     * @param string    $host
+     * @param int       $port
+     * @param string    $user
+     * @param string    $password
+     * @param string    $vhost
+     * @param bool      $insist
+     * @param string    $login_method
+     * @param null      $login_response
+     * @param string    $locale
+     * @param float|int $timeout
+     * @param int       $read_write_timeout
+     * @param bool      $keepalive
+     * @param int       $heartbeat
      */
     public function __construct(
         $host,
@@ -29,9 +31,11 @@ class AMQPSocketConnection extends AbstractConnection
         $login_response = null,
         $locale = 'en_US',
         $timeout = 3,
-        $keepalive = false
+        $read_write_timeout = 3,
+        $keepalive = false,
+        $heartbeat = 0
     ) {
-        $io = new SocketIO($host, $port, $timeout, $keepalive);
+        $io = new SocketIO($host, $port, $timeout, $read_write_timeout, $heartbeat, $keepalive);
 
         parent::__construct(
             $user,
@@ -41,7 +45,8 @@ class AMQPSocketConnection extends AbstractConnection
             $login_method,
             $login_response,
             $locale,
-            $io
+            $io,
+            $heartbeat
         );
     }
 }

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -38,12 +38,12 @@ class SocketIO extends AbstractIO
     /**
      * @param string     $host
      * @param int        $port
-     * @param float      $send_timeout
-     * @param bool       $keepalive
      * @param float|null $read_timeout if null - defaults to $send_timeout
+     * @param bool       $keepalive
+     * @param float      $send_timeout
      * @param int        $heartbeat
      */
-    public function __construct($host, $port, $send_timeout, $keepalive = false, $read_timeout = null, $heartbeat)
+    public function __construct($host, $port, $read_timeout = null, $keepalive = false, $send_timeout, $heartbeat)
     {
         $this->host = $host;
         $this->port = $port;

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -39,11 +39,11 @@ class SocketIO extends AbstractIO
      * @param string     $host
      * @param int        $port
      * @param float      $send_timeout
+     * @param bool       $keepalive
      * @param float|null $read_timeout if null - defaults to $send_timeout
      * @param int        $heartbeat
-     * @param bool       $keepalive
      */
-    public function __construct($host, $port, $send_timeout, $read_timeout = null, $heartbeat, $keepalive = false)
+    public function __construct($host, $port, $send_timeout, $keepalive = false, $read_timeout = null, $heartbeat)
     {
         $this->host = $host;
         $this->port = $port;

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -36,19 +36,19 @@ class SocketIO extends AbstractIO
     private $keepalive;
 
     /**
-     * @param string     $host
-     * @param int        $port
-     * @param float|null $read_timeout if null - defaults to $send_timeout
-     * @param bool       $keepalive
-     * @param float      $send_timeout
-     * @param int        $heartbeat
+     * @param string $host
+     * @param int $port
+     * @param float $read_timeout
+     * @param bool $keepalive
+     * @param float|null $write_timeout if null defaults to read timeout
+     * @param int $heartbeat
      */
-    public function __construct($host, $port, $read_timeout = null, $keepalive = false, $send_timeout, $heartbeat)
+    public function __construct($host, $port, $read_timeout, $keepalive = false, $write_timeout = null, $heartbeat)
     {
         $this->host = $host;
         $this->port = $port;
-        $this->send_timeout = $send_timeout;
-        $this->read_timeout = $read_timeout ?: $send_timeout;
+        $this->read_timeout = $read_timeout;
+        $this->send_timeout = $write_timeout ?: $read_timeout;
         $this->heartbeat = $heartbeat;
         $this->keepalive = $keepalive;
     }

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -189,6 +189,8 @@ class SocketIO extends AbstractIO
             socket_close($this->sock);
         }
         $this->sock = null;
+        $this->last_read = null;
+        $this->last_write = null;
     }
 
     /**

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -41,9 +41,9 @@ class SocketIO extends AbstractIO
      * @param float $read_timeout
      * @param bool $keepalive
      * @param float|null $write_timeout if null defaults to read timeout
-     * @param int $heartbeat
+     * @param int $heartbeat how often to send heartbeat. 0 means off
      */
-    public function __construct($host, $port, $read_timeout, $keepalive = false, $write_timeout = null, $heartbeat)
+    public function __construct($host, $port, $read_timeout, $keepalive = false, $write_timeout = null, $heartbeat = 0)
     {
         $this->host = $host;
         $this->port = $port;


### PR DESCRIPTION
As an answer for #272 where `AMQPSocketConnection` was an issue.

Actual heartbeat code is taken from `StreamIO` with adaptation to sockets.
Also includes splitting of receive timeout and send timeout as it's done in `StreamIO`, though there it's `$connect_timeout` and `$read_write_timeout` which is hard to be accomplished for sockets

As soon as this PR is merged I need to update bundle as it passes options incorrectly (or better mimic same constructor everywhere? or better have a builder to fade out all discrepancies between different connection types).
