### PR TITLE
Enable heartbeats by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `php-amqplib` will be documented in this file
 
+## 2.9.0 - 2019-02-25
+
+[GitHub Milestone](https://github.com/php-amqplib/php-amqplib/milestone/7?closed=1)
+
+- heartbeats are now enabled by default [Issue](https://github.com/php-amqplib/php-amqplib/issues/563) / [PR](https://github.com/php-amqplib/php-amqplib/pull/648)
+
 ## 2.8.1 - 2018-11-13
 
 [GitHub Milestone](https://github.com/php-amqplib/php-amqplib/milestone/6?closed=1)

--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -36,7 +36,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
             isset($options['read_write_timeout']) ? $options['read_write_timeout'] : 3,
             $ssl_context,
             isset($options['keepalive']) ? $options['keepalive'] : false,
-            isset($options['heartbeat']) ? $options['heartbeat'] : 0
+            isset($options['heartbeat']) ? $options['heartbeat'] : 10
         );
     }
 

--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -36,7 +36,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
             isset($options['read_write_timeout']) ? $options['read_write_timeout'] : 3,
             $ssl_context,
             isset($options['keepalive']) ? $options['keepalive'] : false,
-            isset($options['heartbeat']) ? $options['heartbeat'] : 10
+            isset($options['heartbeat']) ? $options['heartbeat'] : 60
         );
     }
 

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -32,10 +32,10 @@ class AMQPSocketConnection extends AbstractConnection
         $login_method = 'AMQPLAIN',
         $login_response = null,
         $locale = 'en_US',
-        $read_timeout = 3,
+        $read_timeout = 20,
         $keepalive = false,
