### PR TITLE
Fixed another possible indefinite waiting for data in StreamIO

### DIFF
--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -146,7 +146,18 @@ class AMQPReader extends AbstractClient
     {
         if ($this->io) {
             $this->wait();
-            $res = $this->io->read($n);
+
+            while (true) {
+                try {
+                    $res = $this->io->read($n);
+                    break;
+                } catch (AMQPTimeoutException $e) {
+                    if ($this->timeout > 0) {
+                        throw $e;
+                    }
+                }
+            }
+
             $this->offset += $n;
 
             return $res;

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -9,7 +9,8 @@ use PhpAmqpLib\Wire\AMQPWriter;
 
 class StreamIO extends AbstractIO
 {
-    const READ_BUFFER_WAIT_INTERVAL = 100000;
+    const READ_BUFFER_WAIT_INTERVAL = 100000; // 0.1 second
+    const READ_BUFFER_LIMIT         = 300; // 30 seconds / 0.1 second
 
     /** @var string */
     protected $protocol;
@@ -209,6 +210,7 @@ class StreamIO extends AbstractIO
         $read = 0;
         $data = '';
 
+        $wait_buffer_count = 0;
         while ($read < $len) {
             if (!is_resource($this->sock) || feof($this->sock)) {
                 throw new AMQPRuntimeException('Broken pipe or closed connection');
@@ -229,6 +231,12 @@ class StreamIO extends AbstractIO
 
             if ($buffer === '') {
                 if ($this->canDispatchPcntlSignal) {
+                    $wait_buffer_count++;
+                    if ($wait_buffer_count > self::READ_BUFFER_LIMIT) {
+                        // No bytes has been being read during READ_BUFFER_WAIT_INTERVAL * READ_BUFFER_LIMIT seconds.
+                        // We assume the connection hangs if the timeout is set.
+                        throw new AMQPTimeoutException('Too many read attempts detected in StreamIO');
+                    }
                     $this->select(0, self::READ_BUFFER_WAIT_INTERVAL);
                     pcntl_signal_dispatch();
                 }


### PR DESCRIPTION
Several weeks ago we encounered a problem with consumers in production environment. A consumer hangs once or twice a day on sending ACK after a message is processed. Strace shows an infinite loop of selecting and reading a socket.

I've looked through the code and found a potential infinite while-loop in StreamIO.php. I've introduced a limit on iterations number as a workaround. It works fine in our production environment for a week. That's why I create this pull request.

The workaround helps in certain conditions, when the consumer reads no data during 30 seconds. The AMQPRuntimeException is thrown since handling this case is a client code responsibity. I think the longer delay would be crutilal to business.

Our devops could not reproduce the bug in testing environment and could not figure out the reason. However, potentially infinite loop should be limited anyway.