### PR TITLE
Fix channel wait timeouts and endless loops

### DIFF
--- a/PhpAmqpLib/Exception/AMQPNoDataException.php
+++ b/PhpAmqpLib/Exception/AMQPNoDataException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpAmqpLib\Exception;
+
+/**
+ * Used mostly in non-blocking methods when no data is ready for processing.
+ */
+class AMQPNoDataException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Helper/MiscHelper.php
+++ b/PhpAmqpLib/Helper/MiscHelper.php
@@ -32,11 +32,11 @@ class MiscHelper
      * different arguments
      *
      * @param int|float $number
-     * @return array
+     * @return int[]
      */
     public static function splitSecondsMicroseconds($number)
     {
-        return array(floor($number), ($number - floor($number)) * 1000000);
+        return array((int)floor($number), (int)(fmod($number, 1) * 1000000));
     }
 
     /**

--- a/demo/amqp_consumer_non_blocking.php
+++ b/demo/amqp_consumer_non_blocking.php
@@ -80,12 +80,7 @@ register_shutdown_function('shutdown', $channel, $connection);
 
 // Loop as long as the channel has callbacks registered
 while (count($channel->callbacks)) {
-    $read = array($connection->getSocket()); // add here other sockets that you need to attend
-    $write = null;
-    $except = null;
-    if (false === ($changeStreamsCount = stream_select($read, $write, $except, 60))) {
-        /* Error handling */
-    } elseif ($changeStreamsCount > 0 || $channel->hasPendingMethods()) {
-        $channel->wait();
-    }
+    $channel->wait(null, true);
+    // do something else
+    usleep(300000);
 }

--- a/tests/Functional/Channel/ChannelWaitTest.php
+++ b/tests/Functional/Channel/ChannelWaitTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Channel;
+
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPSocketConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PHPUnit\Framework\TestCase;
+
+class ChannelWaitTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provide_channels
+     * @param callable $factory
+     */
+    public function should_wait_forever_by_default($factory)
+    {
+        $this->deferSignal(0.5);
+        /** @var AMQPChannel $channel */
+        $channel = $factory();
+        try {
+            $channel->wait();
+        } catch (\Exception $exception) {
+            $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPIOWaitException', $exception);
+        }
+
+        $this->closeChannel($channel);
+    }
+
+    /**
+     * @test
+     * @dataProvider provide_channels
+     * @param callable $factory
+     * @expectedException \PhpAmqpLib\Exception\AMQPTimeoutException
+     */
+    public function should_throw_timeout_exception($factory)
+    {
+        $channel = $factory();
+        $channel->wait(null, false, 0.01);
+        $this->closeChannel($channel);
+    }
+
+    /**
+     * @test
+     * @dataProvider provide_channels
+     * @param callable $factory
+     */
+    public function should_return_instantly_non_blocking($factory)
+    {
+        $channel = $factory();
+        $start = microtime(true);
+        $channel->wait(null, true);
+        $took = microtime(true) - $start;
+
+        $this->assertLessThan(0.1, $took);
+
+        $this->closeChannel($channel);
+    }
+
+    public function provide_channels()
+    {
+        if (!defined('HOST')) {
+            $this->markTestSkipped('Unkown RabbitMQ host');
+        }
+
+        return [
+            [$this->channelFactory(true, 0.1)],
+            [$this->channelFactory(false, 0.1)],
+            [$this->channelFactory(true, 2, 1)],
+            [$this->channelFactory(false, 2, 1)],
+        ];
+    }
+
+    protected function channelFactory($stream = true, $connectionTimeout = 1, $heartBeat = 0)
+    {
+        $factory = function() use ($stream, $connectionTimeout, $heartBeat) {
+            try {
+                if ($stream) {
+                    $connection = new AMQPStreamConnection(
+                        HOST, PORT, USER, PASS, VHOST,
+                        false, 'AMQPLAIN', null, 'en_us',
+                        $connectionTimeout, $connectionTimeout, null, false, $heartBeat
+                    );
+                } else {
+                    $connection = new AMQPSocketConnection(
+                        HOST, PORT, USER, PASS, VHOST,
+                        false, 'AMQPLAIN', null, 'en_US',
+                        $connectionTimeout,
+                        false,
+                        $connectionTimeout,
+                        $heartBeat
+                    );
+                }
+            } catch (\ErrorException $exception) {
+                $this->markTestSkipped('Cannot connect to RabbitMQ: ' . $exception->getMessage());
+            }
+
+            $channel = $connection->channel();
+            $channel->queue_declare($queue = 'basic_get_queue', false, true, false, false);
+            $channel->exchange_declare($exchange = 'basic_get_test', 'fanout', false, true, false);
+            $channel->queue_bind($queue, $exchange);
+
+            return $channel;
+        };
+
+        return $factory;
+    }
+
+    protected function deferSignal($delay = 1)
+    {
+        if (!extension_loaded('pcntl')) {
+            $this->markTestSkipped('pcntl extension is not available');
+        }
+        pcntl_signal(SIGTERM, function () {
+        });
+        $pid = getmypid();
+        exec('php -r "usleep(' . $delay * 1e6 . ');posix_kill(' . $pid . ', SIGTERM);" > /dev/null 2>/dev/null &');
+    }
+
+    protected function closeChannel(AMQPChannel $channel)
+    {
+        $connection = $channel->getConnection();
+        $channel->close();
+        $connection->close();
+    }
+}

--- a/tests/Functional/StreamIOTest.php
+++ b/tests/Functional/StreamIOTest.php
@@ -18,7 +18,7 @@ class StreamIOTest extends TestCase
 
         $exceptionThrown = false;
         try {
-            new AMQPStreamConnection('google.com', PORT, USER, PASS, VHOST);
+            new AMQPStreamConnection(HOST, PORT - 1, USER, PASS, VHOST);
         } catch (\ErrorException $e) {
             $exceptionThrown = true;
         }

--- a/tests/config.php
+++ b/tests/config.php
@@ -1,8 +1,8 @@
 <?php
 
-define('HOST', 'localhost');
-define('PORT', 5672);
-define('USER', 'guest');
-define('PASS', 'guest');
+define('HOST', isset($_ENV['TEST_RABBITMQ_HOST']) ? $_ENV['TEST_RABBITMQ_HOST'] : 'localhost');
+define('PORT', isset($_ENV['TEST_RABBITMQ_PORT']) ? (int)$_ENV['TEST_RABBITMQ_PORT'] : 5672);
+define('USER', isset($_ENV['TEST_RABBITMQ_USER']) ? $_ENV['TEST_RABBITMQ_USER'] : 'guest');
+define('PASS', isset($_ENV['TEST_RABBITMQ_PASS']) ? $_ENV['TEST_RABBITMQ_PASS'] : 'guest');
 define('VHOST', '/');
-define('AMQP_DEBUG', false);
+define('AMQP_DEBUG', isset($_ENV['TEST_AMQP_DEBUG']) ? (bool)$_ENV['TEST_AMQP_DEBUG'] : false);


### PR DESCRIPTION
This one is mostly focused on $channel->wait() function and related issues. Previously this function throwed exception if no data was received in `connection_timeout` time, but most of us expect it to run indefinitely(timeout=0), like people complaining in #547 and #636.

- fix channel read error and endless loop #622
- make non blocking operations trully non blocking - just poll socket state and do not try to read anything if there is no data ready, introduce AMQPNoDataException
- cover stream & socket connections with same tests
- fix potentially unclosed sockets on connect exceptions - hhvm & docker for mac does not like those
- configurable test options via ENV