### PR TITLE
Use specific exceptions instead of general AMQPRuntimeException

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -2,9 +2,11 @@
 namespace PhpAmqpLib\Channel;
 
 use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Exception\AMQPChannelClosedException;
+use PhpAmqpLib\Exception\AMQPInvalidFrameException;
+use PhpAmqpLib\Exception\AMQPNotImplementedException;
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
 use PhpAmqpLib\Exception\AMQPOutOfRangeException;
-use PhpAmqpLib\Exception\AMQPRuntimeException;
 use PhpAmqpLib\Helper\DebugHelper;
 use PhpAmqpLib\Helper\Protocol\MethodMap080;
 use PhpAmqpLib\Helper\Protocol\MethodMap091;
@@ -106,7 +108,7 @@ abstract class AbstractChannel
                 $this->methodMap = new MethodMap080();
                 break;
             default:
-                throw new AMQPRuntimeException(sprintf(
+                throw new AMQPNotImplementedException(sprintf(
                     'Protocol: %s not implemented.',
                     $this->protocolVersion
                 ));
@@ -185,7 +187,7 @@ abstract class AbstractChannel
     public function dispatch($method_sig, $args, $amqpMessage)
     {
         if (!$this->methodMap->valid_method($method_sig)) {
-            throw new AMQPRuntimeException(sprintf(
+            throw new AMQPNotImplementedException(sprintf(
                 'Unknown AMQP method "%s"',
                 $method_sig
             ));
@@ -194,7 +196,7 @@ abstract class AbstractChannel
         $amqp_method = $this->methodMap->get_method($method_sig);
 
         if (!method_exists($this, $amqp_method)) {
-            throw new AMQPRuntimeException(sprintf(
+            throw new AMQPNotImplementedException(sprintf(
                 'Method: "%s" not implemented by class: %s',
                 $amqp_method,
                 get_class($this)
@@ -232,7 +234,7 @@ abstract class AbstractChannel
     protected function send_method_frame($method_sig, $args = '')
     {
         if ($this->connection === null) {
-            throw new AMQPRuntimeException('Channel connection is closed.');
+            throw new AMQPChannelClosedException('Channel connection is closed.');
         }
 
         $this->connection->send_channel_method_frame($this->channel_id, $method_sig, $args);
@@ -397,7 +399,7 @@ abstract class AbstractChannel
 
     /**
      * @param int $frame_type
-     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPInvalidFrameException
      */
     protected function validate_method_frame($frame_type)
     {
@@ -406,7 +408,7 @@ abstract class AbstractChannel
 
     /**
      * @param int $frame_type
-     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPInvalidFrameException
      */
     protected function validate_header_frame($frame_type)
     {
@@ -415,7 +417,7 @@ abstract class AbstractChannel
 
     /**
      * @param int $frame_type
-     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPInvalidFrameException
      */
     protected function validate_body_frame($frame_type)
     {
@@ -431,7 +433,7 @@ abstract class AbstractChannel
     {
         if ($frameType != $expectedType) {
             $protocolClass = self::$PROTOCOL_CONSTANTS_CLASS;
-            throw new AMQPRuntimeException(sprintf(
+            throw new AMQPInvalidFrameException(sprintf(
                     'Expecting %s, received frame type %s (%s)',
                     $expectedMessage,
                     $frameType,

--- a/PhpAmqpLib/Exception/AMQPChannelClosedException.php
+++ b/PhpAmqpLib/Exception/AMQPChannelClosedException.php
@@ -1,0 +1,6 @@
+<?php
+namespace PhpAmqpLib\Exception;
+
+class AMQPChannelClosedException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Exception/AMQPConnectionClosedException.php
+++ b/PhpAmqpLib/Exception/AMQPConnectionClosedException.php
@@ -1,0 +1,6 @@
+<?php
+namespace PhpAmqpLib\Exception;
+
+class AMQPConnectionClosedException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Exception/AMQPDataReadException.php
+++ b/PhpAmqpLib/Exception/AMQPDataReadException.php
@@ -1,0 +1,6 @@
+<?php
+namespace PhpAmqpLib\Exception;
+
+class AMQPDataReadException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Exception/AMQPHeartbeatMissedException.php
+++ b/PhpAmqpLib/Exception/AMQPHeartbeatMissedException.php
@@ -1,0 +1,6 @@
+<?php
+namespace PhpAmqpLib\Exception;
+
+class AMQPHeartbeatMissedException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Exception/AMQPInvalidFrameException.php
+++ b/PhpAmqpLib/Exception/AMQPInvalidFrameException.php
@@ -1,0 +1,6 @@
+<?php
+namespace PhpAmqpLib\Exception;
+
+class AMQPInvalidFrameException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Exception/AMQPNotImplementedException.php
+++ b/PhpAmqpLib/Exception/AMQPNotImplementedException.php
@@ -1,0 +1,6 @@
+<?php
+namespace PhpAmqpLib\Exception;
+
+class AMQPNotImplementedException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Exception/AMQPSocketException.php
+++ b/PhpAmqpLib/Exception/AMQPSocketException.php
@@ -1,0 +1,6 @@
+<?php
+namespace PhpAmqpLib\Exception;
+
+class AMQPSocketException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -1,9 +1,9 @@
 <?php
 namespace PhpAmqpLib\Wire;
 
+use PhpAmqpLib\Exception\AMQPDataReadException;
 use PhpAmqpLib\Exception\AMQPInvalidArgumentException;
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
-use PhpAmqpLib\Exception\AMQPRuntimeException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Exception\AMQPIOWaitException;
 use PhpAmqpLib\Helper\MiscHelper;
@@ -140,7 +140,7 @@ class AMQPReader extends AbstractClient
      * @param int $n
      * @return string
      * @throws \RuntimeException
-     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPDataReadException
      */
     protected function rawread($n)
     {
@@ -153,7 +153,7 @@ class AMQPReader extends AbstractClient
         }
 
         if ($this->str_length < $n) {
-            throw new AMQPRuntimeException(sprintf(
+            throw new AMQPDataReadException(sprintf(
                 'Error reading data. Requested %s bytes while string buffer has only %s',
                 $n,
                 $this->str_length
@@ -442,7 +442,7 @@ class AMQPReader extends AbstractClient
      * @param int $fieldType One of AMQPAbstractCollection::T_* constants
      * @param bool $collectionsAsObjects Description
      * @return mixed
-     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPDataReadException
      */
     public function read_value($fieldType, $collectionsAsObjects = false)
     {

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -1,8 +1,9 @@
 <?php
 namespace PhpAmqpLib\Wire\IO;
 
+use PhpAmqpLib\Exception\AMQPHeartbeatMissedException;
 use PhpAmqpLib\Exception\AMQPIOException;
-use PhpAmqpLib\Exception\AMQPRuntimeException;
+use PhpAmqpLib\Exception\AMQPSocketException;
 use PhpAmqpLib\Helper\MiscHelper;
 use PhpAmqpLib\Wire\AMQPWriter;
 
@@ -107,11 +108,12 @@ class SocketIO extends AbstractIO
      * @return mixed|string
      * @throws \PhpAmqpLib\Exception\AMQPIOException
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPSocketException
      */
     public function read($n)
     {
         if (is_null($this->sock)) {
-            throw new AMQPRuntimeException(sprintf(
+            throw new AMQPSocketException(sprintf(
                 'Socket was null! Last SocketError was: %s',
                 socket_strerror(socket_last_error())
             ));
@@ -145,7 +147,7 @@ class SocketIO extends AbstractIO
      * @return void
      *
      * @throws \PhpAmqpLib\Exception\AMQPIOException
-     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPSocketException
      */
     public function write($data)
     {
@@ -154,7 +156,7 @@ class SocketIO extends AbstractIO
         while (true) {
             // Null sockets are invalid, throw exception
             if (is_null($this->sock)) {
-                throw new AMQPRuntimeException(sprintf(
+                throw new AMQPSocketException(sprintf(
                     'Socket was null! Last SocketError was: %s',
                     socket_strerror(socket_last_error())
                 ));
@@ -234,7 +236,7 @@ class SocketIO extends AbstractIO
             // server has gone away
             if (($this->heartbeat * 2) < $t_read) {
                 $this->close();
-                throw new AMQPRuntimeException("Missed server heartbeat");
+                throw new AMQPHeartbeatMissedException("Missed server heartbeat");
             }
 
             // time for client to send a heartbeat

--- a/tests/Functional/Channel/DirectExchangeTest.php
+++ b/tests/Functional/Channel/DirectExchangeTest.php
@@ -16,8 +16,7 @@ class DirectExchangeTest extends ChannelTestCase
 
     /**
      * @test
-     * @expectedException \PhpAmqpLib\Exception\AMQPRuntimeException
-     * @expectedExceptionMessage Channel connection is closed.
+     * @expectedException \PhpAmqpLib\Exception\AMQPChannelClosedException
      */
     public function exchange_declare_with_closed_connection()
     {
@@ -28,8 +27,7 @@ class DirectExchangeTest extends ChannelTestCase
 
     /**
      * @test
-     * @expectedException \PhpAmqpLib\Exception\AMQPRuntimeException
-     * @expectedExceptionMessage Channel connection is closed.
+     * @expectedException \PhpAmqpLib\Exception\AMQPChannelClosedException
      */
     public function exchange_declare_with_closed_channel()
     {

--- a/tests/Functional/Channel/TopicExchangeTest.php
+++ b/tests/Functional/Channel/TopicExchangeTest.php
@@ -17,8 +17,7 @@ class TopicExchangeTest extends ChannelTestCase
 
     /**
      * @test
-     * @expectedException \PhpAmqpLib\Exception\AMQPRuntimeException
-     * @expectedExceptionMessage Channel connection is closed.
+     * @expectedException \PhpAmqpLib\Exception\AMQPChannelClosedException
      */
     public function exchange_declare_with_closed_connection()
     {
@@ -29,8 +28,7 @@ class TopicExchangeTest extends ChannelTestCase
 
     /**
      * @test
-     * @expectedException \PhpAmqpLib\Exception\AMQPRuntimeException
-     * @expectedExceptionMessage Channel connection is closed.
+     * @expectedException \PhpAmqpLib\Exception\AMQPChannelClosedException
      */
     public function exchange_declare_with_closed_channel()
     {

--- a/tests/Unit/Wire/IO/SocketIOTest.php
+++ b/tests/Unit/Wire/IO/SocketIOTest.php
@@ -32,7 +32,7 @@ class SocketIOTest extends TestCase
     /**
      * @test
      * @depends connect
-     * @expectedException \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @expectedException \PhpAmqpLib\Exception\AMQPSocketException
      */
     public function read_when_closed(SocketIO $socketIO)
     {
@@ -44,7 +44,7 @@ class SocketIOTest extends TestCase
     /**
      * @test
      * @depends connect
-     * @expectedException \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @expectedException \PhpAmqpLib\Exception\AMQPSocketException
      */
     public function write_when_closed(SocketIO $socketIO)
     {


### PR DESCRIPTION
So far, handling runtime exceptions might be clumsy. For example, writing code which reacts to the connection being closed currently relies on the exception message `'Broken pipe or closed connection'`. Rather than throwing the general `AMQPRuntimeException`, specific exceptions shall be used in reasonable situations.

The patch is backwards-compatible as all new exception classes extend `AMQPRuntimeException`.