### PR TITLE
Fix signal handling exit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ $pcntlHandler = function ($signal) {
         case \SIGUSR1:
         case \SIGINT:
             // some stuff before stop consumer e.g. delete lock etc
-            exit(0);
-            break;
+            pcntl_signal($signal, SIG_DFL); // restore handler
+            posix_kill(posix_getpid(), $signal); // kill self with signal, see https://www.cons.org/cracauer/sigint.html
         case \SIGHUP:
             // some stuff to restart consumer
             break;


### PR DESCRIPTION
Processes that terminate in response to a signal must not exit manually, but instead terminate themselves using the received signal number, so that calling programs can reliably determine the cause of the termination. This is important for example in scripted bash loops to correctly terminate on Ctrl+C.