### PR TITLE
Handle broken pipe or closed connection exceptions

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -3,6 +3,7 @@ namespace PhpAmqpLib\Channel;
 
 use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Exception\AMQPChannelClosedException;
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Exception\AMQPInvalidFrameException;
 use PhpAmqpLib\Exception\AMQPNoDataException;
 use PhpAmqpLib\Exception\AMQPNotImplementedException;
@@ -347,6 +348,11 @@ abstract class AbstractChannel
             } catch (AMQPNoDataException $e) {
                 // no data ready for non-blocking actions - stop and exit
                 break;
+            } catch (AMQPConnectionClosedException $exception) {
+                if ($this instanceof AMQPChannel) {
+                    $this->do_close();
+                }
+                throw $exception;
             }
 
             $this->validate_method_frame($frame_type);

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -54,6 +54,7 @@ class AMQPSocketConnection extends AbstractConnection
             $locale,
             $io,
             $heartbeat,
+            max($read_timeout, $write_timeout),
             $channel_rpc_timeout
         );
     }

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -351,6 +351,9 @@ class AbstractConnection extends AbstractChannel
 
         try {
             $this->getIO()->write($data);
+        } catch (AMQPConnectionClosedException $e) {
+            $this->do_close();
+            throw $e;
         } catch (AMQPRuntimeException $e) {
             $this->setIsConnected(false);
             throw $e;
@@ -556,6 +559,9 @@ class AbstractConnection extends AbstractChannel
                 $this->input->setTimeout($currentTimeout);
             }
             throw $e;
+        } catch (AMQPConnectionClosedException $exception) {
+            $this->do_close();
+            throw $exception;
         }
 
         $this->input->setTimeout($currentTimeout);

--- a/PhpAmqpLib/Exception/AMQPConnectionClosedException.php
+++ b/PhpAmqpLib/Exception/AMQPConnectionClosedException.php
@@ -1,6 +1,9 @@
 <?php
 namespace PhpAmqpLib\Exception;
 
+/**
+ * When connection was closed by server, proxy or some tunnel due to timeout or network issue.
+ */
 class AMQPConnectionClosedException extends AMQPRuntimeException
 {
 }

--- a/PhpAmqpLib/Exception/AMQPTimeoutException.php
+++ b/PhpAmqpLib/Exception/AMQPTimeoutException.php
@@ -1,6 +1,35 @@
 <?php
