### PR TITLE
Ensure integer values are actually integers for HHVM compatibility

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -405,6 +405,8 @@ class StreamIO extends AbstractIO
         $write = null;
         $except = null;
         $result = false;
+        $sec = is_int($sec) ? $sec : 0;
+        $usec = is_int($usec) ? $usec : 0;
 
         set_error_handler(array($this, 'error_handler'));
         try {


### PR DESCRIPTION
HHVM will error if `sec` or `usec` are null, and they are specifically passed as null here: https://github.com/php-amqplib/php-amqplib/blob/master/PhpAmqpLib/Wire/IO/StreamIO.php#L227