### PR TITLE
half-open connection detection with heartbeat while reapeating 

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -197,12 +197,12 @@ class StreamIO extends AbstractIO
      */
     public function read($len)
     {
+        $this->check_heartbeat();
+
         $read = 0;
         $data = '';
 
         while ($read < $len) {
-            $this->check_heartbeat();
-
             if (!is_resource($this->sock) || feof($this->sock)) {
                 throw new AMQPRuntimeException('Broken pipe or closed connection');
             }
@@ -401,6 +401,8 @@ class StreamIO extends AbstractIO
      */
     public function select($sec, $usec)
     {
+        $this->check_heartbeat();
+
         $read = array($this->sock);
         $write = null;
         $except = null;


### PR DESCRIPTION
When consuming and waiting for a message, if server becomes suddenly unreachable (network split, machine fail) only the StreamIO select is called (possibly with a timeout) in `AMQPReader::wait()` and exists with an exception: AMQPTimeoutException that can be handled successfully and StreamIO read is never called to be able to trigger heartbeat logic.
We use this pattern with calling `AMQPChannel::wait()` with 1 second timeout while consuming in order to do some other checks and want to rely on heartbeat in this case also.
We use it in a worker and need to detect as soon as possible when the connection drops but messages might get into the queue with one hour interval.

Was thinking about adding it to the StreamIO write method also.

From what I can see, the heartbeat logic is fast and I'm not concerned about performance.