### PR TITLE
Fix and add test for signal handling with PCNTL extension

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -54,15 +54,6 @@ class StreamIO extends AbstractIO
     /** @var bool */
     private $canDispatchPcntlSignal;
 
-    /** @var string */
-    private static $ERRNO_EQUALS_EAGAIN;
-
-    /** @var string */
-    private static $ERRNO_EQUALS_EWOULDBLOCK;
-
-    /** @var string */
-    private static $ERRNO_EQUALS_EINTR;
-
     /**
      * @param string $host
      * @param int $port
@@ -84,11 +75,6 @@ class StreamIO extends AbstractIO
         if ($heartbeat !== 0 && ($read_write_timeout < ($heartbeat * 2))) {
             throw new \InvalidArgumentException('read_write_timeout must be at least 2x the heartbeat');
         }
-
-        // SOCKET_EAGAIN can't be accessed in Windows
-        self::$ERRNO_EQUALS_EAGAIN = 'errno=' . (defined('SOCKET_EAGAIN') ? SOCKET_EAGAIN : SOCKET_EWOULDBLOCK);
-        self::$ERRNO_EQUALS_EWOULDBLOCK = 'errno=' . SOCKET_EWOULDBLOCK;
-        self::$ERRNO_EQUALS_EINTR = 'errno=' . SOCKET_EINTR;
 
         $this->protocol = 'tcp';
         $this->host = $host;
@@ -346,14 +332,18 @@ class StreamIO extends AbstractIO
      */
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
+        // SOCKET_EAGAIN is not defined in Windows
+        $SOCKET_EAGAIN = defined(SOCKET_EAGAIN) ? SOCKET_EAGAIN : SOCKET_EWOULDBLOCK;
+
         // fwrite notice that the stream isn't ready - EAGAIN or EWOULDBLOCK
-        if (strpos($errstr, self::$ERRNO_EQUALS_EAGAIN) !== false || strpos($errstr, self::$ERRNO_EQUALS_EWOULDBLOCK) !== false) {
+        if (strpos($errstr, socket_strerror($SOCKET_EAGAIN)) !== false
+            || strpos($errstr, socket_strerror(SOCKET_EWOULDBLOCK)) !== false) {
              // it's allowed to retry
             return null;
         }
 
         // stream_select warning that it has been interrupted by a signal - EINTR
-        if (strpos($errstr, self::$ERRNO_EQUALS_EINTR) !== false) {
+        if (strpos($errstr, socket_strerror(SOCKET_EINTR)) !== false) {
              // it's allowed while processing signals
             return null;
         }

--- a/tests/Functional/Bug/Bug458Test.php
+++ b/tests/Functional/Bug/Bug458Test.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Bug;
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PHPUnit\Framework\TestCase;
+
+class Bug458Test extends TestCase
+{
+    private $channel;
+
+    public function setUp()
+    {
+        if (!extension_loaded('pcntl')) {
+            $this->markTestSkipped('pcntl extension is not available');
+        }
+
+        $connection = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
+
+        $this->channel = $connection->channel();
+        $this->addSignalHandlers();
+    }
+
+    /**
+     * This test will be skipped in Windows, because pcntl extension is not available there
+     *
+     * @test
+     *
+     * @expectedException PhpAmqpLib\Exception\AMQPIOWaitException
+     */
+    public function stream_select_interruption()
+    {
+        $pid = getmypid();
+        exec('php -r "sleep(1);posix_kill(' . $pid . ', SIGTERM);" > /dev/null 2>/dev/null &');
+        $this->channel->wait(null, false, 2);
+    }
+
+    private function addSignalHandlers()
+    {
+        pcntl_signal(SIGTERM, function () {
+            // do nothing
+        });
+    }
+}


### PR DESCRIPTION
Fixes bug that was reintroduced after commit ef318f1 that causes stream_select to raise an exception after the process receives a signal (issue #458).

The bug can be easily reproduced by running the **demo/amqp_consumer_signals.php**

The bug didn't have any tests, that's why the build passed.