### PR TITLE
pass connection timeout to wait method

### DIFF
--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -56,7 +56,8 @@ class AMQPStreamConnection extends AbstractConnection
             $login_response,
             $locale,
             $io,
-            $heartbeat
+            $heartbeat,
+            $connection_timeout
         );
 
         // save the params for the use of __clone, this will overwrite the parent


### PR DESCRIPTION
This passes the connection timeout parameter defined in AMQPStreamConnection to the AbstractConnection class where it is used when opening and closing the connection