### PR TITLE
fix in the AMQPSocketConnection parameters constructor to be the same…

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -7,7 +7,7 @@ class AMQPSocketConnection extends AbstractConnection
 {
     /**
      * @param string $host
-     * @param int $port
+     * @param string $port
      * @param string $user
      * @param string $password
      * @param string $vhost
@@ -15,9 +15,10 @@ class AMQPSocketConnection extends AbstractConnection
      * @param string $login_method
      * @param null $login_response
      * @param string $locale
-     * @param float $read_timeout
+     * @param float $connection_timeout
+     * @param float $read_write_timeout
+     * @param null $context
      * @param bool $keepalive
-     * @param int $write_timeout
      * @param int $heartbeat
      */
     public function __construct(
@@ -30,12 +31,13 @@ class AMQPSocketConnection extends AbstractConnection
         $login_method = 'AMQPLAIN',
         $login_response = null,
         $locale = 'en_US',
-        $read_timeout = 3,
+        $connection_timeout = 3.0,
+        $read_write_timeout = 3.0,
+        $context = null,
         $keepalive = false,
-        $write_timeout = 3,
         $heartbeat = 0
     ) {
-        $io = new SocketIO($host, $port, $read_timeout, $keepalive, $write_timeout, $heartbeat);
+        $io = new SocketIO($host, $port, $connection_timeout, $keepalive, $read_write_timeout, $heartbeat);
 
         parent::__construct(
             $user,


### PR DESCRIPTION
… as in the AMQPConnectionFactory::createConnection() (and AMQPStreamConnection::__construct())

Before, the constructor was incorrect - the list of parameters was broken, and the keep-alive + timeouts didn't work for the socket connection (because they were included incorrectly from the factory).