### PR TITLE
Use errno instead of error strings

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -323,14 +323,14 @@ class StreamIO extends AbstractIO
      */
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
-        // fwrite notice that the stream isn't ready
-        if (strstr($errstr, 'Resource temporarily unavailable')) {
+        // fwrite notice that the stream isn't ready - errno=11, EAGAIN or EWOULDBLOCK
+        if ($errno == 11) {
              // it's allowed to retry
             return null;
         }
 
-        // stream_select warning that it has been interrupted by a signal
-        if (strstr($errstr, 'Interrupted system call')) {
+        // stream_select warning that it has been interrupted by a signal - errno=4, EINTR
+        if ($errno == 4) {
              // it's allowed while processing signals
             return null;
         }


### PR DESCRIPTION
System errors strings might be localised. In case of non-english error messages (that's our case, `LANG` is set by application to another value than default), `EAGAIN` and `EINTR` were not correctly detected and caused client to fail with an exception, as the error was not ignored.