### PR TITLE
Fix fatal error in skipped tests

### DIFF
--- a/tests/Functional/Bug/Bug458Test.php
+++ b/tests/Functional/Bug/Bug458Test.php
@@ -9,7 +9,7 @@ class Bug458Test extends TestCase
 {
     private $channel;
 
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('pcntl')) {
             $this->markTestSkipped('pcntl extension is not available');
@@ -23,7 +23,9 @@ class Bug458Test extends TestCase
 
     protected function tearDown()
     {
-        $this->channel->close();
+        if ($this->channel && $this->channel->is_open()) {
+            $this->channel->close();
+        }
         $this->channel = null;
     }
 


### PR DESCRIPTION
This test always calls `$this->channel->close()` even if it is skipped due to missing pcntl extension or failed connection to broker. Exception message:
```
PHP Fatal error:  Call to a member function close() on null in .../php-amqplib/php-amqplib/tests/Functional/Bug/Bug458Test.php on line 26
```

Affects mostly windows and macos operating systems.