### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,10 @@ Extensions that modify existing methods like `alternate exchanges` are also supp
 
 ## Setup ##
 
- Add a `composer.json` file to your project:
-
-```javascript
-{
-  "require": {
-      "php-amqplib/php-amqplib": "2.7.*"
-  }
-}
-```
-
-Then provided you have [composer](http://getcomposer.org) installed, you can run the following command:
+Ensure you have [composer](http://getcomposer.org) installed, then run the following command:
 
 ```bash
-$ composer.phar install
+$ composer require php-amqplib/php-amqplib
 ```
 
 That will fetch the library and its dependencies inside your vendor folder. Then you can add the following to your


### PR DESCRIPTION
This is more maintainable, because you no longer have to change the
version number. It is also less error-prone, and will use whatever
version constraint operator is best when run (at the time I make this
PR, it's the caret operator).