### PR TITLE
Add extended datatype for bytes

### DIFF
--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -95,6 +95,7 @@ abstract class AMQPAbstractCollection implements \Iterator
         self::T_STRING_LONG => 'S',
         self::T_ARRAY => 'A',
         self::T_TABLE => 'F',
+        self::T_BYTES => 'x',
     );
 
     /**

--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -38,6 +38,7 @@ abstract class AMQPAbstractCollection implements \Iterator
     const T_ARRAY = 15;
     const T_TABLE = 16;
 
+    const T_BYTES = 17;
     /**
      * @var string
      */
@@ -75,7 +76,8 @@ abstract class AMQPAbstractCollection implements \Iterator
         self::T_STRING_SHORT => 's',
         self::T_STRING_LONG => 'S',
         self::T_ARRAY => 'A',
-        self::T_TABLE => 'F'
+        self::T_TABLE => 'F',
+        self::T_BYTES => 'x',
     );
 
     /**
@@ -92,7 +94,7 @@ abstract class AMQPAbstractCollection implements \Iterator
         self::T_BOOL => 't',
         self::T_STRING_LONG => 'S',
         self::T_ARRAY => 'A',
-        self::T_TABLE => 'F'
+        self::T_TABLE => 'F',
     );
 
     /**

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -501,6 +501,9 @@ class AMQPReader extends AbstractClient
             case AMQPAbstractCollection::T_VOID:
                 $val = null;
                 break;
+            case AMQPAbstractCollection::T_BYTES:
+                $val = $this->read_longstr();
+                break;
             default:
                 throw new AMQPInvalidArgumentException(sprintf(
                     'Unsupported type "%s"',

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -502,6 +502,9 @@ class AMQPWriter extends AbstractClient
                 break;
             case AMQPAbstractCollection::T_VOID:
                 break;
+            case AMQPAbstractCollection::T_BYTES:
+                $this->write_longstr($val);
+                break;
             default:
                 throw new AMQPInvalidArgumentException(sprintf(
                     'Unsupported type "%s"',

--- a/tests/Unit/Wire/AMQPReaderTest.php
+++ b/tests/Unit/Wire/AMQPReaderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Unit\Wire;
+
+use PhpAmqpLib\Wire\AMQPArray;
+use PhpAmqpLib\Wire\AMQPTable;
+use PhpAmqpLib\Wire\AMQPReader;
+use PhpAmqpLib\Wire\AMQPWriter;
+use PHPUnit\Framework\TestCase;
+
+class AMQPReaderTest extends TestCase
+{
+
+    public function setUp()
+    {
+        $this->setProtoVersion(AMQPArray::PROTOCOL_091);
+    }
+
+    protected function setProtoVersion($proto)
+    {
+        $r = new \ReflectionProperty('\\PhpAmqpLib\\Wire\\AMQPAbstractCollection', '_protocol');
+        $r->setAccessible(true);
+        $r->setValue(null, $proto);
+    }
+
+    public function tearDown()
+    {
+    }
+
+    public function testReadBytes()
+    {
+        $expected = [
+            'snowman' => ['x', "\x26\x03"]
+        ];
+        $data = hex2bin('0000000f07736e6f776d616e78000000022603');
+        $reader = new AMQPReader($data);
+        $parsed = $reader->read_table();
+        $this->assertEquals($expected, $parsed);
+    }
+}

--- a/tests/Unit/Wire/AMQPWriterTest.php
+++ b/tests/Unit/Wire/AMQPWriterTest.php
@@ -81,14 +81,15 @@ class AMQPWriterTest extends TestCase
             'x-shortshort-u' => array('B', 5),
             'x-short' => array('U', -1024),
             'x-short-u' => array('u', 125),
-            'x-short-str' => array('s', 'foo')
+            'x-short-str' => array('s', 'foo'),
+            'x-bytes' => array('x', 'foobar'),
         ));
 
         $out = $this->writer->getvalue();
 
 
-        $expected = "\x00\x00\x00\x90\x05x-fooS\x00\x00\x00\x03bar\x05x-barA\x00\x00\x00\x10S\x00\x00\x00\x03bazS\x00\x00\x00\x03qux\x05x-bazI\x00\x00\x00\x2a\x06x-truet\x01\x07x-falset\x00" .
-            "\X0cx-shortshortb\xfb\x0ex-shortshort-uB\x05\x07x-shortU\xfc\x00\x09x-short-uu\x00\x7d\x0bx-short-strs\x03foo";
+        $expected = "\x00\x00\x00\xa3\x05x-fooS\x00\x00\x00\x03bar\x05x-barA\x00\x00\x00\x10S\x00\x00\x00\x03bazS\x00\x00\x00\x03qux\x05x-bazI\x00\x00\x00\x2a\x06x-truet\x01\x07x-falset\x00" .
+            "\X0cx-shortshortb\xfb\x0ex-shortshort-uB\x05\x07x-shortU\xfc\x00\x09x-short-uu\x00\x7d\x0bx-short-strs\x03foo\x07x-bytesx\x00\x00\x00\x06foobar";
 
         $this->assertEquals($expected, $out);
     }


### PR DESCRIPTION
```                                                                                                                                                                                                PHP Fatal error: Uncaught exception "PhpAmqpLib\Exception\AMQPOutOfRangeException" with message "0 - AMQP-rabbit doesn't define data of type [x]" in app/start.php                                  
 Stack trace:                                                                                                                                                                                       
 #0 /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/AMQPReader.php(389): getDataTypeForSymbol(string);                                                                                          
#1 /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/AMQPReader.php(402): read_table(boolean);                                                                                                    
#2 /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/GenericContent.php(146): read_table_object();                                                                                                
#3 /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Channel/AbstractChannel.php(290): load_properties(object);                                                                                        
#4 /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Channel/AbstractChannel.php(275): createMessage(object, object);                                                                                  
#5 /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Channel/AbstractChannel.php(497): wait_content();                                                                                                 
#6 /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Channel/AbstractChannel.php(345): maybe_wait_for_content(string);                                                                                 
 thrown in /app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/AMQPAbstractCollection.php on line 417
```

Need to add support for a extension to rabbitmq spec to support binary values:
https://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v3.6.0/rabbitmq-dotnet-client-3.6.0-client-htmldoc/html/type-RabbitMQ.Client.BinaryTableValue.html


Publisher is a Java Spring application, and it seems no way to override on that side.
This is already implemented in Java, Python and Ruby:
ruby: https://github.com/ruby-amqp/amq-protocol/blob/master/lib/amq/protocol/type_constants.rb#L18
python: https://github.com/pika/pika/blob/master/pika/data.py#L290
java: https://github.com/rabbitmq/rabbitmq-java-client/blob/master/src/main/java/com/rabbitmq/client/impl/ValueWriter.java#L190-L194