### PR TITLE
Add getLibraryProperties abstract connection method and test

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -212,7 +212,12 @@ class AbstractConnection extends AbstractChannel
 
                 $this->write($this->amqp_protocol_header);
                 $this->wait(array($this->waitHelper->get_wait('connection.start')),false,$this->connection_timeout);
-                $this->x_start_ok(self::$LIBRARY_PROPERTIES, $this->login_method, $this->login_response, $this->locale);
+                $this->x_start_ok(
+                    $this->getLibraryProperties(),
+                    $this->login_method,
+                    $this->login_response,
+                    $this->locale
+                );
 
                 $this->wait_tune_ok = true;
                 while ($this->wait_tune_ok) {
@@ -979,6 +984,16 @@ class AbstractConnection extends AbstractChannel
     public function getServerProperties()
     {
         return $this->server_properties;
+    }
+
+    /**
+     * Get the library properties for populating the client protocol information
+     *
+     * @return array
+     */
+    public function getLibraryProperties()
+    {
+        return self::$LIBRARY_PROPERTIES;
     }
 
     public static function create_connection($hosts, $options = array()){

--- a/tests/Unit/Connection/LibraryPropertiesTest.php
+++ b/tests/Unit/Connection/LibraryPropertiesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Unit\Helper;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the library properties
+ */
+class LibraryPropertiesTest extends TestCase
+{
+    /**
+     * Client properties.
+     *
+     * https://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.start-ok.client-properties
+     * The properties SHOULD contain at least these fields:
+     *    "product", giving the name of the client product,
+     *    "version", giving the name of the client version,
+     *    "platform", giving the name of the operating system,
+     *    "copyright", if appropriate, and
+     *    "information", giving other general information.
+     *
+     * @test
+     */
+    public function requiredProperties()
+    {
+        $connection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+            ->setMethods(null)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $properties = $connection->getLibraryProperties();
+
+        // Assert that the library properties method returns an array
+        $this->assertInternalType('array', $properties);
+
+        // Ensure that the required properties exist in the array
+        $this->assertArrayHasKey('product', $properties);
+        $this->assertArrayHasKey('version', $properties);
+        $this->assertArrayHasKey('platform', $properties);
+        $this->assertArrayHasKey('copyright', $properties);
+        $this->assertArrayHasKey('information', $properties);
+    }
+
+    /**
+     * AMQPWriter::table_write expects values given with data types and values
+     * ensure each property is an array with the first value being a data type
+     *
+     * @test
+     */
+    public function propertyTypes()
+    {
+        $connection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+            ->setMethods(null)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $properties = $connection->getLibraryProperties();
+
+        // Assert that the library properties method returns an array
+        $this->assertInternalType('array', $properties);
+
+        // Iterate array checking each value is suitable
+        foreach ($properties as $property) {
+            // Property should be an array with exactly 2 properties
+            $this->assertInternalType('array', $property);
+            $this->assertCount(2, $property);
+            // Retreive the datatype and ensure it matches our signature
+            $dataType = $property[0];
+            $this->assertInternalType('string', $dataType);
+            $this->assertStringMatchesFormat('%c', $dataType);
+        }
+    }
+}


### PR DESCRIPTION
Added a new method getLibraryProperties to allow custom connections to override the client-properties sent to RabbitMQ