### PR TITLE
Docker dev environment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+  php:
+    build: ./docker/php
+    volumes:
+      - .:/src
+    working_dir: /src
+    environment:
+      - TEST_RABBITMQ_HOST=rabbitmq
+      - TOXIPROXY_HOST=proxy
+      - TOXIPROXY_AMQP_PORT=5673
+    links:
+      - rabbitmq
+    depends_on:
+      - rabbitmq
+      - proxy
+    entrypoint: ['tail', '-f', '/dev/null']
+
+  rabbitmq:
+    image: rabbitmq:latest
+    ports:
+      - "5672:5672"
+
+  proxy:
+    image: shopify/toxiproxy
+    ports:
+      - "8474:8474"
+      - "5673:5673"
+    links:
+      - rabbitmq

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:5.4-cli
+
+RUN apt update && \
+    apt -qy install git unzip zlib1g-dev && \
+    docker-php-ext-install bcmath sockets pcntl zip
+
+WORKDIR /src
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    php composer-setup.php && \
+    php -r "unlink('composer-setup.php');" && \
+    mv composer.phar /usr/local/bin/composer
+

--- a/tests/config.php
+++ b/tests/config.php
@@ -1,8 +1,8 @@
 <?php
 
-define('HOST', isset($_ENV['TEST_RABBITMQ_HOST']) ? $_ENV['TEST_RABBITMQ_HOST'] : 'localhost');
-define('PORT', isset($_ENV['TEST_RABBITMQ_PORT']) ? (int)$_ENV['TEST_RABBITMQ_PORT'] : 5672);
-define('USER', isset($_ENV['TEST_RABBITMQ_USER']) ? $_ENV['TEST_RABBITMQ_USER'] : 'guest');
-define('PASS', isset($_ENV['TEST_RABBITMQ_PASS']) ? $_ENV['TEST_RABBITMQ_PASS'] : 'guest');
+define('HOST', getenv('TEST_RABBITMQ_HOST') ? getenv('TEST_RABBITMQ_HOST') : 'localhost');
+define('PORT', getenv('TEST_RABBITMQ_PORT') ? getenv('TEST_RABBITMQ_PORT') : 5672);
+define('USER', getenv('TEST_RABBITMQ_USER') ? getenv('TEST_RABBITMQ_USER') : 'guest');
+define('PASS', getenv('TEST_RABBITMQ_PASS') ? getenv('TEST_RABBITMQ_PASS') : 'guest');
 define('VHOST', '/');
-define('AMQP_DEBUG', isset($_ENV['TEST_AMQP_DEBUG']) ? (bool)$_ENV['TEST_AMQP_DEBUG'] : false);
+define('AMQP_DEBUG', getenv('TEST_AMQP_DEBUG') !== false ? (bool)getenv('TEST_AMQP_DEBUG') : false);


### PR DESCRIPTION
Based on PHP5.4 as it is minimal supported version.

Fo the first time:
`docker-compose up -d`
`docker-compose exec php composer install`

to run tests:
`docker-compose exec php vendor/bin/phpunit`