### PR TITLE
Drop support for HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: nightly
-    - php: hhvm
   allow_failures:
     - php: nightly
 
@@ -28,7 +27,6 @@ cache:
     - vendor
 
 before_script:
-  - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
 script:


### PR DESCRIPTION
Latest HHVM 4.0 is not compatible with PHP and no longer able to execute composer.