### PR TITLE
bcadd and bcmul are replaced by built-in operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `php-amqplib` will be documented in this file
 
+## 2.8.0 - 2018-10-10
+
+[GitHub Milestone](https://github.com/php-amqplib/php-amqplib/milestone/3)
+
+- Drop testing and support for PHP 5.3
+- Remove `bcmath` and `mbstring` requirements
+
 ## 2.7.2 - 2018-02-11
 
 [GitHub Milestone](https://github.com/php-amqplib/php-amqplib/milestone/5)

--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -838,7 +838,7 @@ class AMQPChannel extends AbstractChannel
              * @param string $key
              */
             function ($keys, $key) use ($value) {
-                if (bccomp($key, $value, 0) <= 0) {
+                if ($key <= $value) {
                     $keys[] = $key;
                 }
 

--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -1127,7 +1127,7 @@ class AMQPChannel extends AbstractChannel
 
         if ($this->next_delivery_tag > 0) {
             $this->published_messages[$this->next_delivery_tag] = $msg;
-            $this->next_delivery_tag = bcadd($this->next_delivery_tag, '1', 0);
+            $this->next_delivery_tag += 1;
         }
     }
 
@@ -1187,7 +1187,7 @@ class AMQPChannel extends AbstractChannel
 
             if ($this->next_delivery_tag > 0) {
                 $this->published_messages[$this->next_delivery_tag] = $msg;
-                $this->next_delivery_tag = bcadd($this->next_delivery_tag, '1', 0);
+                $this->next_delivery_tag += 1;
             }
         }
 

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -294,7 +294,7 @@ abstract class AbstractChannel
             list($frame_type, $payload) = $this->next_frame();
 
             $this->validate_body_frame($frame_type);
-            $bodyReceivedBytes = bcadd($bodyReceivedBytes, mb_strlen($payload, 'ASCII'), 0);
+            $bodyReceivedBytes += mb_strlen($payload, 'ASCII');
 
             if (is_int($this->maxBodySize) && $bodyReceivedBytes > $this->maxBodySize ) {
                 $message->setIsTruncated(true);

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -290,7 +290,7 @@ abstract class AbstractChannel
             ->load_properties($propertyReader)
             ->setBodySize($contentReader->read_longlong());
 
-        while (bccomp($message->getBodySize(), $bodyReceivedBytes, 0) == 1) {
+        while ($message->getBodySize() > $bodyReceivedBytes) {
             list($frame_type, $payload) = $this->next_frame();
 
             $this->validate_body_frame($frame_type);

--- a/PhpAmqpLib/Wire/AMQPDecimal.php
+++ b/PhpAmqpLib/Wire/AMQPDecimal.php
@@ -42,7 +42,7 @@ class AMQPDecimal
      */
     public function asBCvalue()
     {
-        return bcdiv($this->n, bcpow(10, $this->e));
+        return $this->n / (10 ** $this->e);
     }
 
     /**

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -299,7 +299,11 @@ class AMQPReader extends AbstractClient
             }
         }
 
-        return bcadd($this->is64bits && !$msb ? $hi << 32 : bcmul($hi, '4294967296', 0), $lo, 0);
+        if ($this->is64bits && !$msb) {
+            return ($hi << 32) + $lo;
+        } else {
+            return $hi * 4294967296 + $lo;
+        }
     }
 
     /**
@@ -312,9 +316,11 @@ class AMQPReader extends AbstractClient
         list(, $hi, $lo) = unpack('N2', $this->rawread(8));
 
         if ($this->is64bits) {
-            return bcadd($hi << 32, $lo, 0);
+            return ($hi << 32) + $lo;
+        } elseif (self::getLongMSB($lo)) {
+            return $hi * 4294967296 + sprintf('%u', $lo);
         } else {
-            return bcadd(bcmul($hi, '4294967296', 0), self::getLongMSB($lo) ? sprintf('%u', $lo) : $lo, 0);
+            return $hi * 4294967296 + $lo;
         }
     }
 

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -59,7 +59,7 @@ class AMQPWriter extends AbstractClient
         }
 
         if ($isNeg) {
-            $x = bcadd($x, -1, 0);
+            $x -= 1;
         } //in negative domain starting point is -1, not 0
 
         $res = array();
@@ -271,7 +271,7 @@ class AMQPWriter extends AbstractClient
 
         // if PHP_INT_MAX is big enough for that
         // direct $n<=PHP_INT_MAX check is unreliable on 64bit (values close to max) due to limited float precision
-        if (bcadd($n, -PHP_INT_MAX, 0) <= 0) {
+        if ($n - PHP_INT_MAX <= 0) {
             // trick explained in http://www.php.net/manual/fr/function.pack.php#109328
             if ($this->is64bits) {
                 list($hi, $lo) = $this->splitIntoQuads($n);
@@ -297,7 +297,7 @@ class AMQPWriter extends AbstractClient
      */
     public function write_signed_longlong($n)
     {
-        if ((bcadd($n, PHP_INT_MAX, 0) >= -1) && (bcadd($n, -PHP_INT_MAX, 0) <= 0)) {
+        if (($n + PHP_INT_MAX >= -1) && ($n - PHP_INT_MAX <= 0)) {
             if ($this->is64bits) {
                 list($hi, $lo) = $this->splitIntoQuads($n);
             } else {
@@ -308,7 +308,7 @@ class AMQPWriter extends AbstractClient
         } elseif ($this->is64bits) {
             throw new AMQPInvalidArgumentException('Signed longlong out of range: ' . $n);
         } else {
-            if (bcadd($n, '-9223372036854775807', 0) > 0) {
+            if ($n - PHP_INT_MAX > 0) {
                 throw new AMQPInvalidArgumentException('Signed longlong out of range: ' . $n);
             }
             try {

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -64,8 +64,8 @@ class AMQPWriter extends AbstractClient
 
         $res = array();
         for ($b = 0; $b < $bytes; $b += 2) {
-            $chnk = (int) bcmod($x, 65536);
-            $x = bcdiv($x, 65536, 0);
+            $chnk = (int)($x % 65536);
+            $x = $x / 65536;
             $res[] = pack('n', $isNeg ? ~$chnk : $chnk);
         }
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,7 @@
 This library is a _pure PHP_ implementation of the [AMQP 0-9-1 protocol](http://www.rabbitmq.com/tutorials/amqp-concepts.html).
 It's been tested against [RabbitMQ](http://www.rabbitmq.com/).
 
-**Requirements: PHP 5.3** due to the use of `namespaces`.
-
-**Requirements: bcmath extension** This library utilizes the bcmath PHP extension. The installation steps vary per PHP version and the underlying OS. The following example shows how to add to an existing PHP installation on Ubuntu 15.10:
-
-```bash
-sudo apt-get install php7.0-bcmath
-```
+**Requirement: PHP 5.4 or newer**
 
 The library was used for the PHP examples of [RabbitMQ in Action](http://manning.com/videla/) and the [official RabbitMQ tutorials](http://www.rabbitmq.com/tutorials/tutorial-one-php.html).
 

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "ext-bcmath": "*"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/tests/Unit/WireTest.php
+++ b/tests/Unit/WireTest.php
@@ -224,7 +224,7 @@ class WireTest extends TestCase
      */
     public function signed_longlong_wr_out_of_range_lower()
     {
-        $this->wr('-9223372036854775809', 'write_signed_longlong', 'read_signed_longlong');
+        $this->wr('-99223372036854775809', 'write_signed_longlong', 'read_signed_longlong');
     }
 
     /**
@@ -233,7 +233,7 @@ class WireTest extends TestCase
      */
     public function signed_longlong_wr_out_of_range_upper()
     {
-        $this->wr('9223372036854775808', 'write_signed_longlong', 'read_signed_longlong');
+        $this->wr('99223372036854775808', 'write_signed_longlong', 'read_signed_longlong');
     }
 
     /**


### PR DESCRIPTION
I just was wondering why BC Math is required. It would be great to know if replacing `bcadd` and `bcmul` with PHP built-in operators would make any sense? This PR is only to share the idea on replacing operations -- `bcadd` and `bcmul` more specifically. Looking forward to your comments! 
