### PR TITLE
Fixed restoring previous error handler in StreamIO

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -147,8 +147,6 @@ class StreamIO extends AbstractIO
             throw $e;
         }
 
-        restore_error_handler();
-
         if (false === $this->sock) {
             throw new AMQPRuntimeException(
                 sprintf(
@@ -300,7 +298,6 @@ class StreamIO extends AbstractIO
                 restore_error_handler();
                 throw new AMQPRuntimeException($e->getMessage());
             }
-            restore_error_handler();
 
             if ($buffer === false) {
                 throw new AMQPRuntimeException('Error sending data');
@@ -464,7 +461,6 @@ class StreamIO extends AbstractIO
             restore_error_handler();
             throw $e;
         }
-        restore_error_handler();
 
         return $result;
     }

--- a/tests/Functional/StreamIOTest.php
+++ b/tests/Functional/StreamIOTest.php
@@ -12,6 +12,8 @@ class StreamIOTest extends TestCase
      */
     public function error_handler_is_restored_on_failed_connection()
     {
+        set_error_handler(array($this, 'custom_error_handler'));
+
         error_reporting(~E_NOTICE);
 
         $exceptionThrown = false;
@@ -33,5 +35,26 @@ class StreamIOTest extends TestCase
         $this->assertFalse($exceptionThrown, 'Default error handler was not restored.');
 
         error_reporting(E_ALL);
+
+        $previousErrorHandler = set_error_handler(array($this, 'custom_error_handler'));
+        $this->assertSame('custom_error_handler', $previousErrorHandler[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function error_handler_is_restored_on_success()
+    {
+        set_error_handler(array($this, 'custom_error_handler'));
+
+        new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
+
+        $previousErrorHandler = set_error_handler(array($this, 'custom_error_handler'));
+
+        $this->assertSame('custom_error_handler', $previousErrorHandler[1]);
+    }
+
+    public function custom_error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
+    {
     }
 }


### PR DESCRIPTION
After 2.8.0 version got released there is a problem with restoring previous error handler in StreamIO class. 

In several places the `restore_error_handler()` was called twice in one function (once by calling `$this->cleanup_error_handler()` and later on by calling  `restore_error_handler()` directly) and because of that the previous error handler was not set correctly since each call popped the previous handler from the stack. 

This PR removes unnecessary calls to  `restore_error_handler()`.