### PR TITLE
Fwrite \ErrorException not being thrown to the top function call when doing basic_publish

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -282,7 +282,7 @@ class StreamIO extends AbstractIO
                 $buffer = fwrite($this->sock, mb_substr($data, $written, 8192, 'ASCII'), 8192);
             } catch (\ErrorException $e) {
                 restore_error_handler();
-                throw $e;
+                throw new AMQPRuntimeException($e->getMessage());
             }
             restore_error_handler();
 


### PR DESCRIPTION
When the underlying tcp connection disconnected for any reason, the next call to basic_publish will freeze the application indefinitely. 
Translating ErrorException to AMQPRuntimeException inside the write function will fix the issue, in this case the exception will be caught by AbstractConnection class `write` method and marked the connection as closed, which then the application be able to detect the connection close and try to reconnect.