### PR TITLE
Bugfix for HHVM compatability

### DIFF
--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -59,7 +59,7 @@ class AMQPReader extends AbstractClient
     {
         parent::__construct();
 
-        $this->str = $str;
+        $this->str = is_string($str) ? $str : '';
         $this->str_length = mb_strlen($this->str, 'ASCII');
         $this->io = $io;
         $this->offset = 0;


### PR DESCRIPTION
mb_strlen will error if passed null on HHVM, this is a workaround for that.