### PR TITLE
getDeliveryTag method for AMQPMessage

### DIFF
--- a/PhpAmqpLib/Exception/AMQPEmptyDeliveryTagException.php
+++ b/PhpAmqpLib/Exception/AMQPEmptyDeliveryTagException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpAmqpLib\Exception;
+
+class AMQPEmptyDeliveryTagException extends AMQPRuntimeException
+{
+}

--- a/PhpAmqpLib/Message/AMQPMessage.php
+++ b/PhpAmqpLib/Message/AMQPMessage.php
@@ -117,4 +117,18 @@ class AMQPMessage extends GenericContent
 
         return $this;
     }
+
+    /**
+     * @return int
+     *
+     * @throws \PhpAmqpLib\Exception\AMQPEmptyDeliveryTagException
+     */
+    public function getDeliveryTag()
+    {
+        if (!isset($this->delivery_info['delivery_tag'])) {
+            throw new \PhpAmqpLib\Exception\AMQPEmptyDeliveryTagException();
+        }
+
+        return (int) $this->delivery_info['delivery_tag'];
+    }
 }

--- a/tests/Unit/Message/AMQPMessageTest.php
+++ b/tests/Unit/Message/AMQPMessageTest.php
@@ -44,6 +44,24 @@ class AMQPMessageTest extends TestCase
         $this->assertEquals($message->getContentEncoding(), 'shortstr');
     }
 
+    /**
+     * @test
+     */
+    public function get_delivery_tag()
+    {
+        $message = new AMQPMessage('');
+
+        $message->delivery_info['delivery_tag'] = "10";
+        $this->assertEquals(10, $message->getDeliveryTag());
+
+        $message->delivery_info['delivery_tag'] = 1231;
+        $this->assertEquals(1231, $message->getDeliveryTag());
+
+        unset($message->delivery_info['delivery_tag']);
+        $this->setExpectedException('\PhpAmqpLib\Exception\AMQPEmptyDeliveryTagException');
+        $message->getDeliveryTag();
+    }
+
     public function propertiesData()
     {
         return [


### PR DESCRIPTION
Pretty obvious PR. Added helper method for [RabbitMQ delivery tags](https://www.rabbitmq.com/confirms.html#consumer-acks-delivery-tags) + test. Casting it to int, because official docs says it's `monotonically growing positive integers`.