### PR TITLE
Parse error string to determine error number instead of using errno

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -331,9 +331,9 @@ class StreamIO extends AbstractIO
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
         if (preg_match('/errno=(' . SOCKET_EAGAIN . '|' . SOCKET_EWOULDBLOCK . '|' . SOCKET_EINTR . ')/', $errstr)) {
-	    // Allow it to retry if it gets a notice that the stream isn't ready - EAGAIN or EWOULDBLOCK.
-	    // Allow it to retry if it gets a warning that it was interrupted by a signal that is being processed - EINTR.
-	    return null;
+            // Allow it to retry if it gets a notice that the stream isn't ready - EAGAIN or EWOULDBLOCK.
+            // Allow it to retry if it gets a warning that it was interrupted by a signal that is being processed - EINTR.
+            return null;
         }
 
         // throwing an exception in an error handler will halt execution

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -331,9 +331,9 @@ class StreamIO extends AbstractIO
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
         if (preg_match('/errno=(' . SOCKET_EAGAIN . '|' . SOCKET_EWOULDBLOCK . '|' . SOCKET_EINTR . ')/', $errstr)) {
-            // Allow it to retry if it gets a notice that the stream isn't ready - EAGAIN or EWOULDBLOCK.
-            // Allow it to retry if it gets a warning that it was interrupted by a signal that is being processed - EINTR.
-            return null;
+	    // Allow it to retry if it gets a notice that the stream isn't ready - EAGAIN or EWOULDBLOCK.
+	    // Allow it to retry if it gets a warning that it was interrupted by a signal that is being processed - EINTR.
+	    return null;
         }
 
         // throwing an exception in an error handler will halt execution

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -331,13 +331,13 @@ class StreamIO extends AbstractIO
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
         // fwrite notice that the stream isn't ready - EAGAIN or EWOULDBLOCK
