### PR TITLE
AMQPExceptionInterface should always be Throwable

### DIFF
--- a/PhpAmqpLib/Exception/AMQPExceptionInterface.php
+++ b/PhpAmqpLib/Exception/AMQPExceptionInterface.php
@@ -1,6 +1,7 @@
 <?php
+
 namespace PhpAmqpLib\Exception;
 
-interface AMQPExceptionInterface
+interface AMQPExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
We found it in static code analysis. `AMQPExceptionInterface` should always be `\Throwable`, as it is intend to be caught with try-catch.

