### PR TITLE
Introduce a method to create connection from multiple hosts.

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -40,6 +40,11 @@ class AMQPSSLConnection extends AMQPStreamConnection
         );
     }
 
+    public static function try_create_connection($host, $port, $user, $password, $vhost, $options) {
+        $ssl_options = isset($options['ssl_options']) ? $options['ssl_options'] : [];
+        return new static($host, $port, $user, $password, $vhost, $ssl_options, $options);
+    }
+
     /**
      * @param array $options
      * @return resource

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -49,4 +49,36 @@ class AMQPSocketConnection extends AbstractConnection
             $heartbeat
         );
     }
+
+    protected static function try_create_connection($host, $port, $user, $password, $vhost, $options){
+        $insist = isset($options['insist']) ?
+                        $options['insist'] : false;
+        $login_method = isset($options['login_method']) ?
+                              $options['login_method'] :'AMQPLAIN';
+        $login_response = isset($options['login_response']) ?
+                                $options['login_response'] : null;
+        $locale = isset($options['locale']) ?
+                        $options['locale'] : 'en_US';
+        $read_timeout = isset($options['read_timeout']) ?
+                              $options['read_timeout'] : 3;
+        $keepalive = isset($options['keepalive']) ?
+                           $options['keepalive'] : false;
+        $write_timeout = isset($options['write_timeout']) ?
+                               $options['write_timeout'] : 3;
+        $heartbeat = isset($options['heartbeat']) ?
+                           $options['heartbeat'] : 0;
+        return new static($host,
+                          $port,
+                          $user,
+                          $password,
+                          $vhost,
+                          $insist,
+                          $login_method,
+                          $login_response,
+                          $locale,
+                          $read_timeout,
+                          $keepalive,
+                          $write_timeout,
+                          $heartbeat);
+    }
 }

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -63,4 +63,39 @@ class AMQPStreamConnection extends AbstractConnection
         // save the params for the use of __clone, this will overwrite the parent
         $this->construct_params = func_get_args();
     }
+
+    protected static function try_create_connection($host, $port, $user, $password, $vhost, $options){
+        $insist = isset($options['insist']) ?
+                        $options['insist'] : false;
+        $login_method = isset($options['login_method']) ?
+                              $options['login_method'] :'AMQPLAIN';
+        $login_response = isset($options['login_response']) ?
+                                $options['login_response'] : null;
+        $locale = isset($options['locale']) ?
+                        $options['locale'] : 'en_US';
+        $connection_timeout = isset($options['connection_timeout']) ?
+                                    $options['connection_timeout'] : 3.0;
+        $read_write_timeout = isset($options['read_write_timeout']) ?
+                                    $options['read_write_timeout'] : 3.0;
+        $context = isset($options['context']) ?
+                         $options['context'] : null;
+        $keepalive = isset($options['keepalive']) ?
+                           $options['keepalive'] : false;
+        $heartbeat = isset($options['heartbeat']) ?
+                           $options['heartbeat'] : 0;
+        return new static($host,
+                          $port,
+                          $user,
+                          $password,
+                          $vhost,
+                          $insist,
+                          $login_method,
+                          $login_response,
+                          $locale,
+                          $connection_timeout,
+                          $read_write_timeout,
+                          $context,
+                          $keepalive,
+                          $heartbeat);
+    }
 }

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -991,7 +991,6 @@ class AbstractConnection extends AbstractChannel
             $password = $hosts[$i]['password'];
             $vhost = isset($hosts[$i]['vhost']) ? $hosts[$i]['vhost'] : "/";
             try {
-                echo "TRY" . PHP_EOL;
                 $conn = static::try_create_connection($host, $port, $user, $password, $vhost, $options);
                 return $conn;
             } catch (\Exception $e) {

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -980,4 +980,39 @@ class AbstractConnection extends AbstractChannel
     {
         return $this->server_properties;
     }
+
+    public static function create_connection($hosts, $options = array()){
+        $latest_exception = null;
+        for($i = 0; $i < count($hosts); $i++) {
+            AbstractConnection::validate_host($hosts[$i]);
+            $host = $hosts[$i]['host'];
+            $port = $hosts[$i]['port'];
+            $user = $hosts[$i]['user'];
+            $password = $hosts[$i]['password'];
+            $vhost = isset($hosts[$i]['vhost']) ? $hosts[$i]['vhost'] : "/";
+            try {
+                echo "TRY" . PHP_EOL;
+                $conn = static::try_create_connection($host, $port, $user, $password, $vhost, $options);
+                return $conn;
+            } catch (\Exception $e) {
+                $latest_exception = $e;
+            }
+        }
+        throw $latest_exception;
+    }
+
+    public static function validate_host($host) {
+        if(!isset($host['host'])){
+            throw new \InvalidArgumentException("'host' key is required.");
+        }
+        if(!isset($host['port'])){
+            throw new \InvalidArgumentException("'port' key is required.");
+        }
+        if(!isset($host['user'])){
+            throw new \InvalidArgumentException("'user' key is required.");
+        }
+        if(!isset($host['password'])){
+            throw new \InvalidArgumentException("'password' key is required.");
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ please refer to the [official RabbitMQ tutorials](http://www.rabbitmq.com/tutori
 - `amqp_consumer_fanout_{1,2}.php` and `amqp_publisher_fanout.php`: demos fanout exchanges with named queues.
 - `basic_get.php`: demos obtaining messages from the queues by using the _basic get_ AMQP call.
 
+## Multiple hosts connections ##
+
+If you have a cluster of multiple nodes your application can connect, you can start
+a connection with an array of hosts instead one. To do that you should use
+the `create_connection` static method.
+
+For example:
+```
+$connection = AMQPStreamConnection::create_connection([
+    ['host' => HOST1, 'port' => PORT, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST2, 'port' => PORT, 'user' => USER, 'password' => PASS, 'vhost' => VHOST]
+],
+$options);
+```
+
+This code will try to connect to `HOST1` first, and connect to `HOST2` if the
+first connection fails.
+The method returns a connection object for a first successful connection.
+Should all connections fail it will throw the last connection exception.
+
+See `demo/amqp_connect_multiple_hosts.php` for more examples.
+
 ## Batch Publishing ##
 
 Let's say you have a process that generates a bunch of messages that are going to be published to the same `exchange` using the same `routing_key` and options like `mandatory`.

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ please refer to the [official RabbitMQ tutorials](http://www.rabbitmq.com/tutori
 
 ## Multiple hosts connections ##
 
-If you have a cluster of multiple nodes your application can connect, you can start
-a connection with an array of hosts instead one. To do that you should use
+If you have a cluster of multiple nodes to which your application can connect,
+you can start a connection with an array of hosts. To do that you should use
 the `create_connection` static method.
 
 For example:
@@ -135,9 +135,9 @@ $options);
 ```
 
 This code will try to connect to `HOST1` first, and connect to `HOST2` if the
-first connection fails.
-The method returns a connection object for a first successful connection.
-Should all connections fail it will throw the last connection exception.
+first connection fails. The method returns a connection object for the first
+successful connection. Should all connections fail it will throw the exception
+from the last connection attempt.
 
 See `demo/amqp_connect_multiple_hosts.php` for more examples.
 

--- a/demo/amqp_connect_multiple_hosts.php
+++ b/demo/amqp_connect_multiple_hosts.php
@@ -1,0 +1,65 @@
+<?php
+
+include(__DIR__ . '/config.php');
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AMQPSSLConnection;
+
+define('CERTS_PATH', '/git/rabbitmqinaction/av_scratchwork/openssl');
+
+$sslOptions = array(
+    'cafile' => CERTS_PATH . '/rmqca/cacert.pem',
+    'local_cert' => CERTS_PATH . '/phpcert.pem',
+    'verify_peer' => true
+);
+
+/*
+    create_connection takes an array of host configurations and an array of options
+    It will try connecting to hosts one-by-one and return the first successful
+    connection.
+    After reaching the end of the array, it will throw the last connection exception.
+    Options will be mapped to constructor arguments for used connection type.
+*/
+$connection = AMQPStreamConnection::create_connection([
+    ['host' => HOST, 'port' => PORT, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5673, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5674, 'user' => USER, 'password' => PASS, 'vhost' => VHOST]
+],
+[
+    'insist' => false,
+    'login_method' => 'AMQPLAIN',
+    'login_response' => null,
+    'locale' => 'en_US',
+    'connection_timeout' => 3.0,
+    'read_write_timeout' => 3.0,
+    'context' => null,
+    'keepalive' => false,
+    'heartbeat' => 0
+]);
+
+/*
+    For SSL connections you should set 'ssl_options' in the options array
+*/
+$ssl_connection = AMQPSSLConnection::create_connection([
+    ['host' => HOST, 'port' => PORT, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5673, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5674, 'user' => USER, 'password' => PASS, 'vhost' => VHOST]
+],
+[
+    'ssl_options' => $ssl_options
+]);
+
+
+/**
+ * @param \PhpAmqpLib\Connection\AbstractConnection $connection
+ */
+function shutdown($connection)
+{
+    $connection->close();
+}
+
+register_shutdown_function('shutdown', $connection);
+register_shutdown_function('shutdown', $ssl_connection);
+
+while (true) {
+}
+

