### PR TITLE
Add php-enqueue/amqp-lib (queue-interop/amqp-interop) shim interface

### DIFF
--- a/PhpAmqpLib/Interop/AmqpConnectionFactory.php
+++ b/PhpAmqpLib/Interop/AmqpConnectionFactory.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace PhpAmqpLib\Interop;
+
+use Interop\Amqp\AmqpConnectionFactory as InteropAmqpConnectionFactory;
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Connection\AMQPLazyConnection;
+use PhpAmqpLib\Connection\AMQPLazySocketConnection;
+use PhpAmqpLib\Connection\AMQPSocketConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+class AmqpConnectionFactory implements InteropAmqpConnectionFactory
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @var AbstractConnection
+     */
+    private $connection;
+
+    /**
+     * The config could be an array, string DSN or null. In case of null it will attempt to connect to localhost with default credentials.
+     *
+     * [
+     *     'host'  => 'amqp.host The host to connect too. Note: Max 1024 characters.',
+     *     'port'  => 'amqp.port Port on the host.',
+     *     'vhost' => 'amqp.vhost The virtual host on the host. Note: Max 128 characters.',
+     *     'user' => 'amqp.user The user name to use. Note: Max 128 characters.',
+     *     'pass' => 'amqp.password Password. Note: Max 128 characters.',
+     *     'lazy' => 'the connection will be performed as later as possible, if the option set to true',
+     *     'stream' => 'stream or socket connection',
+     *     'receive_method' => 'Could be either basic_get or basic_consume',
+     * ]
+     *
+     * or
+     *
+     * amqp://user:pass@host:10000/vhost?lazy=true&socket=true
+     *
+     * @param array|string $config
+     */
+    public function __construct($config = 'amqp://')
+    {
+        if (empty($config) || 'amqp://' === $config) {
+            $config = [];
+        } elseif (is_string($config)) {
+            $config = $this->parseDsn($config);
+        } elseif (is_array($config)) {
+        } else {
+            throw new \LogicException('The config must be either an array of options, a DSN string or null');
+        }
+
+        $this->config = array_replace($this->defaultConfig(), $config);
+
+        $supportedMethods = ['basic_get', 'basic_consume'];
+        if (false == in_array($this->config['receive_method'], $supportedMethods, true)) {
+            throw new \LogicException(sprintf(
+                'Invalid "receive_method" option value "%s". It could be only "%s"',
+                $this->config['receive_method'],
+                implode('", "', $supportedMethods)
+            ));
+        }
+    }
+
+    /**
+     * @return AmqpContext
+     */
+    public function createContext()
+    {
+        return new AmqpContext($this->establishConnection(), $this->config['receive_method']);
+    }
+
+    /**
+     * @return AbstractConnection
+     */
+    private function establishConnection()
+    {
+        if (false == $this->connection) {
+            if ($this->config['stream']) {
+                if ($this->config['lazy']) {
+                    $con = new AMQPLazyConnection(
+                        $this->config['host'],
+                        $this->config['port'],
+                        $this->config['user'],
+                        $this->config['pass'],
+                        $this->config['vhost'],
+                        $this->config['insist'],
+                        $this->config['login_method'],
+                        $this->config['login_response'],
+                        $this->config['locale'],
+                        $this->config['connection_timeout'],
+                        $this->config['read_write_timeout'],
+                        null,
+                        $this->config['keepalive'],
+                        $this->config['heartbeat']
+                    );
+                } else {
+                    $con = new AMQPStreamConnection(
+                        $this->config['host'],
+                        $this->config['port'],
+                        $this->config['user'],
+                        $this->config['pass'],
+                        $this->config['vhost'],
+                        $this->config['insist'],
+                        $this->config['login_method'],
+                        $this->config['login_response'],
+                        $this->config['locale'],
+                        $this->config['connection_timeout'],
+                        $this->config['read_write_timeout'],
+                        null,
+                        $this->config['keepalive'],
+                        $this->config['heartbeat']
+                    );
+                }
+            } else {
+                if ($this->config['lazy']) {
+                    $con = new AMQPLazySocketConnection(
+                        $this->config['host'],
+                        $this->config['port'],
+                        $this->config['user'],
+                        $this->config['pass'],
+                        $this->config['vhost'],
+                        $this->config['insist'],
+                        $this->config['login_method'],
+                        $this->config['login_response'],
+                        $this->config['locale'],
+                        $this->config['read_timeout'],
+                        $this->config['keepalive'],
+                        $this->config['write_timeout'],
+                        $this->config['heartbeat']
+                    );
+                } else {
+                    $con = new AMQPSocketConnection(
+                        $this->config['host'],
+                        $this->config['port'],
+                        $this->config['user'],
+                        $this->config['pass'],
+                        $this->config['vhost'],
+                        $this->config['insist'],
+                        $this->config['login_method'],
+                        $this->config['login_response'],
+                        $this->config['locale'],
+                        $this->config['read_timeout'],
+                        $this->config['keepalive'],
+                        $this->config['write_timeout'],
+                        $this->config['heartbeat']
+                    );
+                }
+            }
+
+            $this->connection = $con;
+        }
+
+        return $this->connection;
+    }
+
+    /**
+     * @param string $dsn
+     *
+     * @return array
+     */
+    private function parseDsn($dsn)
+    {
+        $dsnConfig = parse_url($dsn);
+        if (false === $dsnConfig) {
+            throw new \LogicException(sprintf('Failed to parse DSN "%s"', $dsn));
+        }
+
+        $dsnConfig = array_replace([
+            'scheme' => null,
+            'host' => null,
+            'port' => null,
+            'user' => null,
+            'pass' => null,
+            'path' => null,
+            'query' => null,
+        ], $dsnConfig);
+
+        if ('amqp' !== $dsnConfig['scheme']) {
+            throw new \LogicException(sprintf('The given DSN scheme "%s" is not supported. Could be "amqp" only.', $dsnConfig['scheme']));
+        }
+
+        if ($dsnConfig['query']) {
+            $query = [];
+            parse_str($dsnConfig['query'], $query);
+
+            $dsnConfig = array_replace($query, $dsnConfig);
+        }
+
+        $dsnConfig['vhost'] = ltrim($dsnConfig['path'], '/');
+
+        unset($dsnConfig['scheme'], $dsnConfig['query'], $dsnConfig['fragment'], $dsnConfig['path']);
+
+        $dsnConfig = array_map(function ($value) {
+            return urldecode($value);
+        }, $dsnConfig);
+
+        return $dsnConfig;
+    }
+
+    /**
+     * @return array
+     */
+    private function defaultConfig()
+    {
+        return [
+            'stream' => true,
+            'lazy' => true,
+            'host' => 'localhost',
+            'port' => 5672,
+            'user' => 'guest',
+            'pass' => 'guest',
+            'vhost' => '/',
+            'insist' => false,
+            'login_method' => 'AMQPLAIN',
+            'login_response' => null,
+            'locale' => 'en_US',
+            'read_timeout' => 3,
+            'keepalive' => false,
+            'write_timeout' => 3,
+            'heartbeat' => 0,
+            'connection_timeout' => 3.0,
+            'read_write_timeout' => 3.0,
+            'receive_method' => 'basic_get',
+        ];
+    }
+}

