### PR TITLE
Use tcp_nodelay for StreamIO, fixed #516 #449

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -89,7 +89,16 @@ class StreamIO extends AbstractIO
         $this->canDispatchPcntlSignal = $this->isPcntlSignalEnabled();
 
         if (is_null($this->context)) {
-            $this->context = stream_context_create();
+            // tcp_nodelay was added in 7.1.0
+            if (PHP_VERSION_ID >= 70100) {
+                $this->context = stream_context_create([
+                    "socket" => [
+                        "tcp_nodelay" => true
+                    ]
+                ]);
+            } else {
+                $this->context = stream_context_create();
+            }
         } else {
             $this->protocol = 'ssl';
             // php bugs 41631 & 65137 prevent select null from working on ssl streams


### PR DESCRIPTION
Fixes #516 
Fixes #449 

`tcp_nodelay` option for stream was added since PHP-7.1.0, benchmark shows great improvements.

before:
```
Stream produce 100:
php benchmark/stream_tmp_produce.php 100
5.1695640087128
Socket produce 100:
php benchmark/socket_tmp_produce.php 100
0.29251194000244
```

with `tcp_nodelay` option:
```
Stream produce 100:
php benchmark/stream_tmp_produce.php 100
0.28404712677002
Socket produce 100:
php benchmark/socket_tmp_produce.php 100
0.32037281990051
```

root@32e5c526ee1c:/mnt# php -v
PHP 7.1.10 (cli) (built: Oct 10 2017 01:16:36) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies