### PR TITLE
Don't disguise socket read timeout as missed heartbeat

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -605,7 +605,7 @@ class AbstractConnection extends AbstractChannel
             try {
                 list($frame_type, $frame_channel, $payload) = $this->wait_frame($_timeout);
             } catch (AMQPTimeoutException $e) {
-                if ( $this->heartbeat && microtime(true) - ($this->heartbeat*2) > $this->last_frame ) {
+                if ( $this->heartbeat && $this->last_frame !== null && microtime(true) - ($this->heartbeat*2) > $this->last_frame ) {
                     $this->debug->debug_msg("missed server heartbeat (at threshold * 2)");
                     $this->setIsConnected(false);
                     throw new AMQPHeartbeatMissedException("Missed server heartbeat");


### PR DESCRIPTION
Fixes #713

This change changes
`PHP Fatal error:  Uncaught exception 'PhpAmqpLib\Exception\AMQPHeartbeatMissedException' with message 'Missed server heartbeat'`
to
`PHP Fatal error:  Uncaught exception 'PhpAmqpLib\Exception\AMQPTimeoutException' with message 'The connection timed out after 3 sec while awaiting incoming data' in PhpAmqpLib/Wire/AMQPReader.php:142`

I would try to implement a test for this, but CONTRIBUTING.md does not explain how to setup ToxiProxy.

The same patch (amongst other things) was proposed at https://github.com/php-amqplib/php-amqplib/pull/678/files#diff-46e92955bdff3b3f843a50f6344bd32fR606