### PR TITLE
Fix wrong exception type on failed connect to broker

### DIFF
--- a/tests/Functional/AbstractConnectionTest.php
+++ b/tests/Functional/AbstractConnectionTest.php
@@ -27,6 +27,7 @@ abstract class AbstractConnectionTest extends TestCase
         $keepalive = isset($options['keepalive']) ? $options['keepalive'] : false;
         $heartbeat = isset($options['heartbeat']) ? $options['heartbeat'] : 0;
         $timeout = isset($options['timeout']) ? $options['timeout'] : 1;
+        $connectionTimeout = isset($options['connectionTimeout']) ? $options['connectionTimeout'] : $timeout;
 
         switch ($type) {
             case 'stream':
@@ -40,7 +41,7 @@ abstract class AbstractConnectionTest extends TestCase
                     'AMQPLAIN',
                     null,
                     'en_US',
-                    $timeout,
+                    $connectionTimeout,
                     $timeout,
                     null,
                     $keepalive,


### PR DESCRIPTION
Initialize variable AbstractConnection->last_frame and prevent from wrong exception type when client can't get response from broker.
Fix for #713 