--- a/demo/amqp_connect_multiple_hosts.php
+++ b/demo/amqp_connect_multiple_hosts.php
@@ -2,6 +2,7 @@
 
 include(__DIR__ . '/config.php');
 use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AMQPSocketConnection;
 use PhpAmqpLib\Connection\AMQPSSLConnection;
 
 define('CERTS_PATH', '/git/rabbitmqinaction/av_scratchwork/openssl');
@@ -35,6 +36,40 @@ $connection = AMQPStreamConnection::create_connection([
     'keepalive' => false,
     'heartbeat' => 0
 ]);
+
+
+// Use empty options array for defaults
+$connection = AMQPStreamConnection::create_connection([
+    ['host' => HOST, 'port' => PORT, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5673, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5674, 'user' => USER, 'password' => PASS, 'vhost' => VHOST]
+],
+[]);
+
+// Options keys are different for different connection types
+$connection = AMQPSocketConnection::create_connection([
+    ['host' => HOST, 'port' => PORT, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5673, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5674, 'user' => USER, 'password' => PASS, 'vhost' => VHOST]
+],
+[
+    'insist' => false,
+    'login_method' => 'AMQPLAIN',
+    'login_response' => null,
+    'locale' => 'en_US',
+    'read_timeout' => 3,
+    'keepalive' => false,
+    'write_timeout' => 3,
+    'heartbeat' => 0
+]);
+
+// Use empty options array for defaults
+$connection = AMQPSocketConnection::create_connection([
+    ['host' => HOST, 'port' => PORT, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5673, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+    ['host' => HOST, 'port' => 5674, 'user' => USER, 'password' => PASS, 'vhost' => VHOST]
+], []);
+
 
 /*
     For SSL connections you should set 'ssl_options' in the options array

--- a/demo/connection_recovery_consume.php
+++ b/demo/connection_recovery_consume.php
@@ -17,6 +17,7 @@ const PORT3 = 5674;
 */
 
 function connect() {
+    // If you want a better load-balancing, you cann reshuffle the list.
     return AMQPStreamConnection::create_connection([
         ['host' => HOST, 'port' => PORT1, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
         ['host' => HOST, 'port' => PORT2, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],

--- a/demo/connection_recovery_consume.php
+++ b/demo/connection_recovery_consume.php
@@ -5,6 +5,36 @@ use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 const WAIT_BEFORE_RECONNECT_uS = 1000000;
 
+// Assume we have a cluster of nodes on ports 5672, 5673 and 5674.
+// This should be possible to start on localhost using RABBITMQ_NODE_PORT
+const PORT1 = 5672;
+const PORT2 = 5673;
+const PORT3 = 5674;
+
+/*
+    To handle arbitrary node restart you can use a combination of connection
+    recovery and mulltiple hosts connection.
+*/
+
+function connect() {
+    return AMQPStreamConnection::create_connection([
+        ['host' => HOST, 'port' => PORT1, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+        ['host' => HOST, 'port' => PORT2, 'user' => USER, 'password' => PASS, 'vhost' => VHOST],
+        ['host' => HOST, 'port' => PORT3, 'user' => USER, 'password' => PASS, 'vhost' => VHOST]
+    ],
+    [
+        'insist' => false,
+        'login_method' => 'AMQPLAIN',
+        'login_response' => null,
+        'locale' => 'en_US',
+        'connection_timeout' => 3.0,
+        'read_write_timeout' => 3.0,
+        'context' => null,
+        'keepalive' => false,
+        'heartbeat' => 0
+    ]);
+}
+
 function cleanup_connection($connection) {
     // Connection might already be closed.
     // Ignoring exceptions.
@@ -20,7 +50,7 @@ $connection = null;
 
 while(true){
     try {
-        $connection = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
+        $connection = connect();
         register_shutdown_function('shutdown', $connection);
         // Your application code goes here.
         do_something_with_connection($connection);


### PR DESCRIPTION
Add a new static method `create_connection` in `AbstractConnection`
to create a connection providing multiple hosts.

The method takes an array of host arrays
with host,port,username,password and vhost keys
and tries to connect to them one-by-one.
The first successful connection is returned.
If unable to connect to any of them - the last esception is thrown.

This method is a simplest way to address issues like #253 or #498
There is no bookkeeping and load balancing, hosts are
selected one-by-one starting from the first one.

Combined with connection recovery techniques it can be used
to improve reliability when using clusters.