+
 namespace PhpAmqpLib\Exception;
 
 class AMQPTimeoutException extends \RuntimeException implements AMQPExceptionInterface
 {
+    /**
+     * @var int|float|null
+     */
+    private $timeout;
+
+    public function __construct($message = '', $timeout = 0, $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->timeout = $timeout;
+    }
+
+    /**
+     * @param int|float|null $timeout
+     * @param int $code
+     * @return self
+     */
+    public static function writeTimeout($timeout, $code = 0)
+    {
+        return new self('Error sending data. Connection timed out.', $timeout, $code);
+    }
+
+    /**
+     * @return int|float|null
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
 }

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -8,11 +8,22 @@ use PhpAmqpLib\Wire\AMQPWriter;
 
 abstract class AbstractIO
 {
+    const BUFFER_SIZE = 8192;
+
     /** @var string */
     protected $host;
 
     /** @var int */
     protected $port;
+
+    /** @var int|float */
+    protected $connection_timeout;
+
+    /** @var int|float */
+    protected $read_timeout;
+
+    /** @var int|float */
+    protected $write_timeout;
 
     /** @var int */
     protected $heartbeat;
@@ -36,14 +47,22 @@ abstract class AbstractIO
     protected $canDispatchPcntlSignal = false;
 
     /**
-     * @param int $n
+     * @param int $len
      * @return string
+     * @throws \PhpAmqpLib\Exception\AMQPIOException
+     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \PhpAmqpLib\Exception\AMQPSocketException
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException
+     * @throws \PhpAmqpLib\Exception\AMQPConnectionClosedException
      */
-    abstract public function read($n);
+    abstract public function read($len);
 
     /**
      * @param string $data
-     * @return mixed
+     * @throws \PhpAmqpLib\Exception\AMQPIOException
+     * @throws \PhpAmqpLib\Exception\AMQPSocketException
+     * @throws \PhpAmqpLib\Exception\AMQPConnectionClosedException
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException
      */
     abstract public function write($data);
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ using exception handling mechanism.
 Exceptions which might be thrown in case of connection errors:
 
 ```
+PhpAmqpLib\Exception\AMQPConnectionClosedException
 PhpAmqpLib\Exception\AMQPIOException
 \RuntimeException
 \ErrorException
@@ -226,7 +227,8 @@ while(true){
         $connection = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
         // Your application code goes here.
         do_something_with_connection($connection);
-    } catch(AMQPIOException $e) {
+    } catch(AMQPRuntimeException $e) {
+        echo $e->getMessage();
         cleanup_connection($connection);
         usleep(WAIT_BEFORE_RECONNECT_uS);
     } catch(\RuntimeException $e) {

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,11 @@
         "ext-sockets": "*"
     },
     "require-dev": {
+        "ext-curl": "*",
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.5",
-        "phpdocumentor/phpdocumentor": "^2.9"
+        "phpdocumentor/phpdocumentor": "^2.9",
+        "nategood/httpful": "^0.2.20"
     },
     "autoload": {
         "psr-4": {

--- a/demo/connection_recovery_consume.php
+++ b/demo/connection_recovery_consume.php
@@ -1,7 +1,9 @@
 <?php
 
 include(__DIR__ . '/config.php');
+
 use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Exception\AMQPRuntimeException;
 
 const WAIT_BEFORE_RECONNECT_uS = 1000000;
 
@@ -55,8 +57,8 @@ while(true){
         register_shutdown_function('shutdown', $connection);
         // Your application code goes here.
         do_something_with_connection($connection);
-    } catch(AMQPIOException $e) {
-        echo "AMQP IO exception " . PHP_EOL;
+    } catch(AMQPRuntimeException $e) {
+        echo $e->getMessage() . PHP_EOL;
         cleanup_connection($connection);
         usleep(WAIT_BEFORE_RECONNECT_uS);
     } catch(\RuntimeException $e) {

--- a/tests/Functional/AbstractConnectionTest.php
+++ b/tests/Functional/AbstractConnectionTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional;
+
+use Httpful\Request;
+use PhpAmqpLib\Channel\AbstractChannel;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Connection\AMQPSocketConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Exchange\AMQPExchangeType;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractConnectionTest extends TestCase
+{
+    public static $blocked = false;
+
+    /**
+     * @param string $type
+     * @param string $host
+     * @param string $port
+     * @param array $options
+     * @return AbstractConnection
+     */
+    protected function conection_create($type = 'stream', $host = HOST, $port = PORT, $options = array())
+    {
+        $keepalive = isset($options['keepalive']) ? $options['keepalive'] : false;
+        $heartbeat = isset($options['heartbeat']) ? $options['heartbeat'] : 0;
+        $timeout = isset($options['timeout']) ? $options['timeout'] : 1;
+
+        switch ($type) {
+            case 'stream':
+                $connection = new AMQPStreamConnection(
+                    $host,
+                    $port,
+                    USER,
+                    PASS,
+                    VHOST,
+                    false,
+                    'AMQPLAIN',
+                    null,
+                    'en_US',
+                    $timeout,
+                    $timeout,
+                    null,
+                    $keepalive,
+                    $heartbeat
+                );
+                break;
+            case 'socket':
+                $connection = new AMQPSocketConnection(
+                    $host,
+                    $port,
+                    USER,
+                    PASS,
+                    VHOST,
+                    false,
+                    'AMQPLAIN',
+                    null,
+                    'en_US',
+                    $timeout,
+                    $keepalive,
+                    $timeout,
+                    $heartbeat
+                );
+                break;
+            default:
+        }
+
+        $this->assertTrue($connection->isConnected());
+
+        return $connection;
+    }
+
+    protected function queue_bind(AMQPChannel $channel, $exchange_name, &$queue_name)
+    {
+        $channel->exchange_declare($exchange_name, AMQPExchangeType::DIRECT);
+        list($queue_name, ,) = $channel->queue_declare();
+        $channel->queue_bind($queue_name, $exchange_name, $queue_name);
+    }
+
+    /**
+     * @param string $name
+     * @return ToxiProxy
+     */
+    protected function create_proxy($name = 'amqp_connection')
+    {
+        $proxy = new ToxiProxy($name, $this->get_toxiproxy_host());
+        $proxy->open(HOST, PORT, $this->get_toxiproxy_amqp_port());
+
+        return $proxy;
+    }
+
+    protected function get_toxiproxy_host()
+    {
+        $host = getenv('TOXIPROXY_HOST');
+        if (!$host) {
+            $this->markTestSkipped('TOXIPROXY_HOST is not set');
+        }
+
+        return $host;
+    }
+
+    protected function get_toxiproxy_amqp_port()
+    {
+        $port = getenv('TOXIPROXY_AMQP_PORT');
+        if (!$port) {
+            $this->markTestSkipped('TOXIPROXY_AMQP_PORT is not set');
+        }
+
+        return $port;
+    }
+
+    protected function assertConnectionClosed(AbstractConnection $connection)
+    {
+        $this->assertFalse($connection->isConnected());
+        $this->assertNotNull($connection->getIO());
+        $this->assertNull($connection->getIO()->getSocket());
+        // all channels must be closed
+        foreach ($connection->channels as $ch) {
+            if ($ch instanceof AMQPChannel) {
+                $this->assertFalse($ch->is_open());
+            }
+            if ($ch instanceof AbstractConnection) {
+                $this->assertFalse($ch->isConnected());
+            }
+        }
+        $this->assertNotEmpty($connection->channels);
+    }
+
+    protected function assertChannelClosed(AbstractChannel $channel)
+    {
+        $this->assertFalse($channel->is_open());
+        $this->assertEmpty($channel->callbacks);
+    }
+}
+
+// mock low level IO write functions
+namespace PhpAmqpLib\Wire\IO;
+
+function fwrite() {
+    if (\PhpAmqpLib\Tests\Functional\AbstractConnectionTest::$blocked) {
+        return 0;
+    }
+
+    return call_user_func_array('\fwrite', func_get_args());
+}
+
+namespace PhpAmqpLib\Wire\IO;
+
+function socket_write() {
+    if (\PhpAmqpLib\Tests\Functional\AbstractConnectionTest::$blocked) {
+        return 0;
+    }
+
+    return call_user_func_array('\socket_write', func_get_args());
+}

--- a/tests/Functional/Bug/Bug256Test.php
+++ b/tests/Functional/Bug/Bug256Test.php
@@ -2,15 +2,13 @@
 
 namespace PhpAmqpLib\Tests\Functional\Bug;
 
-use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Connection\AMQPSocketConnection;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
 use PhpAmqpLib\Wire\AMQPTable;
-use PHPUnit\Framework\TestCase;
 
-class Bug256Test extends TestCase
+class Bug256Test extends AbstractConnectionTest
 {
     protected $exchangeName = 'test_exchange';
 
@@ -30,12 +28,12 @@ class Bug256Test extends TestCase
 
     public function setUp()
     {
-        $this->connection = new AMQPSocketConnection(HOST, PORT, USER, PASS, VHOST);
+        $this->connection = $this->conection_create('socket');
         $this->channel = $this->connection->channel();
 
         $this->channel->exchange_declare($this->exchangeName, 'direct', false, true, false);
 
-        $this->connection2 = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
+        $this->connection2 = $this->conection_create('stream');
         $this->channel2 = $this->connection->channel();
 
         list($this->queueName, ,) = $this->channel2->queue_declare();

--- a/tests/Functional/Connection/ConnectionClosedTest.php
+++ b/tests/Functional/Connection/ConnectionClosedTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Connection;
+
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+
+/**
+ * @group connection
+ */
+class ConnectionClosedTest extends AbstractConnectionTest
+{
+    /**
+     * Try to wait for incoming data on blocked and closed connection.
+     * @test
+     * @small
+     * @group connection
+     * @group proxy
+     * @testWith ["stream", false]
+     *           ["stream", true]
+     *           ["socket", false]
+     *           ["socket", true]
+     * @covers \PhpAmqpLib\Channel\AbstractChannel::wait()
+     * @covers \PhpAmqpLib\Connection\AbstractConnection::wait_frame()
+     * @covers \PhpAmqpLib\Wire\IO\StreamIO::read()
+     * @covers \PhpAmqpLib\Wire\IO\SocketIO::read()
+     *
+     * @param string $type
+     * @param bool $keepalive
+     */
+    public function must_throw_exception_broken_pipe_wait($type, $keepalive)
+    {
+        $proxy = $this->create_proxy();
+
+        $options = array(
+            'keepalive' => $keepalive,
+        );
+        /** @var AbstractConnection $connection */
+        $connection = $this->conection_create(
+            $type,
+            $proxy->getHost(),
+            $proxy->getPort(),
+            $options
+        );
+
+        $channel = $connection->channel();
+        $this->assertTrue($channel->is_open());
+
+        $exception = null;
+        // block and close connection after delay
+        $proxy->mode('timeout', array('timeout' => 100));
+        try {
+            $channel->wait(null, false, 1);
+        } catch (\Exception $exception) {
+        }
+
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPConnectionClosedException', $exception);
+        $this->assertChannelClosed($channel);
+        $this->assertConnectionClosed($connection);
+    }
+
+    /**
+     * Try to write(publish) to blocked(unresponsive) connection.
+     * @test
+     * @small
+     * @group connection
+     * @group proxy
+     * @testWith ["stream"]
+     *           ["socket"]
+     * @covers \PhpAmqpLib\Wire\IO\StreamIO::write()
+     * @covers \PhpAmqpLib\Wire\IO\SocketIO::write()
+     *
+     * @param string $type
+     */
+    public function must_throw_exception_broken_pipe_write($type)
+    {
+        $proxy = $this->create_proxy();
+
+        /** @var AbstractConnection $connection */
+        $connection = $this->conection_create(
+            $type,
+            $proxy->getHost(),
+            $proxy->getPort()
+        );
+
+        $channel = $connection->channel();
+        $this->assertTrue($channel->is_open());
+
+        $this->queue_bind($channel, $exchange_name = 'test_exchange_broken', $queue_name);
+        $message = new AMQPMessage(
+            str_repeat('0', 1024 * 32), // 32kb fills up buffer completely on most OS
+            ['delivery_mode' => AMQPMessage::DELIVERY_MODE_NON_PERSISTENT]
+        );
+
+        $exception = null;
+        // block proxy connection
+        $proxy->disable();
+
+        try {
+            $channel->basic_publish($message, $exchange_name, $queue_name);
+        } catch (\Exception $exception) {
+        }
+
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPConnectionClosedException', $exception);
+        $this->assertChannelClosed($channel);
+        $this->assertConnectionClosed($connection);
+    }
+
+    /**
+     * Try to close and reopen connection after timeout.
+     *
+     * @test
+     * @small
+     * @group connection
+     * @group proxy
+     * @testWith ["stream"]
+     *           ["socket"]
+     * @covers \PhpAmqpLib\Wire\IO\StreamIO::write()
+     * @covers \PhpAmqpLib\Wire\IO\SocketIO::write()
+     * @param string $type
+     */
+    public function must_throw_exception_after_connection_was_restored($type)
+    {
+        $timeout = 1;
+        $proxy = $this->create_proxy();
+        /** @var AbstractConnection $connection */
+        $connection = $this->conection_create(
+            $type,
+            $proxy->getHost(),
+            $proxy->getPort(),
+            array('timeout' => $timeout)
+        );
+
+        $channel = $connection->channel();
+        $this->assertTrue($channel->is_open());
+
+        $this->queue_bind($channel, $exchange_name = 'test_exchange_broken', $queue_name);
+        $message = new AMQPMessage(
+            str_repeat('0', 1024 * 32), // 32kb fills up buffer completely on most OS
+            ['delivery_mode' => AMQPMessage::DELIVERY_MODE_NON_PERSISTENT]
+        );
+        $channel->basic_publish($message, $exchange_name, $queue_name);
+
+        // close proxy and wait longer than timeout
+        unset($proxy);
+        sleep($timeout);
+        usleep(100000);
+        $proxy = $this->create_proxy();
+
+        $exception = null;
+        try {
+            $channel->basic_publish($message, $exchange_name, $queue_name);
+        } catch (\Exception $exception) {
+        }
+
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPConnectionClosedException', $exception);
+        $this->assertGreaterThan(0, $exception->getCode());
+        $this->assertChannelClosed($channel);
+        $this->assertConnectionClosed($connection);
+    }
+}

--- a/tests/Functional/Connection/ConnectionUnresponsiveTest.php
+++ b/tests/Functional/Connection/ConnectionUnresponsiveTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Connection;
+
+use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+
+class ConnectionUnresponsiveTest extends AbstractConnectionTest
+{
+    /**
+     * Use mocked write functions to simulate completely blocked connections.
+     * @test
+     * @small
+     * @group connection
+     * @testWith ["stream"]
+     *           ["socket"]
+     * @covers \PhpAmqpLib\Wire\IO\StreamIO::write()
+     * @covers \PhpAmqpLib\Wire\IO\SocketIO::write()
+     * @param string $type
+     */
+    public function must_throw_exception_on_completely_blocked_connection($type)
+    {
+        self::$blocked = false;
+        $connection = $this->conection_create($type);
+        $channel = $connection->channel();
+        $this->assertTrue($channel->is_open());
+        $this->queue_bind($channel, $exchange_name = 'test_exchange_broken', $queue_name);
+
+        self::$blocked = true;
+        $message = new AMQPMessage(
+            str_repeat('0', 8),
+            ['delivery_mode' => AMQPMessage::DELIVERY_MODE_NON_PERSISTENT]
+        );
+
+        $exception = null;
+        try {
+            $channel->basic_publish($message, $exchange_name, $queue_name);
+        } catch (\Exception $exception) {
+        }
+
+        self::$blocked = false;
+
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPTimeoutException', $exception);
+        $this->assertEquals(1, $exception->getTimeout());
+
+        $this->assertTrue($channel->is_open());
+        $this->assertTrue($connection->isConnected());
+    }
+}

--- a/tests/Functional/ToxiProxy.php
+++ b/tests/Functional/ToxiProxy.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional;
+
+use Httpful\Request;
+
+class ToxiProxy
+{
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $api;
+
+    /** @var string */
+    private $host;
+
+    /** @var int */
+    private $listen;
+
+    /**
+     * @param string $name
+     * @param string $host
+     * @param int $port
+     */
+    public function __construct($name, $host, $port = 8474)
+    {
+        $this->name = $name;
+        $this->host = $host;
+        $this->api = 'http://' . $host . ':' . $port;
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    /**
+     * Open new proxy connection to $upstream and listen on port $port.
+     * @param string $upstream
+     * @param int $listen
+     */
+    public function open($host, $port, $listen)
+    {
+        $payload = array(
+            'name' => $this->name,
+            'upstream' => $host . ':' . $port,
+            'listen' => ':' . $listen,
+        );
+        $url = $this->api . '/proxies';
+        $request = Request::post($url, json_encode($payload), 'json');
+        $request->timeout(1);
+        $request->expectsJson();
+        $response = $request->send();
+        if ($response->code !== 201) {
+            throw new \RuntimeException('Cannot create Toxiproxy connection');
+        }
+        $this->listen = $listen;
+    }
+
+    /**
+     * Enable proxy $type manipulation.
+     * @param $type One of latency, bandwidth, slow_close, timeout, slicer, limit_data
+     * @param array $attributes
+     * @param string $direction Either upstream or downstream.
+     * @param float $toxicity
+     * @see https://github.com/Shopify/toxiproxy#toxics
+     */
+    public function mode($type, $attributes = array(), $direction = 'upstream', $toxicity = 1.0)
+    {
+        $payload = [
+            'name' => null,
+            'stream' => $direction,
+            'type' => $type,
+            'toxicity' => $toxicity,
+            'attributes' => !empty($attributes) ? $attributes : null,
+        ];
+        $url = sprintf('%s/proxies/%s/toxics', $this->api, $this->name);
+        $request = Request::post($url, json_encode($payload), 'json');
+        $request->timeout(1);
+        $request->expectsJson();
+        $response = $request->send();
+
+        if ($response->code !== 200) {
+            throw new \RuntimeException('Cannot set Toxiproxy connection mode');
+        }
+    }
+
+    /**
+     * Disable(block) proxy connection so no data can be transferred.
+     * @throws \Httpful\Exception\ConnectionErrorException
+     */
+    public function disable()
+    {
+        $url = sprintf('%s/proxies/%s', $this->api, $this->name);
+        $response = Request::post($url, json_encode(array('enabled' => false)), 'json')->send();
+        if ($response->code !== 200) {
+            throw new \RuntimeException('Cannot disable Toxiproxy connection');
+        }
+    }
+
+    /**
+     * Completely close connection to upstream.
+     * @throws \Httpful\Exception\ConnectionErrorException
+     */
+    public function close()
+    {
+        $url = sprintf('%s/proxies/%s', $this->api, $this->name);
+        $response = Request::delete($url)->send();
+        if ($response->code !== 204 && $response->code !== 404) {
+            throw new \RuntimeException('Cannot close Toxiproxy connection');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPort()
+    {
+        return $this->listen;
+    }
+}


### PR DESCRIPTION
This adresses mostly broken connection handling and proper flag/variable cleanup.

* Handle various connection problems and throw AMQPConnectionClosedException
* Fix endless loop when writing to blocked stream, i.e. unresponsive vpn connection #624 
* Reset connection/channel state, clear callbacks so consumers knows when to stop waiting, allow reconnect, issue #389 
* Write data to socket/stream split in 8k chunks - improves stability and predictability for non-blocking connections
* replace socket_read with socket_recv because latter do not mix read data with syscall output therefore error handling becomes easier
* introduce https://github.com/Shopify/toxiproxy, add tests for blocked/closed connections, those skipped on travis cause need to figure out how to run proxy there
* minor non-functional & code style improvements

I know this one is quite big Nonetheless this would be good improvement for release 2.9.0