### PR TITLE
Update amqp_consumer_non_blocking.php

### DIFF
--- a/demo/amqp_consumer_non_blocking.php
+++ b/demo/amqp_consumer_non_blocking.php
@@ -85,7 +85,7 @@ while (count($channel->callbacks)) {
     $except = null;
     if (false === ($changeStreamsCount = stream_select($read, $write, $except, 60))) {
         /* Error handling */
-    } elseif ($changeStreamsCount > 0) {
+    } elseif ($changeStreamsCount > 0 || !empty($channel->getMethodQueue())) {
         $channel->wait();
     }
 }


### PR DESCRIPTION
If we send a command to rabbitmq server while consuming a queue, client may receive an AmqpMessage before the command response. The message will be queued in this 'method_queue' and we will no longer detect we have something to read in 'stream_select', so we have to check if there is something queued in the channel and call 'wait' then.