### PR TITLE
Remove workarounds for hhvm, use latest version of scrutinizer tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
-# required to test HHVM
-# see https://travis-ci.org/php-amqplib/php-amqplib/jobs/259347861
-dist: trusty
-
 cache:
   directories:
     - $HOME/.composer
@@ -33,7 +29,8 @@ script:
   - vendor/bin/phpunit -d zend.enable_gc=0 --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover; fi
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 
 services:
   rabbitmq

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -209,7 +209,6 @@ class SocketIO extends AbstractIO
         $read = array($this->sock);
         $write = null;
         $except = null;
-        $result = false;
 
         $this->set_error_handler();
         try {

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -459,11 +459,6 @@ class StreamIO extends AbstractIO
         $read = array($this->sock);
         $write = null;
         $except = null;
-        $result = false;
-
-        if (defined('HHVM_VERSION')) {
-            $usec = is_int($usec) ? $usec : 0;
-        }
 
         $this->set_error_handler();
         try {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "scrutinizer/ocular": "^1.1",
         "squizlabs/php_codesniffer": "^2.5",
         "phpdocumentor/phpdocumentor": "^2.9"
     },


### PR DESCRIPTION
This cleanups some strange workaround for HHVM and follows recommended way of how to push code coverage to scrutinizer.