### PR TITLE
Fix wrong exception type on stream timeouts and signals

### DIFF
--- a/tests/Unit/Wire/IO/StreamIOTest.php
+++ b/tests/Unit/Wire/IO/StreamIOTest.php
@@ -24,4 +24,22 @@ class StreamIOTest extends TestCase
             1
         );
     }
+
+    /**
+     * @test
+     * @expectedException \PhpAmqpLib\Exception\AMQPIOWaitException
+     */
+    public function select_must_throw_io_exception()
+    {
+        $property = new \ReflectionProperty('PhpAmqpLib\Wire\IO\StreamIO', 'sock');
+        $property->setAccessible(true);
+
+        $resource = fopen('php://temp', 'r');
+        fclose($resource);
+
+        $stream = new StreamIO('0.0.0.0', PORT, 0.1, 0.1);
+        $property->setValue($stream, $resource);
+
+        $stream->select(0, 0);
+    }
 }


### PR DESCRIPTION
After 2.8.0 stream connections throws \ErrorException on usual SIGTERM signals. Various libraries cannot detect what caused this generic exception and how to behave next. Would be nice to get specific exception in such cases.