### PR TITLE
Change protected method check_heartbeat to public

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -341,7 +341,7 @@ class StreamIO extends AbstractIO
     /**
      * Heartbeat logic: check connection health here
      */
-    protected function check_heartbeat()
+    public function check_heartbeat()
     {
         // ignore unless heartbeat interval is set
         if ($this->heartbeat !== 0 && $this->last_read && $this->last_write) {


### PR DESCRIPTION
Long-running processes should be allowed to manually call the StreamIO check_heartbeat method every so often.