### PR TITLE
Allow choosing a different protocol for SSL/TLS

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -19,7 +19,8 @@ class AMQPSSLConnection extends AMQPStreamConnection
         $password,
         $vhost = '/',
         $ssl_options = array(),
-        $options = array()
+        $options = array(),
+        $ssl_protocol = 'ssl'
     ) {
         if (!isset($ssl_options['verify_peer'])) {
             $ssl_options['verify_peer'] = true;
@@ -39,7 +40,9 @@ class AMQPSSLConnection extends AMQPStreamConnection
             isset($options['read_write_timeout']) ? $options['read_write_timeout'] : 130,
             $ssl_context,
             isset($options['keepalive']) ? $options['keepalive'] : false,
-            isset($options['heartbeat']) ? $options['heartbeat'] : 60
+            isset($options['heartbeat']) ? $options['heartbeat'] : 60,
+            isset($options['channel_rpc_timeout']) ? $options['channel_rpc_timeout'] : 0.0,
+            $ssl_protocol
         );
     }
 

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -37,7 +37,8 @@ class AMQPStreamConnection extends AbstractConnection
         $context = null,
         $keepalive = false,
         $heartbeat = 60,
-        $channel_rpc_timeout = 0.0
+        $channel_rpc_timeout = 0.0,
+        $ssl_protocol = null
     ) {
         if ($channel_rpc_timeout > $read_write_timeout) {
             throw new \InvalidArgumentException('channel RPC timeout must not be greater than I/O read-write timeout');
@@ -50,7 +51,8 @@ class AMQPStreamConnection extends AbstractConnection
             $read_write_timeout,
             $context,
             $keepalive,
-            $heartbeat
+            $heartbeat,
+            $ssl_protocol
         );
 
         parent::__construct(

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -44,7 +44,8 @@ class StreamIO extends AbstractIO
         $read_write_timeout = 130.0,
         $context = null,
         $keepalive = false,
-        $heartbeat = 60
+        $heartbeat = 60,
+        $ssl_protocol = null
     ) {
         if ($heartbeat !== 0 && ($read_write_timeout <= ($heartbeat * 2))) {
             throw new \InvalidArgumentException('read_write_timeout must be greater than 2x the heartbeat');
@@ -78,7 +79,11 @@ class StreamIO extends AbstractIO
 
         $options = stream_context_get_options($this->context);
         if (!empty($options['ssl'])) {
-            $this->protocol = 'ssl';
+            if (isset($ssl_protocol)) {
+                $this->protocol = $ssl_protocol;
+            } else {
+                $this->protocol = 'ssl';
+            }
         }
     }
 
@@ -364,6 +369,10 @@ class StreamIO extends AbstractIO
     {
         if ($this->protocol === 'ssl') {
             throw new AMQPIOException('Can not enable keepalive: ssl connection does not support keepalive (#70939)');
+        }
+
+        if ($this->protocol === 'tls') {
+            throw new AMQPIOException('Can not enable keepalive: tls connection does not support keepalive (#70939)');
         }
 
         if (!function_exists('socket_import_stream')) {


### PR DESCRIPTION
Fixes #641

Allows using tls, tlsv1.0, etc as an argument to AMQPSSLConnection ctor

@Cyrille37 please test this branch in your environment.