### PR TITLE
Allow to specify a timeout for channel operations

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -78,12 +78,19 @@ class AMQPChannel extends AbstractChannel
     private $publish_cache_max_size;
 
     /**
+     * Maximum time to wait for operations on this channel, in seconds.
+     * @var float $channel_rpc_timeout
+     */
+    private $channel_rpc_timeout;
+
+    /**
      * @param \PhpAmqpLib\Connection\AbstractConnection $connection
      * @param null $channel_id
      * @param bool $auto_decode
+     * @param int $channel_rpc_timeout
      * @throws \Exception
      */
-    public function __construct($connection, $channel_id = null, $auto_decode = true)
+    public function __construct($connection, $channel_id = null, $auto_decode = true, $channel_rpc_timeout = 0)
     {
         if ($channel_id == null) {
             $channel_id = $connection->get_free_channel_id();
@@ -102,6 +109,8 @@ class AMQPChannel extends AbstractChannel
         $this->alerts = array();
         $this->callbacks = array();
         $this->auto_decode = $auto_decode;
+
+        $this->channel_rpc_timeout = $channel_rpc_timeout;
 
         try {
             $this->x_open();
@@ -148,6 +157,7 @@ class AMQPChannel extends AbstractChannel
      * @param int $reply_code
      * @param string $reply_text
      * @param array $method_sig
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function close($reply_code = 0, $reply_text = '', $method_sig = array(0, 0))
@@ -168,7 +178,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('channel.close_ok')
-        ));
+        ), false, $this->channel_rpc_timeout );
     }
 
     /**
@@ -203,6 +213,7 @@ class AMQPChannel extends AbstractChannel
      * Enables/disables flow from peer
      *
      * @param $active
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function flow($active)
@@ -212,7 +223,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('channel.flow_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -244,6 +255,7 @@ class AMQPChannel extends AbstractChannel
 
     /**
      * @param string $out_of_band
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     protected function x_open($out_of_band = '')
@@ -257,7 +269,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('channel.open_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -279,6 +291,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $active
      * @param bool $write
      * @param bool $read
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function access_request(
@@ -302,7 +315,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('access.request_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -330,6 +343,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $nowait
      * @param array $arguments
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
      */
     public function exchange_declare(
@@ -365,7 +379,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('exchange.declare_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -383,6 +397,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $if_unused
      * @param bool $nowait
      * @param null $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
      */
     public function exchange_delete(
@@ -407,7 +422,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('exchange.delete_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -428,6 +443,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $nowait
      * @param array $arguments
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
      */
     public function exchange_bind(
@@ -457,7 +473,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('exchange.bind_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -477,6 +493,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $nowait
      * @param array $arguments
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function exchange_unbind(
@@ -502,7 +519,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('exchange.unbind_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -523,6 +540,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $nowait
      * @param array $arguments
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
      */
     public function queue_bind(
@@ -552,7 +570,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('queue.bind_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -572,6 +590,7 @@ class AMQPChannel extends AbstractChannel
      * @param string $routing_key
      * @param array $arguments
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function queue_unbind(
@@ -595,7 +614,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('queue.unbind_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -617,6 +636,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $nowait
      * @param array $arguments
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
      */
     public function queue_declare(
@@ -650,7 +670,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('queue.declare_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -676,6 +696,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $if_empty
      * @param bool $nowait
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
      */
     public function queue_delete($queue = '', $if_unused = false, $if_empty = false, $nowait = false, $ticket = null)
@@ -698,7 +719,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('queue.delete_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -718,6 +739,7 @@ class AMQPChannel extends AbstractChannel
      * @param string $queue
      * @param bool $nowait
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
      */
     public function queue_purge($queue = '', $nowait = false, $ticket = null)
@@ -733,7 +755,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('queue.purge_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -869,6 +891,7 @@ class AMQPChannel extends AbstractChannel
      * @param string $consumer_tag
      * @param bool $nowait
      * @param bool $noreturn
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function basic_cancel($consumer_tag, $nowait = false, $noreturn = false)
@@ -883,7 +906,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('basic.cancel_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -921,6 +944,7 @@ class AMQPChannel extends AbstractChannel
      * @param callable|null $callback
      * @param int|null $ticket
      * @param array $arguments
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|string
      */
     public function basic_consume(
@@ -951,7 +975,7 @@ class AMQPChannel extends AbstractChannel
         if (false === $nowait) {
             $consumer_tag = $this->wait(array(
                 $this->waitHelper->get_wait('basic.consume_ok')
-            ));
+            ), false, $this->channel_rpc_timeout);
         }
 
         $this->callbacks[$consumer_tag] = $callback;
@@ -1004,6 +1028,7 @@ class AMQPChannel extends AbstractChannel
      * @param string $queue
      * @param bool $no_ack
      * @param int $ticket
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function basic_get($queue = '', $no_ack = false, $ticket = null)
@@ -1016,7 +1041,7 @@ class AMQPChannel extends AbstractChannel
         return $this->wait(array(
             $this->waitHelper->get_wait('basic.get_ok'),
             $this->waitHelper->get_wait('basic.get_empty')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -1202,6 +1227,7 @@ class AMQPChannel extends AbstractChannel
      * @param int $prefetch_size
      * @param int $prefetch_count
      * @param bool $a_global
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function basic_qos($prefetch_size, $prefetch_count, $a_global)
@@ -1216,7 +1242,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('basic.qos_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -1231,6 +1257,7 @@ class AMQPChannel extends AbstractChannel
      * Redelivers unacknowledged messages
      *
      * @param bool $requeue
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function basic_recover($requeue = false)
@@ -1240,7 +1267,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('basic.recover_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -1293,6 +1320,7 @@ class AMQPChannel extends AbstractChannel
     }
 
     /**
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function tx_commit()
@@ -1301,7 +1329,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('tx.commit_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -1315,6 +1343,7 @@ class AMQPChannel extends AbstractChannel
     /**
      * Rollbacks the current transaction
      *
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function tx_rollback()
@@ -1323,7 +1352,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('tx.rollback_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**
@@ -1340,6 +1369,7 @@ class AMQPChannel extends AbstractChannel
      * Beware that only non-transactional channels may be put into confirm mode and vice versa
      *
      * @param bool $nowait
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return null
      */
     public function confirm_select($nowait = false)
@@ -1352,7 +1382,9 @@ class AMQPChannel extends AbstractChannel
             return null;
         }
 
-        $this->wait(array($this->waitHelper->get_wait('confirm.select_ok')));
+        $this->wait(array(
+            $this->waitHelper->get_wait('confirm.select_ok')
+        ), false, $this->channel_rpc_timeout);
         $this->next_delivery_tag = 1;
     }
 
@@ -1412,6 +1444,7 @@ class AMQPChannel extends AbstractChannel
     /**
      * Selects standard transaction mode
      *
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
      */
     public function tx_select()
@@ -1420,7 +1453,7 @@ class AMQPChannel extends AbstractChannel
 
         return $this->wait(array(
             $this->waitHelper->get_wait('tx.select_ok')
-        ));
+        ), false, $this->channel_rpc_timeout);
     }
 
     /**

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -321,6 +321,7 @@ abstract class AbstractChannel
      * @param int $timeout
      * @throws \PhpAmqpLib\Exception\AMQPOutOfBoundsException
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException
      * @throws \ErrorException
      * @return mixed
      */

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -38,6 +38,10 @@ class AMQPSocketConnection extends AbstractConnection
         $heartbeat = 0,
         $channel_rpc_timeout = 0.0
     ) {
+        if ($channel_rpc_timeout > $read_timeout) {
+            throw new \InvalidArgumentException('channel RPC timeout must not be greater than I/O read timeout');
+        }
+
         $io = new SocketIO($host, $port, $read_timeout, $keepalive, $write_timeout, $heartbeat);
 
         parent::__construct(

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -19,6 +19,8 @@ class AMQPSocketConnection extends AbstractConnection
      * @param bool $keepalive
      * @param int $write_timeout
      * @param int $heartbeat
+     * @param float $channel_rpc_timeout
+     * @throws \Exception
      */
     public function __construct(
         $host,
@@ -33,7 +35,8 @@ class AMQPSocketConnection extends AbstractConnection
         $read_timeout = 3,
         $keepalive = false,
         $write_timeout = 3,
-        $heartbeat = 0
+        $heartbeat = 0,
+        $channel_rpc_timeout = 0.0
     ) {
         $io = new SocketIO($host, $port, $read_timeout, $keepalive, $write_timeout, $heartbeat);
 
@@ -46,7 +49,8 @@ class AMQPSocketConnection extends AbstractConnection
             $login_response,
             $locale,
             $io,
-            $heartbeat
+            $heartbeat,
+            $channel_rpc_timeout
         );
     }
 

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -20,6 +20,7 @@ class AMQPStreamConnection extends AbstractConnection
      * @param null $context
      * @param bool $keepalive
      * @param int $heartbeat
+     * @param float $channel_rpc_timeout
      */
     public function __construct(
         $host,
@@ -35,7 +36,8 @@ class AMQPStreamConnection extends AbstractConnection
         $read_write_timeout = 3.0,
         $context = null,
         $keepalive = false,
-        $heartbeat = 0
+        $heartbeat = 0,
+        $channel_rpc_timeout = 0.0
     ) {
         $io = new StreamIO(
             $host,
@@ -57,7 +59,8 @@ class AMQPStreamConnection extends AbstractConnection
             $locale,
             $io,
             $heartbeat,
-            $connection_timeout
+            $connection_timeout,
+            $channel_rpc_timeout
         );
 
         // save the params for the use of __clone, this will overwrite the parent

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -39,6 +39,10 @@ class AMQPStreamConnection extends AbstractConnection
         $heartbeat = 0,
         $channel_rpc_timeout = 0.0
     ) {
+        if ($channel_rpc_timeout > $read_write_timeout) {
+            throw new \InvalidArgumentException('channel RPC timeout must not be greater than I/O read-write timeout');
+        }
+
         $io = new StreamIO(
             $host,
             $port,

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -132,6 +132,12 @@ class AbstractConnection extends AbstractChannel
     private $prepare_content_cache_max_size;
 
     /**
+     * Maximum time to wait for channel operations, in seconds
+     * @var float $channel_rpc_timeout
+     */
+    private $channel_rpc_timeout;
+
+    /**
      * @param string $user
      * @param string $password
      * @param string $vhost
@@ -142,6 +148,7 @@ class AbstractConnection extends AbstractChannel
      * @param AbstractIO $io
      * @param int $heartbeat
      * @param int $connection_timeout
+     * @param float $channel_rpc_timeout
      * @throws \Exception
      */
     public function __construct(
@@ -154,7 +161,8 @@ class AbstractConnection extends AbstractChannel
         $locale = 'en_US',
         AbstractIO $io,
         $heartbeat = 0,
-        $connection_timeout = 0
+        $connection_timeout = 0,
+        $channel_rpc_timeout = 0.0
     ) {
         // save the params for the use of __clone
         $this->construct_params = func_get_args();
@@ -639,7 +647,7 @@ class AbstractConnection extends AbstractChannel
         }
 
         $channel_id = $channel_id ? $channel_id : $this->get_free_channel_id();
-        $ch = new AMQPChannel($this->connection, $channel_id);
+        $ch = new AMQPChannel($this->connection, $channel_id, $this->channel_rpc_timeout);
         $this->channels[$channel_id] = $ch;
 
         return $ch;

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -176,6 +176,7 @@ class AbstractConnection extends AbstractChannel
         $this->io = $io;
         $this->heartbeat = $heartbeat;
         $this->connection_timeout = $connection_timeout;
+        $this->channel_rpc_timeout = $channel_rpc_timeout;
 
         if ($user && $password) {
             $this->login_response = new AMQPWriter();
@@ -647,7 +648,7 @@ class AbstractConnection extends AbstractChannel
         }
 
         $channel_id = $channel_id ? $channel_id : $this->get_free_channel_id();
-        $ch = new AMQPChannel($this->connection, $channel_id, $this->channel_rpc_timeout);
+        $ch = new AMQPChannel($this->connection, $channel_id, true, $this->channel_rpc_timeout);
         $this->channels[$channel_id] = $ch;
 
         return $ch;

--- a/tests/Functional/Channel/ChannelTimeoutTest.php
+++ b/tests/Functional/Channel/ChannelTimeoutTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace PhpAmqpLib\Tests\Unit\Channel;
+
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Helper\MiscHelper;
+use PhpAmqpLib\Wire\IO\AbstractIO;
+use PHPUnit\Framework\TestCase;
+
+class ChannelTimeoutTest extends TestCase
+{
+
+    /** @var float $channel_rpc_timeout */
+    private $channel_rpc_timeout;
+
+    /** @var int $channel_rpc_timeout */
+    private $channel_rpc_timeout_seconds;
+
+    /** @var int $channel_rpc_timeout */
+    private $channel_rpc_timeout_microseconds;
+
+    /** @var AbstractIO|\PHPUnit_Framework_MockObject_MockObject $io */
+    private $io;
+
+    /** @var AbstractConnection|\PHPUnit_Framework_MockObject_MockObject $connection */
+    private $connection;
+
+    /** @var AMQPChannel $channel */
+    private $channel;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->channel_rpc_timeout = 3.5;
+
+        list( $this->channel_rpc_timeout_seconds, $this->channel_rpc_timeout_microseconds ) =
+            MiscHelper::splitSecondsMicroseconds( $this->channel_rpc_timeout );
+
+        $this->io = $this->getMockBuilder('\PhpAmqpLib\Wire\IO\StreamIO')
+            ->setConstructorArgs(array(HOST, PORT, 3, 3, null, false, 0))
+            ->setMethods(array('select'))
+            ->getMock();
+        $this->connection = $this->getMockBuilder('\PhpAmqpLib\Connection\AbstractConnection')
+            ->setConstructorArgs(array(USER, PASS, '/', false, 'AMQPLAIN', null, 'en_US', $this->io, 0, 0, $this->channel_rpc_timeout))
+            ->setMethods(array())
+            ->getMockForAbstractClass();
+
+        $this->channel = $this->connection->channel();
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provide_operations
+     * @param string $operation
+     * @param array $args
+     *
+     * @covers \PhpAmqpLib\Channel\AMQPChannel::exchange_declare
+     * @covers \PhpAmqpLib\Channel\AMQPChannel::queue_declare
+     * @covers \PhpAmqpLib\Channel\AMQPChannel::confirm_select
+     *
+     * @expectedException \PhpAmqpLib\Exception\AMQPTimeoutException
+     * @expectedExceptionMessage The connection timed out after 3.5 sec while awaiting incoming data
+     */
+    public function should_throw_exception_for_basic_operations_when_timeout_exceeded($operation, $args)
+    {
+        // simulate blocking on the I/O level
+        $this->io->expects($this->any())
+            ->method('select')
+            ->with($this->channel_rpc_timeout_seconds, $this->channel_rpc_timeout_microseconds)
+            ->willReturn(0);
+
+        call_user_func_array(array($this->channel, $operation), $args);
+    }
+
+    public function provide_operations()
+    {
+        return array(
+            array('exchange_declare', array('test_ex', 'fanout')),
+            array('queue_declare', array('test_queue')),
+            array('confirm_select', array()),
+        );
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->channel->close();
+        $this->connection->close();
+    }
+}

--- a/tests/Unit/Connection/AMQPSocketConnectionTest.php
+++ b/tests/Unit/Connection/AMQPSocketConnectionTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace PhpAmqpLib\Tests\Unit\Connection;
+
+use PhpAmqpLib\Connection\AMQPSocketConnection;
+use PHPUnit\Framework\TestCase;
+
+class AMQPSocketConnectionTest extends TestCase
+{
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage channel RPC timeout must not be greater than I/O read timeout
+     */
+    public function channel_rpc_timeout_should_be_invalid_if_greater_than_read_write_timeout()
+    {
+        new AMQPSocketConnection(
+            HOST,
+            PORT,
+            USER,
+            PASS,
+            VHOST,
+            false,
+            'AMQPLAIN',
+            null,
+            'en_US',
+            3.0,
+            null,
+            false,
+            0,
+            5.0
+        );
+    }
+}

--- a/tests/Unit/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Unit/Connection/AMQPStreamConnectionTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace PhpAmqpLib\Tests\Unit\Connection;
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PHPUnit\Framework\TestCase;
+
+class AMQPStreamConnectionTest extends TestCase
+{
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage channel RPC timeout must not be greater than I/O read-write timeout
+     */
+    public function channel_rpc_timeout_should_be_invalid_if_greater_than_read_write_timeout()
+    {
+        new AMQPStreamConnection(
+            HOST,
+            PORT,
+            USER,
+            PASS,
+            VHOST,
+            false,
+            'AMQPLAIN',
+            null,
+            'en_US',
+            3.0,
+            3.0,
+            null,
+            false,
+            0,
+            5.0
+        );
+    }
+}


### PR DESCRIPTION
Add a new optional parameter allowing to specify a timeout for channel RPC operations (such as declaring an exchange, closing the channel etc.). This should allow clients to fail-fast if the server is unable to provide a response in time, e.g. because of a resource-driven alarm (see https://github.com/php-amqplib/php-amqplib/issues/88).

The default value for this new parameter is 0, i.e. no timeout which is the current behavior.

cc: @lukebakken 