### PR TITLE
Install RabbitMQ package before travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ matrix:
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
+
 cache:
   directories:
     - $HOME/.composer


### PR DESCRIPTION
According to travis-ci docs:
> RabbitMQ can be launched on Ubuntu Xenial using the APT addon in .travis.yml

and by default it is not enabled anymore. This is reason why recent build fails.