### PR TITLE
Restore code that sets last_read

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -276,6 +276,8 @@ class StreamIO extends AbstractIO
             );
         }
 
+        $this->last_read = microtime(true);
+
         return $data;
     }
 


### PR DESCRIPTION
Fixes #617 

This is in-line with the `SocketIO` implementation.