### PR TITLE
Fix infinite loop on reconnect - check_heartbeat

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -247,6 +247,8 @@ class StreamIO extends AbstractIO
             fclose($this->sock);
         }
         $this->sock = null;
+        $this->last_read = null;
+        $this->last_write = null;
     }
 
     /**


### PR DESCRIPTION
The problem this PR fixes is:
* StreamConnection with heartbeat is created (e.g. heartbeat=10 seconds)
* Start consuming messages from the queue
* If one of the messages take more than 2*heartbeat interval to process (e.g. 30 seconds), the next time it tries to read something from Rabbit it will check_heartbeat()
* As it finds that it passed more than 2*heartbeat, it will reconnect()
* But as it does not reset the values of ``last_read`` and ``last_write``, after reconnect it will do the check_heartbeat() again and as it is based on ``last_read``, it will try to reconnect again
* It keeps trying to reconnect in infinite loop

This PR fixes issues: https://github.com/php-amqplib/php-amqplib/issues/413 and https://github.com/php-amqplib/php-amqplib/issues/309