-        $write_timeout = 3,
-        $heartbeat = 0,
+        $write_timeout = 20,
+        $heartbeat = 10,
         $channel_rpc_timeout = 0.0
     ) {
         if ($channel_rpc_timeout > $read_timeout) {
@@ -74,7 +74,7 @@ class AMQPSocketConnection extends AbstractConnection
         $write_timeout = isset($options['write_timeout']) ?
                                $options['write_timeout'] : 3;
         $heartbeat = isset($options['heartbeat']) ?
-                           $options['heartbeat'] : 0;
+                           $options['heartbeat'] : 10;
         return new static($host,
                           $port,
                           $user,

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -32,10 +32,10 @@ class AMQPSocketConnection extends AbstractConnection
         $login_method = 'AMQPLAIN',
         $login_response = null,
         $locale = 'en_US',
-        $read_timeout = 20,
+        $read_timeout = 130,
         $keepalive = false,
-        $write_timeout = 20,
-        $heartbeat = 10,
+        $write_timeout = 130,
+        $heartbeat = 60,
         $channel_rpc_timeout = 0.0
     ) {
         if ($channel_rpc_timeout > $read_timeout) {
@@ -68,13 +68,13 @@ class AMQPSocketConnection extends AbstractConnection
         $locale = isset($options['locale']) ?
                         $options['locale'] : 'en_US';
         $read_timeout = isset($options['read_timeout']) ?
-                              $options['read_timeout'] : 3;
+                              $options['read_timeout'] : 130;
         $keepalive = isset($options['keepalive']) ?
                            $options['keepalive'] : false;
         $write_timeout = isset($options['write_timeout']) ?
-                               $options['write_timeout'] : 3;
+                               $options['write_timeout'] : 130;
         $heartbeat = isset($options['heartbeat']) ?
-                           $options['heartbeat'] : 10;
+                           $options['heartbeat'] : 60;
         return new static($host,
                           $port,
                           $user,

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -33,10 +33,10 @@ class AMQPStreamConnection extends AbstractConnection
         $login_response = null,
         $locale = 'en_US',
         $connection_timeout = 3.0,
-        $read_write_timeout = 3.0,
+        $read_write_timeout = 20.0,
         $context = null,
         $keepalive = false,
-        $heartbeat = 0,
+        $heartbeat = 10,
         $channel_rpc_timeout = 0.0
     ) {
         if ($channel_rpc_timeout > $read_write_timeout) {
@@ -83,13 +83,13 @@ class AMQPStreamConnection extends AbstractConnection
         $connection_timeout = isset($options['connection_timeout']) ?
                                     $options['connection_timeout'] : 3.0;
         $read_write_timeout = isset($options['read_write_timeout']) ?
-                                    $options['read_write_timeout'] : 3.0;
+                                    $options['read_write_timeout'] : 20.0;
         $context = isset($options['context']) ?
                          $options['context'] : null;
         $keepalive = isset($options['keepalive']) ?
                            $options['keepalive'] : false;
         $heartbeat = isset($options['heartbeat']) ?
-                           $options['heartbeat'] : 0;
+                           $options['heartbeat'] : 10;
         return new static($host,
                           $port,
                           $user,

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -33,10 +33,10 @@ class AMQPStreamConnection extends AbstractConnection
         $login_response = null,
         $locale = 'en_US',
         $connection_timeout = 3.0,
-        $read_write_timeout = 20.0,
+        $read_write_timeout = 130.0,
         $context = null,
         $keepalive = false,
-        $heartbeat = 10,
+        $heartbeat = 60,
         $channel_rpc_timeout = 0.0
     ) {
         if ($channel_rpc_timeout > $read_write_timeout) {
@@ -83,13 +83,13 @@ class AMQPStreamConnection extends AbstractConnection
         $connection_timeout = isset($options['connection_timeout']) ?
                                     $options['connection_timeout'] : 3.0;
         $read_write_timeout = isset($options['read_write_timeout']) ?
-                                    $options['read_write_timeout'] : 20.0;
+                                    $options['read_write_timeout'] : 130.0;
         $context = isset($options['context']) ?
                          $options['context'] : null;
         $keepalive = isset($options['keepalive']) ?
                            $options['keepalive'] : false;
         $heartbeat = isset($options['heartbeat']) ?
-                           $options['heartbeat'] : 10;
+                           $options['heartbeat'] : 60;
         return new static($host,
                           $port,
                           $user,

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -161,7 +161,7 @@ class AbstractConnection extends AbstractChannel
         $login_response = null,
         $locale = 'en_US',
         AbstractIO $io,
-        $heartbeat = 10,
+        $heartbeat = 60,
         $connection_timeout = 0,
         $channel_rpc_timeout = 0.0
     ) {

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -161,7 +161,7 @@ class AbstractConnection extends AbstractChannel
         $login_response = null,
         $locale = 'en_US',
         AbstractIO $io,
-        $heartbeat = 0,
+        $heartbeat = 10,
         $connection_timeout = 0,
         $channel_rpc_timeout = 0.0
     ) {

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -51,7 +51,7 @@ class SocketIO extends AbstractIO
      * @param float|null $write_timeout if null defaults to read timeout
      * @param int $heartbeat how often to send heartbeat. 0 means off
      */
-    public function __construct($host, $port, $read_timeout = 20, $keepalive = false, $write_timeout = null, $heartbeat = 10)
+    public function __construct($host, $port, $read_timeout = 130, $keepalive = false, $write_timeout = null, $heartbeat = 60)
     {
         $this->host = $host;
         $this->port = $port;
@@ -61,11 +61,11 @@ class SocketIO extends AbstractIO
         $this->keepalive = $keepalive;
         $this->canDispatchPcntlSignal = $this->isPcntlSignalEnabled();
 
-        if ($this->heartbeat !== 0 && ($this->read_timeout < ($this->heartbeat * 2))) {
-            throw new \InvalidArgumentException('read_timeout must be at least 2x the heartbeat');
+        if ($this->heartbeat !== 0 && ($this->read_timeout <= ($this->heartbeat * 2))) {
+            throw new \InvalidArgumentException('read_timeout must be greater than 2x the heartbeat');
         }
-        if ($this->heartbeat !== 0 && ($this->send_timeout < ($this->heartbeat * 2))) {
-            throw new \InvalidArgumentException('send_timeout must be at least 2x the heartbeat');
+        if ($this->heartbeat !== 0 && ($this->send_timeout <= ($this->heartbeat * 2))) {
+            throw new \InvalidArgumentException('send_timeout must be greater than 2x the heartbeat');
         }
     }
 

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -51,7 +51,7 @@ class SocketIO extends AbstractIO
      * @param float|null $write_timeout if null defaults to read timeout
      * @param int $heartbeat how often to send heartbeat. 0 means off
      */
-    public function __construct($host, $port, $read_timeout, $keepalive = false, $write_timeout = null, $heartbeat = 0)
+    public function __construct($host, $port, $read_timeout = 20, $keepalive = false, $write_timeout = null, $heartbeat = 10)
     {
         $this->host = $host;
         $this->port = $port;
@@ -60,6 +60,13 @@ class SocketIO extends AbstractIO
         $this->heartbeat = $heartbeat;
         $this->keepalive = $keepalive;
         $this->canDispatchPcntlSignal = $this->isPcntlSignalEnabled();
+
+        if ($this->heartbeat !== 0 && ($this->read_timeout < ($this->heartbeat * 2))) {
+            throw new \InvalidArgumentException('read_timeout must be at least 2x the heartbeat');
+        }
+        if ($this->heartbeat !== 0 && ($this->send_timeout < ($this->heartbeat * 2))) {
+            throw new \InvalidArgumentException('send_timeout must be at least 2x the heartbeat');
+        }
     }
 
     /**

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -77,13 +77,13 @@ class StreamIO extends AbstractIO
         $host,
         $port,
         $connection_timeout,
-        $read_write_timeout = 20.0,
+        $read_write_timeout = 130.0,
         $context = null,
         $keepalive = false,
-        $heartbeat = 10
+        $heartbeat = 60
     ) {
-        if ($heartbeat !== 0 && ($read_write_timeout < ($heartbeat * 2))) {
-            throw new \InvalidArgumentException('read_write_timeout must be at least 2x the heartbeat');
+        if ($heartbeat !== 0 && ($read_write_timeout <= ($heartbeat * 2))) {
+            throw new \InvalidArgumentException('read_write_timeout must be greater than 2x the heartbeat');
         }
 
         // SOCKET_EAGAIN is not defined in Windows

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -77,10 +77,10 @@ class StreamIO extends AbstractIO
         $host,
         $port,
         $connection_timeout,
-        $read_write_timeout,
+        $read_write_timeout = 20.0,
         $context = null,
         $keepalive = false,
-        $heartbeat = 0
+        $heartbeat = 10
     ) {
         if ($heartbeat !== 0 && ($read_write_timeout < ($heartbeat * 2))) {
             throw new \InvalidArgumentException('read_write_timeout must be at least 2x the heartbeat');

--- a/demo/amqp_connect_multiple_hosts.php
+++ b/demo/amqp_connect_multiple_hosts.php
@@ -31,10 +31,10 @@ $connection = AMQPStreamConnection::create_connection([
     'login_response' => null,
     'locale' => 'en_US',
     'connection_timeout' => 3.0,
-    'read_write_timeout' => 3.0,
+    'read_write_timeout' => 10.0,
     'context' => null,
     'keepalive' => false,
-    'heartbeat' => 0
+    'heartbeat' => 5
 ]);
 
 
@@ -57,10 +57,10 @@ $connection = AMQPSocketConnection::create_connection([
     'login_method' => 'AMQPLAIN',
     'login_response' => null,
     'locale' => 'en_US',
-    'read_timeout' => 3,
+    'read_timeout' => 10,
     'keepalive' => false,
-    'write_timeout' => 3,
-    'heartbeat' => 0
+    'write_timeout' => 10,
+    'heartbeat' => 5
 ]);
 
 // Use empty options array for defaults

--- a/tests/Functional/Channel/ChannelWaitTest.php
+++ b/tests/Functional/Channel/ChannelWaitTest.php
@@ -68,10 +68,10 @@ class ChannelWaitTest extends TestCase
         }
 
         return [
-            [$this->channelFactory(true, 0.1)],
-            [$this->channelFactory(false, 0.1)],
-            [$this->channelFactory(true, 2, 1)],
-            [$this->channelFactory(false, 2, 1)],
+            [$this->channelFactory(true, 0.1, 0)],
+            [$this->channelFactory(false, 0.1, 0)],
+            [$this->channelFactory(true, 3, 1)],
+            [$this->channelFactory(false, 3, 1)],
         ];
     }
 

--- a/tests/Unit/Wire/IO/SocketIOTest.php
+++ b/tests/Unit/Wire/IO/SocketIOTest.php
@@ -12,7 +12,7 @@ class SocketIOTest extends TestCase
      */
     public function connect()
     {
-        $socketIO = new SocketIO(HOST, PORT, 1, true);
+        $socketIO = new SocketIO(HOST, PORT, 20, true);
         $socketIO->connect();
 
         return $socketIO;
@@ -24,9 +24,28 @@ class SocketIOTest extends TestCase
      */
     public function connect_with_invalid_credentials()
     {
-        $socket = new SocketIO('invalid_host', 1, 1, true);
-
+        $socket = new SocketIO('invalid_host', 5672);
         @$socket->connect();
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage read_timeout must be at least 2x the heartbeat
+     */
+    public function read_timeout_must_be_at_least_2x_the_heartbeat()
+    {
+        new SocketIO('localhost', 5512, 1);
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage send_timeout must be at least 2x the heartbeat
+     */
+    public function send_timeout_must_be_at_least_2x_the_heartbeat()
+    {
+        new SocketIO('localhost', '5512', 20, true, 1, 10);
     }
 
     /**

--- a/tests/Unit/Wire/IO/SocketIOTest.php
+++ b/tests/Unit/Wire/IO/SocketIOTest.php
@@ -12,7 +12,7 @@ class SocketIOTest extends TestCase
      */
     public function connect()
     {
-        $socketIO = new SocketIO(HOST, PORT, 20, true);
+        $socketIO = new SocketIO(HOST, PORT, 20, true, 20, 9);
         $socketIO->connect();
 
         return $socketIO;
@@ -31,9 +31,9 @@ class SocketIOTest extends TestCase
     /**
      * @test
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage read_timeout must be at least 2x the heartbeat
+     * @expectedExceptionMessage read_timeout must be greater than 2x the heartbeat
      */
-    public function read_timeout_must_be_at_least_2x_the_heartbeat()
+    public function read_timeout_must_be_greater_than_2x_the_heartbeat()
     {
         new SocketIO('localhost', 5512, 1);
     }
@@ -41,11 +41,11 @@ class SocketIOTest extends TestCase
     /**
      * @test
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage send_timeout must be at least 2x the heartbeat
+     * @expectedExceptionMessage send_timeout must be greater than 2x the heartbeat
      */
-    public function send_timeout_must_be_at_least_2x_the_heartbeat()
+    public function send_timeout_must_be_greater_than_2x_the_heartbeat()
     {
-        new SocketIO('localhost', '5512', 20, true, 1, 10);
+        new SocketIO('localhost', '5512', 30, true, 20, 10);
     }
 
     /**

--- a/tests/Unit/Wire/IO/StreamIOTest.php
+++ b/tests/Unit/Wire/IO/StreamIOTest.php
@@ -10,9 +10,9 @@ class StreamIOTest extends TestCase
     /**
      * @test
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage read_write_timeout must be at least 2x the heartbeat
+     * @expectedExceptionMessage read_write_timeout must be greater than 2x the heartbeat
      */
-    public function read_write_timeout_must_be_at_least_2x_the_heartbeat()
+    public function read_write_timeout_must_be_greater_than_2x_the_heartbeat()
     {
         new StreamIO(
             'localhost',

--- a/tests/Unit/Wire/IO/StreamIOTest.php
+++ b/tests/Unit/Wire/IO/StreamIOTest.php
@@ -37,7 +37,7 @@ class StreamIOTest extends TestCase
         $resource = fopen('php://temp', 'r');
         fclose($resource);
 
-        $stream = new StreamIO('0.0.0.0', PORT, 0.1, 0.1);
+        $stream = new StreamIO('0.0.0.0', PORT, 0.1, 0.1, null, false, 0);
         $property->setValue($stream, $resource);
 
         $stream->select(0, 0);


### PR DESCRIPTION
Heartbeats are set to 60 seconds by default, with socket timeouts set to 130 seconds.

Fixes #563