### PR TITLE
Throw exception if keepalive cannot be enabled on ssl connections

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -21,7 +21,10 @@ class AMQPSSLConnection extends AMQPStreamConnection
         $ssl_options = array(),
         $options = array()
     ) {
-        $ssl_context = empty($ssl_options) ? null : $this->create_ssl_context($ssl_options);
+        if (!isset($ssl_options['verify_peer'])) {
+            $ssl_options['verify_peer'] = true;
+        }
+        $ssl_context = $this->create_ssl_context($ssl_options);
         parent::__construct(
             $host,
             $port,
@@ -33,7 +36,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
             isset($options['login_response']) ? $options['login_response'] : null,
             isset($options['locale']) ? $options['locale'] : 'en_US',
             isset($options['connection_timeout']) ? $options['connection_timeout'] : 3,
-            isset($options['read_write_timeout']) ? $options['read_write_timeout'] : 3,
+            isset($options['read_write_timeout']) ? $options['read_write_timeout'] : 130,
             $ssl_context,
             isset($options['keepalive']) ? $options['keepalive'] : false,
             isset($options['heartbeat']) ? $options['heartbeat'] : 60


### PR DESCRIPTION
PHP cannot enable tcp keepalive feature on ssl connections due to bug https://bugs.php.net/bug.php?id=70939
No workaround exists so we should raise proper exception about incompatible options.

Always set verify_peer to true, to make sure behaviour is same for older PHP versions.

Fix wrong default read_write_timeout after #648 