### PR TITLE
Queue declare timeout

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -617,6 +617,10 @@ class AMQPChannel extends AbstractChannel
      * @param bool $nowait
      * @param array $arguments
      * @param int $ticket
+     * @param int $timeout - optionally specify max number of seconds to wait 
+     *                       for server confirmation before returning a 
+                             PhpAmqpLib\Exception\AMQPTimeoutException
+     *                       This has no effect if nowait is set to true.
      * @return mixed|null
      */
     public function queue_declare(
@@ -627,7 +631,8 @@ class AMQPChannel extends AbstractChannel
         $auto_delete = true,
         $nowait = false,
         $arguments = array(),
-        $ticket = null
+        $ticket = null,
+        $timeout = 0
     ) {
         $ticket = $this->getTicket($ticket);
 
@@ -648,9 +653,8 @@ class AMQPChannel extends AbstractChannel
             return null;
         }
 
-        return $this->wait(array(
-            $this->waitHelper->get_wait('queue.declare_ok')
-        ));
+        $callbacks = array($this->waitHelper->get_wait('queue.declare_ok'));
+        return $this->wait($callbacks, false, $timeout);
     }
 
     /**

--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -619,7 +619,7 @@ class AMQPChannel extends AbstractChannel
      * @param int $ticket
      * @param int $timeout - optionally specify max number of seconds to wait 
      *                       for server confirmation before returning a 
-                             PhpAmqpLib\Exception\AMQPTimeoutException
+     *                       PhpAmqpLib\Exception\AMQPTimeoutException
      *                       This has no effect if nowait is set to true.
      * @return mixed|null
      */


### PR DESCRIPTION
Hello there,
I have submitted this pull request in an attempt to resolve an issue where services which use RabbitMQ are left hanging (no timeout), when a purge operation is in process on the queue they are using. I posted [this issue on Stack Overflow](https://stackoverflow.com/questions/49882208/rabbitmq-using-amqplib-timeout-for-queue-declare) before thinking I might be able to have a whack at the code myself.

The change simply allows the developer to set a timeout which would occur in such a situation and allow the developer to gracefully handle such a situation.

This may not be the best way, but I tested it locally and it seems to do the job for me and doesn't change any of the default behavior. It simply adds an optional timeout parameter to the queue_declare method. This timeout variable is passed onto the wait method and the default of 0 matches the wait's default of 0.

I wasn't sure how to write a test for this, but was able to run your tests with the following output:

```
stuart@stu-home-office⟫ make test
./vendor/bin/phpunit
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:	PHP 7.0.28-0ubuntu0.16.04.1
Configuration:	/home/stuart/Seafile/Desktop/Desktop/php-amqplib/phpunit.xml.dist
Warning:	The Xdebug extension is not loaded
		No code coverage will be generated.

...............................................................  63 / 135 ( 46%)
....................PHP Warning:  socket_connect(): Host lookup failed [-10001]: Unknown host in /home/stuart/Seafile/Desktop/Desktop/php-amqplib/PhpAmqpLib/Wire/IO/SocketIO.php on line 70
........................................... 126 / 135 ( 93%)
.........

Time: 4.47 seconds, Memory: 12.00MB

OK (135 tests, 873 assertions
```

If one is to make a test for this, it needs to create a queue with a large number of items (say 2 million), and then send off a purge request just before trying to create a connection and calling queu_declare with a short timeout of say 1 second. You should get a timeout exception (which is what we want). If you don't set that timeout of 1 second, you will just wait forever until the purge completes.
