### PR TITLE
Fix wrong error code on stream connection exception

### DIFF
--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -175,8 +175,8 @@ class SocketIO extends AbstractIO
                     case SOCKET_ENETRESET:
                     case SOCKET_ECONNABORTED:
                     case SOCKET_ECONNRESET:
-                    case SOCKET_ETIMEDOUT:
                     case SOCKET_ECONNREFUSED:
+                    case SOCKET_ETIMEDOUT:
                         $this->close();
                         throw new AMQPConnectionClosedException(socket_strerror($code), $code, $e);
                     default:

--- a/tests/Functional/Bug/Bug256Test.php
+++ b/tests/Functional/Bug/Bug256Test.php
@@ -45,15 +45,19 @@ class Bug256Test extends AbstractConnectionTest
         if ($this->channel) {
             $this->channel->exchange_delete($this->exchangeName);
             $this->channel->close();
+            $this->channel = null;
         }
         if ($this->connection) {
             $this->connection->close();
+            $this->connection = null;
         }
         if ($this->channel2) {
             $this->channel2->close();
+            $this->channel2 = null;
         }
         if ($this->connection2) {
             $this->connection2->close();
+            $this->connection2 = null;
         }
     }
 

--- a/tests/Functional/Bug/Bug40Test.php
+++ b/tests/Functional/Bug/Bug40Test.php
@@ -41,9 +41,15 @@ class Bug40Test extends TestCase
         if ($this->channel) {
             $this->channel->exchange_delete($this->exchangeName);
             $this->channel->close();
+            $this->channel = null;
+        }
+        if ($this->channel2) {
+            $this->channel2->close();
+            $this->channel2 = null;
         }
         if ($this->connection) {
             $this->connection->close();
+            $this->connection = null;
         }
     }
 

--- a/tests/Functional/Bug/Bug458Test.php
+++ b/tests/Functional/Bug/Bug458Test.php
@@ -21,6 +21,12 @@ class Bug458Test extends TestCase
         $this->addSignalHandlers();
     }
 
+    protected function tearDown()
+    {
+        $this->channel->close();
+        $this->channel = null;
+    }
+
     /**
      * This test will be skipped in Windows, because pcntl extension is not available there
      *

--- a/tests/Functional/Bug/Bug49Test.php
+++ b/tests/Functional/Bug/Bug49Test.php
@@ -22,13 +22,19 @@ class Bug49Test extends TestCase
         $this->channel2 = $this->connection->channel();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
+        if ($this->channel) {
+            $this->channel->close();
+            $this->channel = null;
+        }
         if ($this->channel2) {
             $this->channel2->close();
+            $this->channel2 = null;
         }
         if ($this->connection) {
             $this->connection->close();
+            $this->connection = null;
         }
     }
 

--- a/tests/Functional/Channel/ChannelTestCase.php
+++ b/tests/Functional/Channel/ChannelTestCase.php
@@ -40,6 +40,8 @@ abstract class ChannelTestCase extends TestCase
     public function tearDown()
     {
         $this->channel->close();
+        $this->channel = null;
         $this->connection->close();
+        $this->connection = null;
     }
 }

--- a/tests/Functional/Channel/ChannelTimeoutTest.php
+++ b/tests/Functional/Channel/ChannelTimeoutTest.php
@@ -87,6 +87,8 @@ class ChannelTimeoutTest extends TestCase
     {
         parent::tearDown();
         $this->channel->close();
+        $this->channel = null;
         $this->connection->close();
+        $this->connection = null;
     }
 }

--- a/tests/Functional/Connection/ConnectionClosedTest.php
+++ b/tests/Functional/Connection/ConnectionClosedTest.php
@@ -57,6 +57,7 @@ class ConnectionClosedTest extends AbstractConnectionTest
 
         $this->assertInstanceOf('Exception', $exception);
         $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPConnectionClosedException', $exception);
+        $this->assertEquals(0, $exception->getCode());
         $this->assertChannelClosed($channel);
         $this->assertConnectionClosed($connection);
     }
@@ -105,6 +106,7 @@ class ConnectionClosedTest extends AbstractConnectionTest
 
         $this->assertInstanceOf('Exception', $exception);
         $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPConnectionClosedException', $exception);
+        $this->assertEquals(SOCKET_EPIPE, $exception->getCode());
         $this->assertChannelClosed($channel);
         $this->assertConnectionClosed($connection);
     }

--- a/tests/Functional/FileTransferTest.php
+++ b/tests/Functional/FileTransferTest.php
@@ -33,9 +33,11 @@ class FileTransferTest extends TestCase
         if ($this->channel) {
             $this->channel->exchange_delete($this->exchangeName);
             $this->channel->close();
+            $this->channel = null;
         }
         if ($this->connection) {
             $this->connection->close();
+            $this->connection = null;
         }
     }
 

--- a/tests/Functional/ReconnectConnectionTest.php
+++ b/tests/Functional/ReconnectConnectionTest.php
@@ -27,9 +27,11 @@ class ReconnectConnectionTest extends TestCase
             $this->channel->exchange_delete($this->exchange);
             $this->channel->queue_delete($this->queue);
             $this->channel->close();
+            $this->channel = null;
         }
         if ($this->connection) {
             $this->connection->close();
+            $this->connection = null;
         }
     }
 


### PR DESCRIPTION
* error number from stream connection warnings means error level, not actual error, so we must "extract" it from error message, fix regression after #653 on line:
https://github.com/php-amqplib/php-amqplib/pull/653/files#diff-593ddf6cbc93f7e4518ba0d20c13a8d7R250
* handle same kind of connection issues in both stream and socket connections
* fix unclean functional test tear down