### PR TITLE
Issue #672: Changes in SSL handling breaks bschmitt/laravel-amqp

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -22,7 +22,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
         $options = array(),
         $ssl_protocol = 'ssl'
     ) {
-        if (!isset($ssl_options['verify_peer'])) {
+        if (!empty($ssl_options) && !isset($ssl_options['verify_peer'])) {
             $ssl_options['verify_peer'] = true;
         }
         $ssl_context = $this->create_ssl_context($ssl_options);


### PR DESCRIPTION
Referring to issue https://github.com/php-amqplib/php-amqplib/issues/672

Automatically setting `$ssl_options['verify_peer'] = true` breaks `bschmitt/laravel-amqp` which sends empty ssl_options when ssl is not enabled. Setting verify_peer enforces `ssl` later in `PhpAmqpLib/Wire/IO/StreamIO.php` even if it is not what the user wants.

Simply checking if `$ssl_options` is defined fixes this problem.
