### PR TITLE
Set minimum PHP version to 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 This library is a _pure PHP_ implementation of the [AMQP 0-9-1 protocol](http://www.rabbitmq.com/tutorials/amqp-concepts.html).
 It's been tested against [RabbitMQ](http://www.rabbitmq.com/).
 
-**Requirements: PHP 5.3** due to the use of `namespaces`.
-
 **Requirements: bcmath extension** This library utilizes the bcmath PHP extension. The installation steps vary per PHP version and the underlying OS. The following example shows how to add to an existing PHP installation on Ubuntu 15.10:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6",
         "ext-bcmath": "*",
         "ext-sockets": "*"
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8|^5.7",
         "squizlabs/php_codesniffer": "^2.5",
         "phpdocumentor/phpdocumentor": "^2.9",
         "nategood/httpful": "^0.2.20"
@@ -54,7 +54,7 @@
     "license": "LGPL-2.1-or-later",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.8-dev"
+            "dev-master": "2.10-dev"
         }
     }
 }

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.4-cli
+FROM php:5.6-cli
 
 RUN apt update && \
     apt -qy install git unzip zlib1g-dev && \


### PR DESCRIPTION
Old supported versions like 5.4 and 5.5 became unpopular and rarely used. According to packagist statistics[1] only 1.5% of all installs use PHP 5.5, 5.4 less than 1%. Meanwhile 5.5 and 5.6 has some very nice improvements and features like generators, finally keyword, support for constant array/string dereferencing and scalar class names via constant ::class.

[1] https://blog.packagist.com/php-versions-stats-2019-1-edition/
[2] https://www.php.net/releases/5_5_0.php
[3] https://www.php.net/releases/5_6_0.php