### PR TITLE
fix isssue with close channel

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -174,7 +174,13 @@ class AMQPChannel extends AbstractChannel
             $method_sig[1]
         );
 
-        $this->send_method_frame(array($class_id, $method_id), $args);
+        try {
+            $this->send_method_frame(array($class_id, $method_id), $args);
+        } catch (\Exception $e) {
+            $this->do_close();
+
+            throw $e;
+        }
 
         return $this->wait(array(
             $this->waitHelper->get_wait('channel.close_ok')


### PR DESCRIPTION
I have got an issue with close channel when i tried to reconnect when connection was closed because of heartbeat timeout

We use swoole to handle http request in our applications.
So application does not die after one request it will process more requests
Also we use RabbitMqBundle to publish messages into queue

When connection is not used longer than heartbeat it is closed on rabbitmq server side
To handle this issue i try to call method AbstractConnection::reconnect
Everything is ok except channels are not closed. Because method AMQPChannel::do_close is not called. So channel is not marked as closed.
It happens because AMQPRuntimeException with message like "fwrite(): send of 19 bytes failed with errno=104 Connection reset by peer" is thrown on line $this->send_method_frame(array($class_id, $method_id), $args); in AMQPChannel::close

So i have made this fix.
If it should be done in different way i am ready to do it.
Or maybe the is a different approach to handle my issue. 