### PR TITLE
Wrapper for sockets extension constants

### DIFF
--- a/PhpAmqpLib/Helper/SocketConstants.php
+++ b/PhpAmqpLib/Helper/SocketConstants.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace PhpAmqpLib\Helper;
+
+/**
+  * @property-read int SOCKET_EPIPE
+ * @property-read int SOCKET_ENETDOWN
+ * @property-read int SOCKET_ENETUNREACH
+ * @property-read int SOCKET_ENETRESET
+ * @property-read int SOCKET_ECONNABORTED
+ * @property-read int SOCKET_ECONNRESET
+ * @property-read int SOCKET_ECONNREFUSED
+ * @property-read int SOCKET_ETIMEDOUT
+ * @property-read int SOCKET_EWOULDBLOCK
+ * @property-read int SOCKET_EINTR
+ * @property-read int SOCKET_EAGAIN
+ */
+final class SocketConstants
+{
+    /**
+     * @var int[]
+     */
+    private $constants;
+
+    /** @var self */
+    private static $instance;
+
+    public function __construct()
+    {
+        $constants = get_defined_constants(true);
+        if (isset($constants['sockets'])) {
+            $this->constants = $constants['sockets'];
+        } else {
+            trigger_error('Sockets extension is not enabled', E_USER_WARNING);
+            $this->constants = array();
+        }
+    }
+
+    /**
+     * @param string $name
+     * @return int
+     */
+    public function __get($name)
+    {
+        return isset($this->constants[$name]) ? $this->constants[$name] : 0;
+    }
+
+    /**
+     * @param string $name
+     * @param int $value
+     * @internal
+     */
+    public function __set($name, $value)
+    {
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        return isset($this->constants[$name]);
+    }
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (!self::$instance) {
+            self::$instance = new self;
+        }
+
+        return self::$instance;
+    }
+}

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -6,6 +6,7 @@ use PhpAmqpLib\Exception\AMQPIOException;
 use PhpAmqpLib\Exception\AMQPSocketException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Helper\MiscHelper;
+use PhpAmqpLib\Helper\SocketConstants;
 
 class SocketIO extends AbstractIO
 {
@@ -172,15 +173,16 @@ class SocketIO extends AbstractIO
                 $this->cleanup_error_handler();
             } catch (\ErrorException $e) {
                 $code = socket_last_error($this->sock);
+                $constants = SocketConstants::getInstance();
                 switch ($code) {
-                    case SOCKET_EPIPE:
-                    case SOCKET_ENETDOWN:
-                    case SOCKET_ENETUNREACH:
-                    case SOCKET_ENETRESET:
-                    case SOCKET_ECONNABORTED:
-                    case SOCKET_ECONNRESET:
-                    case SOCKET_ECONNREFUSED:
-                    case SOCKET_ETIMEDOUT:
+                    case $constants->SOCKET_EPIPE:
+                    case $constants->SOCKET_ENETDOWN:
+                    case $constants->SOCKET_ENETUNREACH:
+                    case $constants->SOCKET_ENETRESET:
+                    case $constants->SOCKET_ECONNABORTED:
+                    case $constants->SOCKET_ECONNRESET:
+                    case $constants->SOCKET_ECONNREFUSED:
+                    case $constants->SOCKET_ETIMEDOUT:
                         $this->close();
                         throw new AMQPConnectionClosedException(socket_strerror($code), $code, $e);
                     default:
@@ -265,8 +267,9 @@ class SocketIO extends AbstractIO
      */
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
+        $constants = SocketConstants::getInstance();
         // socket_select warning that it has been interrupted by a signal - EINTR
-        if (false !== strrpos($errstr, socket_strerror(SOCKET_EINTR))) {
+        if (isset($constants->SOCKET_EINTR) && false !== strrpos($errstr, socket_strerror($constants->SOCKET_EINTR))) {
             // it's allowed while processing signals
             return;
         }

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -7,6 +7,7 @@ use PhpAmqpLib\Exception\AMQPIOException;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Helper\MiscHelper;
+use PhpAmqpLib\Helper\SocketConstants;
 
 class StreamIO extends AbstractIO
 {
@@ -72,10 +73,6 @@ class StreamIO extends AbstractIO
             } else {
                 $this->protocol = 'ssl';
             }
-        }
-
-        if (!defined('SOCKET_EAGAIN')) {
-            define('SOCKET_EAGAIN', SOCKET_EWOULDBLOCK);
         }
     }
 
@@ -243,15 +240,16 @@ class StreamIO extends AbstractIO
                 $this->cleanup_error_handler();
             } catch (\ErrorException $e) {
                 $code = $this->last_error['errno'];
+                $constants = SocketConstants::getInstance();
                 switch ($code) {
-                    case SOCKET_EPIPE:
-                    case SOCKET_ENETDOWN:
-                    case SOCKET_ENETUNREACH:
-                    case SOCKET_ENETRESET:
-                    case SOCKET_ECONNABORTED:
-                    case SOCKET_ECONNRESET:
-                    case SOCKET_ECONNREFUSED:
-                    case SOCKET_ETIMEDOUT:
+                    case $constants->SOCKET_EPIPE:
+                    case $constants->SOCKET_ENETDOWN:
+                    case $constants->SOCKET_ENETUNREACH:
+                    case $constants->SOCKET_ENETRESET:
+                    case $constants->SOCKET_ECONNABORTED:
+                    case $constants->SOCKET_ECONNRESET:
+                    case $constants->SOCKET_ECONNREFUSED:
+                    case $constants->SOCKET_ETIMEDOUT:
                         $this->close();
                         throw new AMQPConnectionClosedException(socket_strerror($code), $code, $e);
                     default:
@@ -291,12 +289,13 @@ class StreamIO extends AbstractIO
     public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
         $code = $this->extract_error_code($errstr);
+        $constants = SocketConstants::getInstance();
         switch ($code) {
             // fwrite notice that the stream isn't ready - EAGAIN or EWOULDBLOCK
-            case SOCKET_EAGAIN:
-            case SOCKET_EWOULDBLOCK:
+            case $constants->SOCKET_EAGAIN:
+            case $constants->SOCKET_EWOULDBLOCK:
             // stream_select warning that it has been interrupted by a signal - EINTR
-            case SOCKET_EINTR:
+            case $constants->SOCKET_EINTR:
                 return;
         }
 


### PR DESCRIPTION
This wrapper for sockets extension constants helps to avoid warnings when some constants are not defined in various operating systems or PHP versions.

Triggers warning when sockets extension is not enabled and user will be informed about it. Prevents from cases like #705.

Also there is no need to manually define constants which can cause weird conflicts with other libraries.

Fix #723