### PR TITLE
Add support for serializing DateTimeImmutable objects

### DIFF
--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -207,7 +207,10 @@ abstract class AMQPAbstractCollection implements \Iterator
             $val = $this->encodeBool($val);
         } elseif (is_null($val)) {
             $val = $this->encodeVoid();
+        } elseif ($val instanceof \DateTimeInterface) {
+            $val = array(self::T_TIMESTAMP, $val->getTimestamp());
         } elseif ($val instanceof \DateTime) {
+            // PHP <= 5.4 has no DateTimeInterface
             $val = array(self::T_TIMESTAMP, $val->getTimestamp());
         } elseif ($val instanceof AMQPDecimal) {
             $val = array(self::T_DECIMAL, $val);

--- a/tests/Unit/Wire/AMQPCollectionTest.php
+++ b/tests/Unit/Wire/AMQPCollectionTest.php
@@ -19,7 +19,14 @@ class AMQPCollectionTest extends \PHPUnit_Framework_TestCase
             false,
             array('foo' => 'bar'),
             array('foo'),
-            array()
+            array(),
+            new \DateTime('2009-02-13 23:31:30'),
+            (
+                // DateTimeImmutable was added in PHP 5.5
+                class_exists('DateTimeImmutable')
+                ? new \DateTimeImmutable('2009-02-13 23:31:30')
+                : new \DateTime('2009-02-13 23:31:30')
+            )
         ));
 
         $this->assertEquals(
@@ -39,7 +46,9 @@ class AMQPCollectionTest extends \PHPUnit_Framework_TestCase
                     Wire\AMQPAbstractCollection::getDataTypeForSymbol('F'),
                     array(0 => array(Wire\AMQPAbstractCollection::getDataTypeForSymbol('S'), 'foo'))
                 ),
-                array(Wire\AMQPAbstractCollection::getDataTypeForSymbol('F'), array())
+                array(Wire\AMQPAbstractCollection::getDataTypeForSymbol('F'), array()),
+                array(Wire\AMQPAbstractCollection::getDataTypeForSymbol('T'), 1234567890),
+                array(Wire\AMQPAbstractCollection::getDataTypeForSymbol('T'), 1234567890),
             ),
             $this->getEncodedRawData($a)
         );


### PR DESCRIPTION
Rather than checking for \DateTime objects directly, check for the
\DateTimeInterface added in PHP 5.5. Since older versions are still
supported, a redundant check for \DateTime is left in place.

Reading a timestamp still always returns a DateTime object.