-        if ($errno == SOCKET_EAGAIN || $errno == SOCKET_EWOULDBLOCK) {
+        if (strpos($errstr, 'errno=' . SOCKET_EAGAIN) !== false || strpos($errstr, 'errno=' . SOCKET_EWOULDBLOCK) !== false) {
              // it's allowed to retry
             return null;
         }
 
         // stream_select warning that it has been interrupted by a signal - EINTR
-        if ($errno == SOCKET_EINTR) {
+        if (strpos($errstr, 'errno=' . SOCKET_EINTR) !== false) {
              // it's allowed while processing signals
             return null;
         }

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -55,13 +55,13 @@ class StreamIO extends AbstractIO
     private $canDispatchPcntlSignal;
 
     /** @var string */
-    private static $ERRNO_EQUALS_EAGAIN = 'errno=' . SOCKET_EAGAIN;
+    private static $ERRNO_EQUALS_EAGAIN;
 
     /** @var string */
-    private static $ERRNO_EQUALS_EWOULDBLOCK = 'errno=' . SOCKET_EWOULDBLOCK;
+    private static $ERRNO_EQUALS_EWOULDBLOCK;
 
     /** @var string */
-    private static $ERRNO_EQUALS_EINTR = 'errno=' . SOCKET_EINTR;
+    private static $ERRNO_EQUALS_EINTR;
 
     /**
      * @param string $host
@@ -84,6 +84,10 @@ class StreamIO extends AbstractIO
         if ($heartbeat !== 0 && ($read_write_timeout < ($heartbeat * 2))) {
             throw new \InvalidArgumentException('read_write_timeout must be at least 2x the heartbeat');
         }
+
+        self::$ERRNO_EQUALS_EAGAIN = 'errno=' . SOCKET_EAGAIN;
+        self::$ERRNO_EQUALS_EWOULDBLOCK = 'errno=' . SOCKET_EWOULDBLOCK;
+        self::$ERRNO_EQUALS_EINTR = 'errno=' . SOCKET_EINTR;
 
         $this->protocol = 'tcp';
         $this->host = $host;

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -54,6 +54,15 @@ class StreamIO extends AbstractIO
     /** @var bool */
     private $canDispatchPcntlSignal;
 
+    /** @var string */
+    private static $ERRNO_EQUALS_EAGAIN = 'errno=' . SOCKET_EAGAIN;
+
+    /** @var string */
+    private static $ERRNO_EQUALS_EWOULDBLOCK = 'errno=' . SOCKET_EWOULDBLOCK;
+
+    /** @var string */
+    private static $ERRNO_EQUALS_EINTR = 'errno=' . SOCKET_EINTR;
+
     /**
      * @param string $host
      * @param int $port
@@ -331,13 +340,13 @@ class StreamIO extends AbstractIO
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
         // fwrite notice that the stream isn't ready - EAGAIN or EWOULDBLOCK
-        if (strpos($errstr, 'errno=' . SOCKET_EAGAIN) !== false || strpos($errstr, 'errno=' . SOCKET_EWOULDBLOCK) !== false) {
+        if (strpos($errstr, self::$ERRNO_EQUALS_EAGAIN) !== false || strpos($errstr, self::$ERRNO_EQUALS_EWOULDBLOCK) !== false) {
              // it's allowed to retry
             return null;
         }
 
         // stream_select warning that it has been interrupted by a signal - EINTR
-        if (strpos($errstr, 'errno=' . SOCKET_EINTR) !== false) {
+        if (strpos($errstr, self::$ERRNO_EQUALS_EINTR) !== false) {
              // it's allowed while processing signals
             return null;
         }

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -330,10 +330,16 @@ class StreamIO extends AbstractIO
      */
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
-        if (preg_match('/errno=(' . SOCKET_EAGAIN . '|' . SOCKET_EWOULDBLOCK . '|' . SOCKET_EINTR . ')/', $errstr)) {
-	    // Allow it to retry if it gets a notice that the stream isn't ready - EAGAIN or EWOULDBLOCK.
-	    // Allow it to retry if it gets a warning that it was interrupted by a signal that is being processed - EINTR.
-	    return null;
+        // fwrite notice that the stream isn't ready - EAGAIN or EWOULDBLOCK
+        if (strpos($errstr, 'errno=' . SOCKET_EAGAIN) !== false || strpos($errstr, 'errno=' . SOCKET_EWOULDBLOCK) !== false) {
+             // it's allowed to retry
+            return null;
+        }
+
+        // stream_select warning that it has been interrupted by a signal - EINTR
+        if (strpos($errstr, 'errno=' . SOCKET_EINTR) !== false) {
+             // it's allowed while processing signals
+            return null;
         }
 
         // throwing an exception in an error handler will halt execution

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -330,16 +330,10 @@ class StreamIO extends AbstractIO
      */
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
-        // fwrite notice that the stream isn't ready - EAGAIN or EWOULDBLOCK
-        if (strpos($errstr, 'errno=' . SOCKET_EAGAIN) !== false || strpos($errstr, 'errno=' . SOCKET_EWOULDBLOCK) !== false) {
-             // it's allowed to retry
-            return null;
-        }
-
-        // stream_select warning that it has been interrupted by a signal - EINTR
-        if (strpos($errstr, 'errno=' . SOCKET_EINTR) !== false) {
-             // it's allowed while processing signals
-            return null;
+        if (preg_match('/errno=(' . SOCKET_EAGAIN . '|' . SOCKET_EWOULDBLOCK . '|' . SOCKET_EINTR . ')/', $errstr)) {
+	    // Allow it to retry if it gets a notice that the stream isn't ready - EAGAIN or EWOULDBLOCK.
+	    // Allow it to retry if it gets a warning that it was interrupted by a signal that is being processed - EINTR.
+	    return null;
         }
 
         // throwing an exception in an error handler will halt execution


### PR DESCRIPTION
Parse error string to determine error number instead of using $errno, as $errno is the error level (e.g. E_NOTICE) and not the error number.