### PR TITLE
Fix to use of unquoted string that will be deprecated in future PHP v…

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -75,7 +75,7 @@ class StreamIO extends AbstractIO
         }
 
         if (!defined('SOCKET_EAGAIN')) {
-            define('SOCKET_EAGAIN', SOCKET_EWOULDBLOCK);
+            define('SOCKET_EAGAIN', 'SOCKET_EWOULDBLOCK');
         }
     }
 


### PR DESCRIPTION
…ersions

Fix for use of undefined constant (Unquoted string) that will be deprecated in future PHP versions.

https://php.net/manual/en/migration72.deprecated.php