### PR TITLE
Throw exception on missed heartbeat

### DIFF
--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -221,6 +221,7 @@ class SocketIO extends AbstractIO
 
     /**
      * Heartbeat logic: check connection health here
+     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      */
     public function check_heartbeat()
     {
@@ -232,7 +233,8 @@ class SocketIO extends AbstractIO
 
             // server has gone away
             if (($this->heartbeat * 2) < $t_read) {
-                $this->reconnect();
+                $this->close();
+                throw new AMQPRuntimeException("Missed server heartbeat");
             }
 
             // time for client to send a heartbeat

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -199,7 +199,9 @@ class StreamIO extends AbstractIO
 
     /**
      * @param int $len
+     * @throws \ErrorException
      * @throws \PhpAmqpLib\Exception\AMQPIOException
+     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      * @return mixed|string
      */
     public function read($len)
@@ -337,6 +339,7 @@ class StreamIO extends AbstractIO
 
     /**
      * Heartbeat logic: check connection health here
+     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      */
     public function check_heartbeat()
     {
@@ -348,7 +351,8 @@ class StreamIO extends AbstractIO
 
             // server has gone away
             if (($this->heartbeat * 2) < $t_read) {
-                $this->reconnect();
+                $this->close();
+                throw new AMQPRuntimeException("Missed server heartbeat");
             }
 
             // time for client to send a heartbeat
@@ -401,6 +405,8 @@ class StreamIO extends AbstractIO
      * @param int $sec
      * @param int $usec
      * @return int|mixed
+     * @throws \ErrorException
+     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      */
     public function select($sec, $usec)
     {


### PR DESCRIPTION
If an IO detects missed heartbeats, it should not reconnect because
the AMQP connection and channels will not be recovered and server-side
connection and channels will be stopped on TCP connection close or
heartbeat timeout.
The current reconnection logic leads to delayed exception, if the client
waits for messages or tries to publish/ack.
It also will create a TCP connection on the server, which will consume
socket descriptors and memory.

Replace reconnect on missed heartbear with close and exception.

Since handling exceptions is a way to address connection issues in the
client, reconnection logic should be moved to exception handlers and be
higher-level, so channels and consumers can be recovered.

Addresses #309 