### PR TITLE
Adapt to PHPUnit 8

### DIFF
--- a/tests/Functional/Bug/Bug256Test.php
+++ b/tests/Functional/Bug/Bug256Test.php
@@ -26,7 +26,7 @@ class Bug256Test extends AbstractConnectionTest
 
     protected $channel2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = $this->conection_create('socket');
         $this->channel = $this->connection->channel();
@@ -40,7 +40,7 @@ class Bug256Test extends AbstractConnectionTest
         $this->channel2->queue_bind($this->queueName, $this->exchangeName, $this->queueName);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->channel) {
             $this->channel->exchange_delete($this->exchangeName);

--- a/tests/Functional/Bug/Bug40Test.php
+++ b/tests/Functional/Bug/Bug40Test.php
@@ -23,7 +23,7 @@ class Bug40Test extends TestCase
 
     protected $channel2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
         $this->channel = $this->connection->channel();
@@ -36,7 +36,7 @@ class Bug40Test extends TestCase
         $this->channel->queue_bind($this->queueName2, $this->exchangeName, $this->queueName2);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->channel) {
             $this->channel->exchange_delete($this->exchangeName);

--- a/tests/Functional/Bug/Bug458Test.php
+++ b/tests/Functional/Bug/Bug458Test.php
@@ -9,7 +9,7 @@ class Bug458Test extends TestCase
 {
     private $channel;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!extension_loaded('pcntl')) {
             $this->markTestSkipped('pcntl extension is not available');
@@ -21,7 +21,7 @@ class Bug458Test extends TestCase
         $this->addSignalHandlers();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->channel && $this->channel->is_open()) {
             $this->channel->close();

--- a/tests/Functional/Bug/Bug49Test.php
+++ b/tests/Functional/Bug/Bug49Test.php
@@ -15,14 +15,14 @@ class Bug49Test extends TestCase
 
     protected $channel2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
         $this->channel = $this->connection->channel();
         $this->channel2 = $this->connection->channel();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->channel) {
             $this->channel->close();

--- a/tests/Functional/Channel/ChannelTestCase.php
+++ b/tests/Functional/Channel/ChannelTestCase.php
@@ -24,7 +24,7 @@ abstract class ChannelTestCase extends TestCase
     /** @var object */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = new AMQPSocketConnection(HOST, PORT, USER, PASS, VHOST);
 
@@ -44,7 +44,7 @@ abstract class ChannelTestCase extends TestCase
         ];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->channel->close();
         $this->channel = null;

--- a/tests/Functional/Channel/ChannelTimeoutTest.php
+++ b/tests/Functional/Channel/ChannelTimeoutTest.php
@@ -28,7 +28,7 @@ class ChannelTimeoutTest extends TestCase
     /** @var AMQPChannel $channel */
     private $channel;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -83,7 +83,7 @@ class ChannelTimeoutTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->channel->close();

--- a/tests/Functional/Channel/DirectExchangeTest.php
+++ b/tests/Functional/Channel/DirectExchangeTest.php
@@ -7,7 +7,7 @@ use PhpAmqpLib\Tests\Functional\Channel\ChannelTestCase;
 
 class DirectExchangeTest extends ChannelTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Functional/Channel/HeadersExchangeTest.php
+++ b/tests/Functional/Channel/HeadersExchangeTest.php
@@ -7,7 +7,7 @@ use PhpAmqpLib\Wire\AMQPTable;
 
 class HeadersExchangeTest extends ChannelTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->exchange->name = 'amq.headers';

--- a/tests/Functional/Channel/TopicExchangeTest.php
+++ b/tests/Functional/Channel/TopicExchangeTest.php
@@ -8,7 +8,7 @@ use PhpAmqpLib\Tests\Functional\Channel\ChannelTestCase;
 
 class TopicExchangeTest extends ChannelTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Functional/FileTransferTest.php
+++ b/tests/Functional/FileTransferTest.php
@@ -19,7 +19,7 @@ class FileTransferTest extends TestCase
 
     protected $messageBody;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connection = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
         $this->channel = $this->connection->channel();
@@ -28,7 +28,7 @@ class FileTransferTest extends TestCase
         $this->channel->queue_bind($this->queueName, $this->exchangeName, $this->queueName);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->channel) {
             $this->channel->exchange_delete($this->exchangeName);

--- a/tests/Functional/ReconnectConnectionTest.php
+++ b/tests/Functional/ReconnectConnectionTest.php
@@ -21,7 +21,7 @@ class ReconnectConnectionTest extends TestCase
 
     protected $msgBody = 'foo bar baz äëïöü';
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->channel) {
             $this->channel->exchange_delete($this->exchange);

--- a/tests/Unit/Helper/Protocol/Protocol091Test.php
+++ b/tests/Unit/Helper/Protocol/Protocol091Test.php
@@ -9,7 +9,7 @@ class Protocol091Test extends TestCase
 {
     protected $protocol091;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->protocol091 = new Protocol091();
     }

--- a/tests/Unit/Wire/AMQPReaderTest.php
+++ b/tests/Unit/Wire/AMQPReaderTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class AMQPReaderTest extends TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setProtoVersion(Wire\Constants091::VERSION);
     }
@@ -21,7 +21,7 @@ class AMQPReaderTest extends TestCase
         $r->setValue(null, $proto);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 

--- a/tests/Unit/Wire/AMQPWriterTest.php
+++ b/tests/Unit/Wire/AMQPWriterTest.php
@@ -12,13 +12,13 @@ class AMQPWriterTest extends TestCase
 {
     protected $writer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setProtoVersion(Wire\Constants091::VERSION);
         $this->writer = new AMQPWriter();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->setProtoVersion(AMQPArray::PROTOCOL_RBT);
         $this->writer = null;


### PR DESCRIPTION
Following up on https://github.com/php-amqplib/php-amqplib/pull/657. These changes are not usable as-is as long as PHP 5 is still supported.