### PR TITLE
fix call to a member function o null when connection was closed

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -2,6 +2,7 @@
 namespace PhpAmqpLib\Channel;
 
 use PhpAmqpLib\Exception\AMQPBasicCancelException;
+use PhpAmqpLib\Exception\AMQPChannelClosedException;
 use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
@@ -1156,6 +1157,9 @@ class AMQPChannel extends AbstractChannel
         $immediate = false,
         $ticket = null
     ) {
+        if ($this->connection === null) {
+            throw new AMQPChannelClosedException('Channel connection is closed.');
+        }
         $pkt = new AMQPWriter();
         $pkt->write($this->pre_publish($exchange, $routing_key, $mandatory, $immediate, $ticket));
 

--- a/tests/Functional/Connection/ConnectionClosedTest.php
+++ b/tests/Functional/Connection/ConnectionClosedTest.php
@@ -104,11 +104,18 @@ class ConnectionClosedTest extends AbstractConnectionTest
         } catch (\Exception $exception) {
         }
 
-        $this->assertInstanceOf('Exception', $exception);
         $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPConnectionClosedException', $exception);
         $this->assertEquals(SOCKET_EPIPE, $exception->getCode());
         $this->assertChannelClosed($channel);
         $this->assertConnectionClosed($connection);
+
+        // 2nd publish call must return exception instantly cause connection is already closed
+        $exception = null;
+        try {
+            $channel->basic_publish($message, $exchange_name, $queue_name);
+        } catch (\Exception $exception) {
+        }
+        $this->assertInstanceOf('PhpAmqpLib\Exception\AMQPChannelClosedException', $exception);
     }
 
     /**


### PR DESCRIPTION
Fix for #698 
throws AMQPChannelClosedException like in other methods with same exception message.