### PR TITLE
declare(ticks=1) no longer needed after PHP5.3 / amqplib 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ the server (which still has a complete copy) to forward it to a Dead Letter Exch
 
 By default, no truncation will occur. To disable truncation on a Channel that has had it enabled, pass `0` (or `null`) to `AMQPChannel::setBodySizeLimit()`.
 
-##UNIX Signals##
+## UNIX Signals ##
 
 If you have installed [PCNTL extension](http://www.php.net/manual/en/book.pcntl.php) dispatching of signal will be handled when consumer is not processing message.
 
@@ -193,12 +193,10 @@ $pcntlHandler = function ($signal) {
     }
 };
 
-declare(ticks = 1) {
-    pcntl_signal(\SIGTERM, $pcntlHandler);
-    pcntl_signal(\SIGINT,  $pcntlHandler);
-    pcntl_signal(\SIGUSR1, $pcntlHandler);
-    pcntl_signal(\SIGHUP,  $pcntlHandler);
-}
+pcntl_signal(\SIGTERM, $pcntlHandler);
+pcntl_signal(\SIGINT,  $pcntlHandler);
+pcntl_signal(\SIGUSR1, $pcntlHandler);
+pcntl_signal(\SIGHUP,  $pcntlHandler);
 ```
 
 To disable this feature just define constant `AMQP_WITHOUT_SIGNALS` as `true`


### PR DESCRIPTION
Hi,

`declare(ticks=1)` is no longer needed to support unix signal handling after PHP 5.3 and [version 90b8cb77fd0fadd313fe60e72d3451e67b29b6fb](https://github.com/php-amqplib/php-amqplib/commit/90b8cb77fd0fadd313fe60e72d3451e67b29b6fb) of this project when [`pcntl_signal_dispatch`](http://php.net/manual/en/function.pcntl-signal-dispatch.php) was introduced. I've updated the README to reflect this.

Please see the following documentation in the PHP manual and Stackoverflow thread for more details
* http://php.net/manual/en/function.pcntl-signal.php
* http://stackoverflow.com/questions/17906758/whats-the-relation-between-declareticks-and-a-signal-handler-in-php

It's also worth noting that `declare(ticks=1)` comes with some expensive CPU overhead, per this comment in the PHP Manual

> Remember that declaring a tick handler can become really expensive in terms of CPU cycles: Every n ticks the signal handling overhead will be executed.
> So instead of declaring tick=1, test if tick=100 can do the job. If so, you are likely to gain fivefold speed.

Definitely not something we should recommend to folks :)