### PR TITLE
Revert default SSL options

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -11,6 +11,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
      * @param string $vhost
      * @param array $ssl_options
      * @param array $options
+     * @param string $ssl_protocol
      */
     public function __construct(
         $host,
@@ -22,10 +23,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
         $options = array(),
         $ssl_protocol = 'ssl'
     ) {
-        if (!isset($ssl_options['verify_peer'])) {
-            $ssl_options['verify_peer'] = true;
-        }
-        $ssl_context = $this->create_ssl_context($ssl_options);
+        $ssl_context = empty($ssl_options) ? null : $this->create_ssl_context($ssl_options);
         parent::__construct(
             $host,
             $port,


### PR DESCRIPTION
Introduced in #658, stream context is always SSL activated and causing some compatibility issues. This PR reverts that and allows AMQPSSLConnection to be insecure even if ssl protocol is `ssl` or `tls`. At least one option must be provided to activate secure context/connection.