--- a/PhpAmqpLib/Interop/AmqpConnectionFactory.php
+++ b/PhpAmqpLib/Interop/AmqpConnectionFactory.php
@@ -9,7 +9,7 @@ use PhpAmqpLib\Connection\AMQPLazySocketConnection;
 use PhpAmqpLib\Connection\AMQPSocketConnection;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 
-class AmqpConnectionFactory implements InteropAmqpConnectionFactory
+final class AmqpConnectionFactory implements InteropAmqpConnectionFactory
 {
     /**
      * @var array

--- a/PhpAmqpLib/Interop/AmqpConsumer.php
+++ b/PhpAmqpLib/Interop/AmqpConsumer.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace PhpAmqpLib\Interop;
+
+use Interop\Amqp\AmqpConsumer as InteropAmqpConsumer;
+use Interop\Amqp\AmqpMessage as InteropAmqpMessage;
+use Interop\Amqp\AmqpQueue as InteropAmqpQueue;
+use Interop\Amqp\Impl\AmqpMessage;
+use Interop\Queue\Exception;
+use Interop\Queue\InvalidMessageException;
+use Interop\Queue\PsrMessage;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Exception\AMQPTimeoutException;
+use PhpAmqpLib\Message\AMQPMessage as LibAMQPMessage;
+use PhpAmqpLib\Wire\AMQPTable;
+
+class AmqpConsumer implements InteropAmqpConsumer
+{
+    /**
+     * @var AMQPChannel
+     */
+    private $channel;
+
+    /**
+     * @var InteropAmqpQueue
+     */
+    private $queue;
+
+    /**
+     * @var Buffer
+     */
+    private $buffer;
+
+    /**
+     * @var bool
+     */
+    private $isInit;
+
+    /**
+     * @var string
+     */
+    private $receiveMethod;
+
+    /**
+     * @var int
+     */
+    private $flags;
+
+    /**
+     * @var string
+     */
+    private $consumerTag;
+
+    /**
+     * @param AMQPChannel      $channel
+     * @param InteropAmqpQueue $queue
+     * @param Buffer           $buffer
+     * @param string           $receiveMethod
+     */
+    public function __construct(AMQPChannel $channel, InteropAmqpQueue $queue, Buffer $buffer, $receiveMethod)
+    {
+        $this->channel = $channel;
+        $this->queue = $queue;
+        $this->buffer = $buffer;
+        $this->receiveMethod = $receiveMethod;
+        $this->flags = self::FLAG_NOPARAM;
+
+        $this->isInit = false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConsumerTag($consumerTag)
+    {
+        if ($this->isInit) {
+            throw new Exception('Consumer tag is not mutable after it has been subscribed to broker');
+        }
+
+        $this->consumerTag = $consumerTag;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConsumerTag()
+    {
+        return $this->consumerTag;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clearFlags()
+    {
+        $this->flags = self::FLAG_NOPARAM;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFlag($flag)
+    {
+        $this->flags |= $flag;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFlags()
+    {
+        return $this->flags;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFlags($flags)
+    {
+        $this->flags = $flags;
+    }
+
+    /**
+     * @return InteropAmqpQueue
+     */
+    public function getQueue()
+    {
+        return $this->queue;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return InteropAmqpMessage|null
+     */
+    public function receive($timeout = 0)
+    {
+        if ('basic_get' == $this->receiveMethod) {
+            return $this->receiveBasicGet($timeout);
+        }
+
+        if ('basic_consume' == $this->receiveMethod) {
+            return $this->receiveBasicConsume($timeout);
+        }
+
+        throw new \LogicException('The "receiveMethod" is not supported');
+    }
+
+    /**
+     * @return InteropAmqpMessage|null
+     */
+    public function receiveNoWait()
+    {
+        if ($message = $this->channel->basic_get($this->queue->getQueueName(), (bool) ($this->getFlags() & InteropAmqpConsumer::FLAG_NOACK))) {
+            return $this->convertMessage($message);
+        }
+    }
+
+    /**
+     * @param InteropAmqpMessage $message
+     */
+    public function acknowledge(PsrMessage $message)
+    {
+        InvalidMessageException::assertMessageInstanceOf($message, InteropAmqpMessage::class);
+
+        $this->channel->basic_ack($message->getDeliveryTag());
+    }
+
+    /**
+     * @param InteropAmqpMessage $message
+     * @param bool               $requeue
+     */
+    public function reject(PsrMessage $message, $requeue = false)
+    {
+        InvalidMessageException::assertMessageInstanceOf($message, InteropAmqpMessage::class);
+
+        $this->channel->basic_reject($message->getDeliveryTag(), $requeue);
+    }
+
+    /**
+     * @param LibAMQPMessage $amqpMessage
+     *
+     * @return InteropAmqpMessage
+     */
+    private function convertMessage(LibAMQPMessage $amqpMessage)
+    {
+        $headers = new AMQPTable($amqpMessage->get_properties());
+        $headers = $headers->getNativeData();
+
+        $properties = [];
+        if (isset($headers['application_headers'])) {
+            $properties = $headers['application_headers'];
+        }
+        unset($headers['application_headers']);
+
+        $message = new AmqpMessage($amqpMessage->getBody(), $properties, $headers);
+        $message->setDeliveryTag($amqpMessage->delivery_info['delivery_tag']);
+        $message->setRedelivered($amqpMessage->delivery_info['redelivered']);
+
+        return $message;
+    }
+
+    /**
+     * @param int $timeout
+     *
+     * @return InteropAmqpMessage|null
+     */
+    private function receiveBasicGet($timeout)
+    {
+        $end = microtime(true) + ($timeout / 1000);
+
+        while (0 === $timeout || microtime(true) < $end) {
+            if ($message = $this->receiveNoWait()) {
+                return $message;
+            }
+
+            usleep(100000); //100ms
+        }
+    }
+
+    /**
+     * @param int $timeout
+     *
+     * @return InteropAmqpMessage|null
+     */
+    private function receiveBasicConsume($timeout)
+    {
+        if (false === $this->isInit) {
+            $callback = function (LibAMQPMessage $message) {
+                $receivedMessage = $this->convertMessage($message);
+                $receivedMessage->setConsumerTag($message->delivery_info['consumer_tag']);
+
+                $this->buffer->push($receivedMessage->getConsumerTag(), $receivedMessage);
+            };
+
+            $consumerTag = $this->channel->basic_consume(
+                $this->queue->getQueueName(),
+                $this->getConsumerTag() ?: $this->getQueue()->getConsumerTag(),
+                (bool) ($this->getFlags() & InteropAmqpConsumer::FLAG_NOLOCAL),
+                (bool) ($this->getFlags() & InteropAmqpConsumer::FLAG_NOACK),
+                (bool) ($this->getFlags() & InteropAmqpConsumer::FLAG_EXCLUSIVE),
+                (bool) ($this->getFlags() & InteropAmqpConsumer::FLAG_NOWAIT),
+                $callback
+            );
+
+            $this->consumerTag = $consumerTag ?: $this->getQueue()->getConsumerTag();
+
+            if (empty($this->consumerTag)) {
+                throw new Exception('Got empty consumer tag');
+            }
+
+            $this->isInit = true;
+        }
+
+        if ($message = $this->buffer->pop($this->consumerTag)) {
+            return $message;
+        }
+
+        try {
+            while (true) {
+                $start = microtime(true);
+
+                $this->channel->wait(null, false, $timeout / 1000);
+
+                if ($message = $this->buffer->pop($this->consumerTag)) {
+                    return $message;
+                }
+
+                // is here when consumed message is not for this consumer
+
+                // as timeout is infinite have to continue consumption, but it can overflow message buffer
+                if ($timeout <= 0) {
+                    continue;
+                }
+
+                // compute remaining timeout and continue until time is up
+                $stop = microtime(true);
+                $timeout -= ($stop - $start) * 1000;
+
+                if ($timeout <= 0) {
+                    break;
+                }
+            }
+        } catch (AMQPTimeoutException $e) {
+        }
+    }
+}

--- a/PhpAmqpLib/Interop/AmqpConsumer.php
+++ b/PhpAmqpLib/Interop/AmqpConsumer.php
@@ -14,7 +14,7 @@ use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage as LibAMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 
-class AmqpConsumer implements InteropAmqpConsumer
+final class AmqpConsumer implements InteropAmqpConsumer
 {
     /**
      * @var AMQPChannel

--- a/PhpAmqpLib/Interop/AmqpContext.php
+++ b/PhpAmqpLib/Interop/AmqpContext.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace PhpAmqpLib\Interop;
+
+use Interop\Amqp\AmqpBind as InteropAmqpBind;
+use Interop\Amqp\AmqpContext as InteropAmqpContext;
+use Interop\Amqp\AmqpMessage as InteropAmqpMessage;
+use Interop\Amqp\AmqpQueue as InteropAmqpQueue;
+use Interop\Amqp\AmqpTopic as InteropAmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use Interop\Amqp\Impl\AmqpMessage;
+use Interop\Amqp\Impl\AmqpQueue;
+use Interop\Amqp\Impl\AmqpTopic;
+use Interop\Queue\Exception;
+use Interop\Queue\InvalidDestinationException;
+use Interop\Queue\PsrDestination;
+use Interop\Queue\PsrTopic;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AbstractConnection;
+
+class AmqpContext implements InteropAmqpContext
+{
+    /**
+     * @var AbstractConnection
+     */
+    private $connection;
+
+    /**
+     * @var AMQPChannel
+     */
+    private $channel;
+
+    /**
+     * @var string
+     */
+    private $receiveMethod;
+
+    /**
+     * @var Buffer
+     */
+    private $buffer;
+
+    /**
+     * @param AbstractConnection $connection
+     * @param string             $receiveMethod
+     */
+    public function __construct(AbstractConnection $connection, $receiveMethod)
+    {
+        $this->connection = $connection;
+        $this->receiveMethod = $receiveMethod;
+        $this->buffer = new Buffer();
+    }
+
+    /**
+     * @param string|null $body
+     * @param array       $properties
+     * @param array       $headers
+     *
+     * @return InteropAmqpMessage
+     */
+    public function createMessage($body = '', array $properties = [], array $headers = [])
+    {
+        return new AmqpMessage($body, $properties, $headers);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return InteropAmqpQueue
+     */
+    public function createQueue($name)
+    {
+        return new AmqpQueue($name);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return InteropAmqpTopic
+     */
+    public function createTopic($name)
+    {
+        return new AmqpTopic($name);
+    }
+
+    /**
+     * @param PsrDestination $destination
+     *
+     * @return AmqpConsumer
+     */
+    public function createConsumer(PsrDestination $destination)
+    {
+        $destination instanceof PsrTopic
+            ? InvalidDestinationException::assertDestinationInstanceOf($destination, InteropAmqpTopic::class)
+            : InvalidDestinationException::assertDestinationInstanceOf($destination, InteropAmqpQueue::class)
+        ;
+
+        if ($destination instanceof AmqpTopic) {
+            $queue = $this->createTemporaryQueue();
+            $this->bind(new AmqpBind($destination, $queue, $queue->getQueueName()));
+
+            return new AmqpConsumer($this->getChannel(), $queue, $this->buffer, $this->receiveMethod);
+        }
+
+        return new AmqpConsumer($this->getChannel(), $destination, $this->buffer, $this->receiveMethod);
+    }
+
+    /**
+     * @return AmqpProducer
+     */
+    public function createProducer()
+    {
+        return new AmqpProducer($this->getChannel());
+    }
+
+    /**
+     * @return InteropAmqpQueue
+     */
+    public function createTemporaryQueue()
+    {
+        $queue = $this->createQueue(null);
+        $queue->addFlag(InteropAmqpQueue::FLAG_EXCLUSIVE);
+
+        $this->declareQueue($queue);
+
+        return $queue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function declareTopic(InteropAmqpTopic $topic)
+    {
+        $this->getChannel()->exchange_declare(
+            $topic->getTopicName(),
+            $topic->getType(),
+            (bool) ($topic->getFlags() & InteropAmqpTopic::FLAG_PASSIVE),
+            (bool) ($topic->getFlags() & InteropAmqpTopic::FLAG_DURABLE),
+            (bool) ($topic->getFlags() & InteropAmqpTopic::FLAG_AUTODELETE),
+            (bool) ($topic->getFlags() & InteropAmqpTopic::FLAG_INTERNAL),
+            (bool) ($topic->getFlags() & InteropAmqpTopic::FLAG_NOWAIT),
+            $topic->getArguments()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteTopic(InteropAmqpTopic $topic)
+    {
+        $this->getChannel()->exchange_delete(
+            $topic->getTopicName(),
+            (bool) ($topic->getFlags() & InteropAmqpTopic::FLAG_IFUNUSED),
+            (bool) ($topic->getFlags() & InteropAmqpTopic::FLAG_NOWAIT)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function declareQueue(InteropAmqpQueue $queue)
+    {
+        return $this->getChannel()->queue_declare(
+            $queue->getQueueName(),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_PASSIVE),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_DURABLE),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_EXCLUSIVE),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_AUTODELETE),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_NOWAIT),
+            $queue->getArguments()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteQueue(InteropAmqpQueue $queue)
+    {
+        $this->getChannel()->queue_delete(
+            $queue->getQueueName(),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_IFUNUSED),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_IFEMPTY),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_NOWAIT)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purgeQueue(InteropAmqpQueue $queue)
+    {
+        $this->getChannel()->queue_purge(
+            $queue->getQueueName(),
+            (bool) ($queue->getFlags() & InteropAmqpQueue::FLAG_NOWAIT)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bind(InteropAmqpBind $bind)
+    {
+        if ($bind->getSource() instanceof InteropAmqpQueue && $bind->getTarget() instanceof InteropAmqpQueue) {
+            throw new Exception('Is not possible to bind queue to queue. It is possible to bind topic to queue or topic to topic');
+        }
+
+        // bind exchange to exchange
+        if ($bind->getSource() instanceof InteropAmqpTopic && $bind->getTarget() instanceof InteropAmqpTopic) {
+            $this->getChannel()->exchange_bind(
+                $bind->getTarget()->getTopicName(),
+                $bind->getSource()->getTopicName(),
+                $bind->getRoutingKey(),
+                (bool) ($bind->getFlags() & InteropAmqpBind::FLAG_NOWAIT),
+                $bind->getArguments()
+            );
+            // bind queue to exchange
+        } elseif ($bind->getSource() instanceof InteropAmqpQueue) {
+            $this->getChannel()->queue_bind(
+                $bind->getSource()->getQueueName(),
+                $bind->getTarget()->getTopicName(),
+                $bind->getRoutingKey(),
+                (bool) ($bind->getFlags() & InteropAmqpBind::FLAG_NOWAIT),
+                $bind->getArguments()
+            );
+            // bind exchange to queue
+        } else {
+            $this->getChannel()->queue_bind(
+                $bind->getTarget()->getQueueName(),
+                $bind->getSource()->getTopicName(),
+                $bind->getRoutingKey(),
+                (bool) ($bind->getFlags() & InteropAmqpBind::FLAG_NOWAIT),
+                $bind->getArguments()
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unbind(InteropAmqpBind $bind)
+    {
+        if ($bind->getSource() instanceof InteropAmqpQueue && $bind->getTarget() instanceof InteropAmqpQueue) {
+            throw new Exception('Is not possible to bind queue to queue. It is possible to bind topic to queue or topic to topic');
+        }
+
+        // bind exchange to exchange
+        if ($bind->getSource() instanceof InteropAmqpTopic && $bind->getTarget() instanceof InteropAmqpTopic) {
+            $this->getChannel()->exchange_unbind(
+                $bind->getTarget()->getTopicName(),
+                $bind->getSource()->getTopicName(),
+                $bind->getRoutingKey(),
+                (bool) ($bind->getFlags() & InteropAmqpBind::FLAG_NOWAIT),
+                $bind->getArguments()
+            );
+            // bind queue to exchange
+        } elseif ($bind->getSource() instanceof InteropAmqpQueue) {
+            $this->getChannel()->queue_unbind(
+                $bind->getSource()->getQueueName(),
+                $bind->getTarget()->getTopicName(),
+                $bind->getRoutingKey(),
+                $bind->getArguments()
+            );
+            // bind exchange to queue
+        } else {
+            $this->getChannel()->queue_unbind(
+                $bind->getTarget()->getQueueName(),
+                $bind->getSource()->getTopicName(),
+                $bind->getRoutingKey(),
+                $bind->getArguments()
+            );
+        }
+    }
+
+    public function close()
+    {
+        if ($this->channel) {
+            $this->channel->close();
+        }
+    }
+
+    /**
+     * @return AMQPChannel
+     */
+    private function getChannel()
+    {
+        if (null === $this->channel) {
+            $this->channel = $this->connection->channel();
+            $this->channel->basic_qos(0, 1, false);
+        }
+
+        return $this->channel;
+    }
+}

--- a/PhpAmqpLib/Interop/AmqpContext.php
+++ b/PhpAmqpLib/Interop/AmqpContext.php
@@ -18,7 +18,7 @@ use Interop\Queue\PsrTopic;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AbstractConnection;
 
-class AmqpContext implements InteropAmqpContext
+final class AmqpContext implements InteropAmqpContext
 {
     /**
      * @var AbstractConnection

--- a/PhpAmqpLib/Interop/AmqpProducer.php
+++ b/PhpAmqpLib/Interop/AmqpProducer.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PhpAmqpLib\Interop;
+
+use Interop\Amqp\AmqpMessage as InteropAmqpMessage;
+use Interop\Amqp\AmqpProducer as InteropAmqpProducer;
+use Interop\Amqp\AmqpQueue as InteropAmqpQueue;
+use Interop\Amqp\AmqpTopic as InteropAmqpTopic;
+use Interop\Queue\InvalidDestinationException;
+use Interop\Queue\InvalidMessageException;
+use Interop\Queue\PsrDestination;
+use Interop\Queue\PsrMessage;
+use Interop\Queue\PsrTopic;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Message\AMQPMessage as LibAMQPMessage;
+use PhpAmqpLib\Wire\AMQPTable;
+
+class AmqpProducer implements InteropAmqpProducer
+{
+    /**
+     * @var AMQPChannel
+     */
+    private $channel;
+
+    /**
+     * @param AMQPChannel $channel
+     */
+    public function __construct(AMQPChannel $channel)
+    {
+        $this->channel = $channel;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param InteropAmqpTopic|InteropAmqpQueue $destination
+     * @param InteropAmqpMessage                $message
+     */
+    public function send(PsrDestination $destination, PsrMessage $message)
+    {
+        $destination instanceof PsrTopic
+            ? InvalidDestinationException::assertDestinationInstanceOf($destination, InteropAmqpTopic::class)
+            : InvalidDestinationException::assertDestinationInstanceOf($destination, InteropAmqpQueue::class)
+        ;
+
+        InvalidMessageException::assertMessageInstanceOf($message, InteropAmqpMessage::class);
+
+        $amqpProperties = $message->getHeaders();
+
+        if ($appProperties = $message->getProperties()) {
+            $amqpProperties['application_headers'] = new AMQPTable($appProperties);
+        }
+
+        $amqpMessage = new LibAMQPMessage($message->getBody(), $amqpProperties);
+
+        if ($destination instanceof InteropAmqpTopic) {
+            $this->channel->basic_publish(
+                $amqpMessage,
+                $destination->getTopicName(),
+                $message->getRoutingKey(),
+                (bool) ($message->getFlags() & InteropAmqpMessage::FLAG_MANDATORY),
+                (bool) ($message->getFlags() & InteropAmqpMessage::FLAG_IMMEDIATE)
+            );
+        } else {
+            $this->channel->basic_publish(
+                $amqpMessage,
+                '',
+                $destination->getQueueName(),
+                (bool) ($message->getFlags() & InteropAmqpMessage::FLAG_MANDATORY),
+                (bool) ($message->getFlags() & InteropAmqpMessage::FLAG_IMMEDIATE)
+            );
+        }
+    }
+}

--- a/PhpAmqpLib/Interop/AmqpProducer.php
+++ b/PhpAmqpLib/Interop/AmqpProducer.php
@@ -15,7 +15,7 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage as LibAMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 
-class AmqpProducer implements InteropAmqpProducer
+final class AmqpProducer implements InteropAmqpProducer
 {
     /**
      * @var AMQPChannel

--- a/PhpAmqpLib/Interop/Buffer.php
+++ b/PhpAmqpLib/Interop/Buffer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PhpAmqpLib\Interop;
+
+use Interop\Amqp\AmqpMessage;
+
+class Buffer
+{
+    /**
+     * @var array ['aTag' => [AmqpMessage, AmqpMessage ...]]
+     */
+    private $messages;
+
+    public function __construct()
+    {
+        $this->messages = [];
+    }
+
+    /**
+     * @param string      $consumerTag
+     * @param AmqpMessage $message
+     */
+    public function push($consumerTag, AmqpMessage $message)
+    {
+        if (false == array_key_exists($consumerTag, $this->messages)) {
+            $this->messages[$consumerTag] = [];
+        }
+
+        $this->messages[$consumerTag][] = $message;
+    }
+
+    /**
+     * @param string $consumerTag
+     *
+     * @return AmqpMessage|null
+     */
+    public function pop($consumerTag)
+    {
+        if (false == empty($this->messages[$consumerTag])) {
+            return array_shift($this->messages[$consumerTag]);
+        }
+    }
+}

--- a/PhpAmqpLib/Interop/Buffer.php
+++ b/PhpAmqpLib/Interop/Buffer.php
@@ -4,7 +4,7 @@ namespace PhpAmqpLib\Interop;
 
 use Interop\Amqp\AmqpMessage;
 
-class Buffer
+final class Buffer
 {
     /**
      * @var array ['aTag' => [AmqpMessage, AmqpMessage ...]]

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "require": {
         "php": ">=5.3.0",
         "ext-bcmath": "*",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "queue-interop/amqp-interop": "^0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/demo/interop/amqp_consumer.php
+++ b/demo/interop/amqp_consumer.php
@@ -1,0 +1,45 @@
+<?php
+
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'router';
+$queueName = 'msgs';
+$consumerTag = 'consumer';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->addFlag(AmqpQueue::FLAG_DURABLE);
+$context->declareQueue($queue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_DIRECT);
+$topic->addFlag(AmqpTopic::FLAG_DURABLE);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+
+$consumer = $context->createConsumer($queue);
+$consumer->setConsumerTag($consumerTag);
+
+while (true) {
+    if (false == $message = $consumer->receive(1000)) {
+        continue;
+    }
+
+    echo "\n--------\n";
+    echo $message->getBody();
+    echo "\n--------\n";
+
+    $consumer->acknowledge($message);
+
+    // Send a message with the string "quit" to cancel the consumer.
+    if ($message->getBody() === 'quit') {
+        break;
+    }
+}

--- a/demo/interop/amqp_consumer_exclusive.php
+++ b/demo/interop/amqp_consumer_exclusive.php
@@ -1,0 +1,50 @@
+<?php
+
+// Only one consumer per queue is allowed.
+// Set $queue name to test exclusiveness
+
+use Interop\Amqp\AmqpConsumer;
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'fanout_exclusive_example_exchange';
+$consumerTag = 'consumer' . getmypid();
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createTemporaryQueue();
+$queue->addFlag(AmqpQueue::FLAG_DURABLE);
+$queue->addFlag(AmqpQueue::FLAG_EXCLUSIVE);
+$context->declareQueue($queue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_FANOUT);
+$topic->addFlag(AmqpTopic::FLAG_DURABLE);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+
+$consumer = $context->createConsumer($queue);
+$consumer->addFlag(AmqpConsumer::FLAG_EXCLUSIVE);
+$consumer->setConsumerTag($consumerTag);
+
+while (true) {
+    if (false == $message = $consumer->receive(1000)) {
+        continue;
+    }
+
+    echo "\n--------\n";
+    echo $message->getBody();
+    echo "\n--------\n";
+
+    $consumer->acknowledge($message);
+
+    // Send a message with the string "quit" to cancel the consumer.
+    if ($message->getBody() === 'quit') {
+        break;
+    }
+}

--- a/demo/interop/amqp_consumer_fanout_1.php
+++ b/demo/interop/amqp_consumer_fanout_1.php
@@ -1,0 +1,49 @@
+<?php
+
+// Run multiple instances of amqp_consumer_fanout_1.php and
+// amqp_consumer_fanout_2.php to test
+
+include(__DIR__ . '/config.php');
+
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+$exchangeName = 'fanout_example_exchange';
+$queueName = 'fanout_group_1';
+$consumerTag = 'consumer' . getmypid();
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->addFlag(AmqpQueue::FLAG_AUTODELETE);
+$context->declareQueue($queue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_FANOUT);
+$topic->addFlag(AmqpTopic::FLAG_AUTODELETE);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+
+$consumer = $context->createConsumer($queue);
+$consumer->setConsumerTag($consumerTag);
+
+
+while (true) {
+    if (false == $message = $consumer->receive(1000)) {
+        continue;
+    }
+
+    echo "\n--------\n";
+    echo $message->getBody();
+    echo "\n--------\n";
+
+    $consumer->acknowledge($message);
+
+    // Send a message with the string "quit" to cancel the consumer.
+    if ($message->getBody() === 'quit') {
+        break;
+    }
+}

--- a/demo/interop/amqp_consumer_fanout_2.php
+++ b/demo/interop/amqp_consumer_fanout_2.php
@@ -1,0 +1,49 @@
+<?php
+
+// Run multiple instances of amqp_consumer_fanout_1.php and
+// amqp_consumer_fanout_2.php to test
+
+include(__DIR__ . '/config.php');
+
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+$exchangeName = 'fanout_example_exchange';
+$queueName = 'fanout_group_2';
+$consumerTag = 'consumer' . getmypid();
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->addFlag(AmqpQueue::FLAG_AUTODELETE);
+$context->declareQueue($queue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_FANOUT);
+$topic->addFlag(AmqpTopic::FLAG_AUTODELETE);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+
+$consumer = $context->createConsumer($queue);
+$consumer->setConsumerTag($consumerTag);
+
+
+while (true) {
+    if (false == $message = $consumer->receive(1000)) {
+        continue;
+    }
+
+    echo "\n--------\n";
+    echo $message->getBody();
+    echo "\n--------\n";
+
+    $consumer->acknowledge($message);
+
+    // Send a message with the string "quit" to cancel the consumer.
+    if ($message->getBody() === 'quit') {
+        break;
+    }
+}

--- a/demo/interop/amqp_consumer_non_blocking.php
+++ b/demo/interop/amqp_consumer_non_blocking.php
@@ -1,0 +1,3 @@
+<?php
+
+// skipped

--- a/demo/interop/amqp_ha_consumer.php
+++ b/demo/interop/amqp_ha_consumer.php
@@ -1,0 +1,56 @@
+<?php
+
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'router';
+$queueName = 'haqueue';
+$specificQueueName = 'specific-haqueue';
+$consumerTag = 'consumer';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->setArguments(array('x-ha-policy' => 'all'));
+$context->declareQueue($queue);
+
+$specificQueue = $context->createQueue($specificQueueName);
+$specificQueue->setArguments(array(
+    'x-ha-policy' => 'nodes',
+    'x-ha-policy-params' => array(
+        'rabbit@' . HOST,
+        'hare@' . HOST,
+    ),
+));
+$context->declareQueue($specificQueue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_DIRECT);
+$topic->addFlag(AmqpTopic::FLAG_DURABLE);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+$context->bind(new AmqpBind($topic, $specificQueue));
+
+$consumer = $context->createConsumer($queue);
+$consumer->setConsumerTag($consumerTag);
+
+while (true) {
+    if (false == $message = $consumer->receive(1000)) {
+        continue;
+    }
+
+    echo "\n--------\n";
+    echo $message->getBody();
+    echo "\n--------\n";
+
+    $consumer->acknowledge($message);
+
+    // Send a message with the string "quit" to cancel the consumer.
+    if ($message->getBody() === 'quit') {
+        break;
+    }
+}

--- a/demo/interop/amqp_message_headers_recv.php
+++ b/demo/interop/amqp_message_headers_recv.php
@@ -1,0 +1,44 @@
+<?php
+
+use Interop\Amqp\AmqpConsumer;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$bindingKeys = array_slice($argv, 1);
+if (empty($bindingKeys)) {
+    file_put_contents('php://stderr', "Usage: $argv[0] [binding_key]\n");
+    exit(1);
+}
+
+$exchangeName = 'topic_headers_test';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createTemporaryQueue();
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_TOPIC);
+$topic->addFlag(AmqpTopic::FLAG_AUTODELETE);
+$context->declareTopic($topic);
+
+foreach ($bindingKeys as $bindingKey) {
+    $context->bind(new AmqpBind($topic, $queue, $bindingKey));
+}
+
+$consumer = $context->createConsumer($queue);
+$consumer->addFlag(AmqpConsumer::FLAG_NOACK);
+$consumer->addFlag(AmqpConsumer::FLAG_EXCLUSIVE);
+
+while (true) {
+    if (false == $message = $consumer->receive(1000)) {
+        continue;
+    }
+
+    echo PHP_EOL . ' [x] ', $message->getRoutingKey(), ':', $message->getBody(), "\n";
+    echo 'Message headers follows' . PHP_EOL;
+    var_dump($message->getProperties());
+    echo PHP_EOL;
+}

--- a/demo/interop/amqp_message_headers_snd.php
+++ b/demo/interop/amqp_message_headers_snd.php
@@ -1,0 +1,68 @@
+<?php
+
+use Interop\Amqp\AmqpTopic;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'topic_headers_test';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_TOPIC);
+$topic->addFlag(AmqpTopic::FLAG_AUTODELETE);
+$context->declareTopic($topic);
+
+$routingKey = empty($argv[1]) ? '' : $argv[1];
+$data = implode(' ', array_slice($argv, 2));
+if (empty($data)) {
+    $data = "Hello World!";
+}
+
+$routingKey = empty($argv[1]) ? '' : $argv[1];
+$data = implode(' ', array_slice($argv, 2));
+if (empty($data)) {
+    $data = "Hello World!";
+}
+
+$message = $context->createMessage($data, array(
+    'x-foo'=>'bar',
+    'table'=>array('figuf', 'ghf'=>5, 5=>675),
+    'num1' => -4294967295,
+    'num2' => 5,
+    'num3' => -2147483648,
+    'true' => true,
+    'false' => false,
+    'void' => null,
+    'date' => new DateTime(),
+    'array' => array(null, 'foo', 'bar', 5, 5674625, 'ttt', array(5, 8, 2)),
+    'arr_with_tbl' => array(
+        'bar',
+        5,
+        array('foo', 57, 'ee', array('foo'=>'bar', 'baz'=>'boo', 'arr'=>array(1,2,3, true, new DateTime()))),
+        67,
+        array(
+            'foo'=>'bar',
+            5=>7,
+            8=>'boo',
+            'baz'=>3
+        )
+    ),
+    '64bitint' => 9223372036854775807,
+    '64bit_uint' => '18446744073709600000',
+    '64bitint_neg' => -pow(2, 40)
+));
+$message->setProperty('shortshort', -5);
+$message->setProperty('short', -1024);
+$message->setRoutingKey($routingKey);
+
+echo PHP_EOL . PHP_EOL . 'SENDING MESSAGE WITH HEADERS' . PHP_EOL . PHP_EOL;
+var_dump($message->getProperties());
+echo PHP_EOL;
+
+$context->createProducer()->send($topic, $message);
+
+echo " [x] Sent ", $routingKey, ':', $data, " \n";
+
+$context->close();

--- a/demo/interop/amqp_publisher.php
+++ b/demo/interop/amqp_publisher.php
@@ -1,0 +1,33 @@
+<?php
+
+use Interop\Amqp\AmqpMessage;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'router';
+$queueName = 'msgs';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->addFlag(AmqpQueue::FLAG_DURABLE);
+$context->declareQueue($queue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_DIRECT);
+$topic->addFlag(AmqpTopic::FLAG_DURABLE);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+
+$message = $context->createMessage(implode(' ', array_slice($argv, 1)));
+$message->setContentType('text/plain');
+$message->setDeliveryMode(AmqpMessage::DELIVERY_MODE_PERSISTENT);
+
+$context->createProducer()->send($topic, $message);
+
+$context->close();

--- a/demo/interop/amqp_publisher_exclusive.php
+++ b/demo/interop/amqp_publisher_exclusive.php
@@ -1,0 +1,22 @@
+<?php
+
+use Interop\Amqp\AmqpTopic;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'fanout_exclusive_example_exchange';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_FANOUT);
+$topic->addFlag(AmqpTopic::FLAG_AUTODELETE);
+$context->declareTopic($topic);
+
+$message = $context->createMessage(implode(' ', array_slice($argv, 1)));
+$message->setContentType('text/plain');
+
+$context->createProducer()->send($topic, $message);
+
+$context->close();

--- a/demo/interop/amqp_publisher_fanout.php
+++ b/demo/interop/amqp_publisher_fanout.php
@@ -1,0 +1,22 @@
+<?php
+
+use Interop\Amqp\AmqpTopic;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'fanout_example_exchange';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_FANOUT);
+$topic->addFlag(AmqpTopic::FLAG_AUTODELETE);
+$context->declareTopic($topic);
+
+$message = $context->createMessage(implode(' ', array_slice($argv, 1)));
+$message->setContentType('text/plain');
+
+$context->createProducer()->send($topic, $message);
+
+$context->close();

--- a/demo/interop/basic_get.php
+++ b/demo/interop/basic_get.php
@@ -1,0 +1,40 @@
+<?php
+
+use Interop\Amqp\AmqpMessage;
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'basic_get_test';
+$queueName = 'basic_get_queue';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->addFlag(AmqpQueue::FLAG_DURABLE);
+$context->declareQueue($queue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_DIRECT);
+$topic->addFlag(AmqpTopic::FLAG_DURABLE);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+
+$toSend = $context->createMessage('test message');
+$toSend->setContentType('text/plain');
+$toSend->setDeliveryMode(AmqpMessage::DELIVERY_MODE_PERSISTENT);
+
+$context->createProducer()->send($topic, $toSend);
+
+$consumer = $context->createConsumer($queue);
+$message = $consumer->receiveNoWait();
+
+$consumer->acknowledge($message);
+
+var_dump($message->getBody());
+
+$context->close();

--- a/demo/interop/basic_nack.php
+++ b/demo/interop/basic_nack.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * - Start this consumer in one window by calling: php demo/basic_nack.php
+ * - Then on a separate window publish a message like this: php demo/amqp_publisher.php good
+ *   that message should be "ack'ed"
+ * - Then publish a message like this: php demo/amqp_publisher.php bad
+ *   that message should be "nack'ed"
+ */
+
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'router';
+$queueName = 'msgs';
+$consumerTag = 'consumer';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->addFlag(AmqpQueue::FLAG_DURABLE);
+$context->declareQueue($queue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType(AmqpTopic::TYPE_DIRECT);
+$topic->addFlag(AmqpTopic::FLAG_DURABLE);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+
+$consumer = $context->createConsumer($queue);
+$consumer->setConsumerTag($consumerTag);
+
+while (true) {
+    if (false == $message = $consumer->receive(1000)) {
+        continue;
+    }
+
+    if ($message->getBody() == 'good') {
+        $consumer->acknowledge($message);
+    } else {
+        $consumer->reject($message);
+    }
+
+    // Send a message with the string "quit" to cancel the consumer.
+    if ($message->getBody() === 'quit') {
+        $context->close();
+        break;
+    }
+}

--- a/demo/interop/config.php
+++ b/demo/interop/config.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+define('AMQP_DSN', 'amqp://');
+
+define('HOST', 'localhost');
+
+//If this is enabled you can see AMQP output on the CLI
+define('AMQP_DEBUG', true);

--- a/demo/interop/delayed_message.php
+++ b/demo/interop/delayed_message.php
@@ -1,0 +1,45 @@
+<?php
+
+use Interop\Amqp\AmqpConsumer;
+use Interop\Amqp\AmqpMessage;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'delayed_exchange';
+$queueName = 'delayed_queue';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->setArgument('x-dead-letter-exchange', 'delayed');
+$context->declareQueue($queue);
+
+$topic = $context->createTopic($exchangeName);
+$topic->setType('x-delayed-message');
+$topic->addFlag(AmqpTopic::FLAG_DURABLE);
+$topic->setArgument('x-delayed-type', AmqpTopic::TYPE_FANOUT);
+$context->declareTopic($topic);
+
+$context->bind(new AmqpBind($topic, $queue));
+
+$message = $context->createMessage('hello', ['x-delay' => 7000]);
+$message->setDeliveryMode(AmqpMessage::DELIVERY_MODE_PERSISTENT);
+$context->createProducer()->send($topic, $message);
+
+$consumer = $context->createConsumer($queue);
+$consumer->addFlag(AmqpConsumer::FLAG_NOACK);
+$consumer->setConsumerTag($consumerTag);
+
+while (true) {
+    if (false == $message = $consumer->receive(1000)) {
+        continue;
+    }
+
+    $properties = $message->getProperties();
+    var_dump($properties['x-delay']);
+
+    $consumer->reject($message);
+}

--- a/demo/interop/e2e_bindings.php
+++ b/demo/interop/e2e_bindings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$sourceName = 'my_source_exchange';
+$destinationName = 'my_dest_exchange';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$source = $context->createTopic($exchangeName);
+$source->setType(AmqpTopic::TYPE_TOPIC);
+$source->addFlag(AmqpTopic::FLAG_DURABLE);
+$context->declareTopic($source);
+
+$destination = $context->createTopic($exchangeName);
+$destination->setType(AmqpTopic::TYPE_DIRECT);
+$destination->addFlag(AmqpTopic::FLAG_DURABLE);
+$context->declareTopic($destination);
+
+$context->bind(new AmqpBind($source, $destination));
+
+$context->unbind(new AmqpBind($source, $destination));
+
+$context->close();

--- a/demo/interop/queue_arguments.php
+++ b/demo/interop/queue_arguments.php
@@ -1,0 +1,22 @@
+<?php
+
+use Interop\Amqp\AmqpQueue;
+use PhpAmqpLib\Interop\AmqpConnectionFactory;
+
+include(__DIR__ . '/config.php');
+
+$exchangeName = 'router';
+$queueName = 'haqueue';
+$specificQueueName = 'specific-haqueue';
+
+$context = (new AmqpConnectionFactory(AMQP_DSN))->createContext();
+
+$queue = $context->createQueue($queueName);
+$queue->addFlag(AmqpQueue::FLAG_DURABLE);
+$queue->setArguments(array(
+    "x-dead-letter-exchange" => "t_test1",
+    "x-message-ttl" => 15000,
+    "x-expires" => 16000
+));
+
+$context->close();


### PR DESCRIPTION
PR ports [eqnueue/amqp-lib](https://github.com/php-enqueue/amqp-lib) which is built on top of [ampq-interop](https://github.com/queue-interop/amqp-interop).  The solution is fully functional and already tested (I'll port tests once we agree on this). The reason to have it instead of stand alone library is that it will be adopted by more developers which is good for a amqp interop and PHP community. 

Here's [usage examples](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_lib.md)

The main reason of the PR is to make messaging easy to do and open new opportunities for our PHP ecosystem. I am welcome you to join the queue interop group. Let's build it together 

1. AMQP itself is a specification, not implementation and it would be good to have it reflected in PHP language. As an author of [a library](https://github.com/formapro/pvm) which relies on messaging, I do not want to choose between amqplib and amqpext. I want it to work with both! It's like `psr/log` or `psr7` but for messaging. 
2. Right now there are two main AMQP clients in PHP world: this library and [amqp ext](https://github.com/pdezwart/php-amqp) and they are not compatible. They have completely different APIs. So people build solutions that work with [the library](https://github.com/php-amqplib/RabbitMqBundle) or with [the extension](https://github.com/M6Web/AmqpBundle) only. All they start to build their own clients. Such a waste of time and resources.  
3. Right now everybody is busy building yet another AMQP client whether it's built on top of this library or not. If we are agreed on messaging standard we can do a step further and start building more advanced stuff on top of the standard. Instead of writing yet another client developers can play with [enterprise patters](http://www.enterpriseintegrationpatterns.com/). It is a lot more fun IMO. 
4. I can create a library on top of the standard that provides a delaying strategy based on dead queues or on the delay plugin without the need to the coupling on an implementation (an example of level up). Everybody can install it using composer and just use it. Right now we have loads of articles explaining how to delay messages using 100500+ different amqp libraries. 
5. I hope frameworks will be more interested in adopting MQ if they have the ability to rely on pure interfaces. 
6. The amqp-interop makes it easier to use AMQP. You learn the interfaces once and you are ready to use any compatible library. 
7. Besides, the PR is relatively small. 

I'll add tests and docs if there is an approved from maintainers 
