### PR TITLE
Fix detection of a missed server heartbeat

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -603,7 +603,7 @@ class AbstractConnection extends AbstractChannel
             $wait_frame_timeout = $_timeout;
             // in case heartbeats are activated prevents waiting more than 2 times the heartbeat frame
             // otherwise we would never detect a missed server heartbeat
-            if($this->heartbeat && ($wait_frame_timeout === 0 || $wait_frame_timeout > $this->heartbeat * 2)) {
+            if($this->heartbeat && !is_null($timeout) && ((double) $wait_frame_timeout === 0.0 || $wait_frame_timeout > $this->heartbeat * 2)) {
                 $wait_frame_timeout = $this->heartbeat * 2 + 1;
             }
             try {


### PR DESCRIPTION
Hi,

We had issues on our infrastructure where the network connection between our consumers and RabbitMQ would get broken from time to time and our consumers wouldn't detect it.

## Issue

After those network interruptions RabbitMQ would show that the consumers were not connected anymore. An inspection of established connections with `netstat` in our consumers containers would show the following:
```bash
root@c0b3853ca0f2:/var/www/html# netstat -tn
Active Internet connections (w/o servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State
tcp        0      0 ***.**.*.*:41088        ***.**.*.**:5672        ESTABLISHED
tcp        0      0 ***.**.*.*:41214        ***.**.*.**:5672        ESTABLISHED
```
; meaning that, according to our consumers, their `IOStream` with RabbitMQ were sill opened. They were still waiting for server incoming messages - even tho they were receiving no heartbeat as we confirmed with `tcpdump`.

## How to reproduce

I found how to reproduce the issue on my local environment with a simple docker setup.
Launch a dummy consumer connected to a RabbitMQ instance.
The consumer must be configured to run indefinitely (see below).

We are using `php-amqplib/rabbitmq-bundle` for Symfony, and the following configuration:
```yaml
old_sound_rabbit_mq:
    connections:
        default:
            host:         ...
            port:         ...
            user:         ...
            password:     ...
            vhost:        ...
            read_write_timeout:     120
            heartbeat:              60
            lazy:                   true
    consumers:
        dummy:
            connection:           default
            exchange_options:     ...
            queue_options:        ...
            auto_setup_fabric:    false
            callback:             ...
```
As you can see, we are not using the `idle_timeout` option in our consumers meaning that they wait indefinitely for new messages and aren't restarted on a regular basis - this is how we would prefer it.

Launch the consumer:

```bash
bin/console rabbitmq:consumer --env=dev -n -w dummy --debug -vvv
```

Simply disconnect the RabbitMQ container from the docker network that links it to the consumer and see what happens.
```bash
docker network disconnect [network_name] [rabbitmq_container_name]
```

### What happens

The consumer keeps running even after twice the heartbeat frame.

### What should happen

The consumer should throw an `AMQPHeartbeatMissedException`.

## How I fixed it

In case the heartbeat feature is activated, and the `$timeout` sent in the `AbstractConnection::wait_frame` method is greater that twice the heartbeat frame, I have shortened the timeout to twice the heartbeat frame (see PR). Disclaimer: I just discovered the library and there maybe is a better way to implement it.

Thank you!