### PR TITLE
Allow cluster support for AMQPLazyConnection by re-initializing StreamIO on node failure

### DIFF
--- a/PhpAmqpLib/Connection/AMQPLazyConnection.php
+++ b/PhpAmqpLib/Connection/AMQPLazyConnection.php
@@ -69,6 +69,16 @@ class AMQPLazyConnection extends AMQPStreamConnection
      */
     protected function connect()
     {
+        if ($this->isConnected()) {
+            return;
+        }
+
+        // only when using AbstractConnection::create_connection for cluster support, allow multiple hosts
+        if (!self::$hosts)
+        {
+            return parent::connect();
+        }
+
         $latest_exception = null;
         foreach (self::$hosts as $hostdef) {
             try {

--- a/PhpAmqpLib/Connection/AMQPLazyConnection.php
+++ b/PhpAmqpLib/Connection/AMQPLazyConnection.php
@@ -1,6 +1,9 @@
 <?php
 namespace PhpAmqpLib\Connection;
 
+use PhpAmqpLib\Wire\IO\StreamIO;
+use PhpAmqpLib\Exception\AMQPIOException;
+
 class AMQPLazyConnection extends AMQPStreamConnection
 {
     /**
@@ -45,5 +48,50 @@ class AMQPLazyConnection extends AMQPStreamConnection
     public function connectOnConstruct()
     {
         return false;
+    }
+
+    /** keep track of the original host configuration */
+    private static $hosts = [];
+    private static $options = [];
+    public static function create_connection($hosts, $options = array())
+    {
+        self::$hosts = $hosts;
+        self::$options = $options;
+
+        return parent::create_connection($hosts, $options);
+    }
+
+    /**
+     * When performing an actual connect, allow cluster support for different nodes
+     *
+     * Known limitation: cluster nodes require the same user, pass and vhost since we are only reinitializing the
+     * IO-layer here, not the connection object
+     */
+    protected function connect()
+    {
+        $latest_exception = null;
+        foreach (self::$hosts as $hostdef) {
+            try {
+                AbstractConnection::validate_host($hostdef);
+                $host = $hostdef['host'];
+                $port = $hostdef['port'];
+
+                $this->io = new StreamIO(
+                    $host,
+                    $port,
+                    isset($this->construct_params[9]) ? $this->construct_params[9] : 3.0,
+                    isset($this->construct_params[10]) ? $this->construct_params[10] : 3.0,
+                    isset($this->construct_params[11]) ? $this->construct_params[11] : null,
+                    isset($this->construct_params[12]) ? $this->construct_params[12] : false,
+                    isset($this->construct_params[13]) ? $this->construct_params[13] : 0,
+                    isset($this->construct_params[15]) ? $this->construct_params[15] : null
+                );
+
+                return parent::connect();
+            } catch(AMQPIOException $e) {
+                $latest_exception = $e;
+            }
+        }
+        throw $latest_exception;
     }
 }

--- a/PhpAmqpLib/Connection/AMQPLazyConnection.php
+++ b/PhpAmqpLib/Connection/AMQPLazyConnection.php
@@ -50,7 +50,7 @@ class AMQPLazyConnection extends AMQPStreamConnection
         return false;
     }
 
-    /** keep track of the original host configuration */
+    /** keep track of the original hosts configuration */
     private static $hosts = [];
     private static $options = [];
     public static function create_connection($hosts, $options = array())

--- a/tests/Functional/Connection/AMQPLazyConnectionTest.php
+++ b/tests/Functional/Connection/AMQPLazyConnectionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Connection;
+
+use PhpAmqpLib\Connection\AMQPLazyConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+
+class AMQPLazyConnectionTest extends AbstractConnectionTest
+{
+    /** @test */
+    public function it_should_fallback_to_second_node_on_first_node_failure()
+    {
+        $connection = AMQPLazyConnection::create_connection([
+            [
+                'host' => HOST,
+                'port' => '5671', // nothing here, node down...
+                'vhost' => VHOST,
+                'user' => USER,
+                'password' => PASS,
+            ],
+            [
+                'host' => HOST,
+                'port' => PORT,
+                'vhost' => VHOST,
+                'user' => USER,
+                'password' => PASS,
+            ],
+        ]);
+
+        $channel = $connection->channel();
+        $this->queue_bind($channel, $exchange_name = 'test_exchange', $queue_name);
+        $message = new AMQPMessage('', ['content_type' => 'application/json']);
+        $channel->basic_publish($message, $exchange_name, $queue_name);
+    }
+}

--- a/tests/Functional/Connection/AMQPLazyConnectionTest.php
+++ b/tests/Functional/Connection/AMQPLazyConnectionTest.php
@@ -2,8 +2,8 @@
 
 namespace PhpAmqpLib\Tests\Functional\Connection;
 
+use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
-use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
 
 class AMQPLazyConnectionTest extends AbstractConnectionTest
@@ -27,10 +27,9 @@ class AMQPLazyConnectionTest extends AbstractConnectionTest
                 'password' => PASS,
             ],
         ]);
+        assert($connection instanceof AMQPLazyConnection);
 
         $channel = $connection->channel();
-        $this->queue_bind($channel, $exchange_name = 'test_exchange', $queue_name);
-        $message = new AMQPMessage('', ['content_type' => 'application/json']);
-        $channel->basic_publish($message, $exchange_name, $queue_name);
+        $this->assertInstanceOf(AMQPChannel::class, $channel);
     }
 }

--- a/tests/Functional/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Functional/Connection/AMQPStreamConnectionTest.php
@@ -13,14 +13,14 @@ class AMQPStreamConnectionTest extends AbstractConnectionTest
         $connection = AMQPStreamConnection::create_connection([
             [
                 'host' => HOST,
-                'port' => '5671',
+                'port' => '5671', // / nothing here, node down...
                 'vhost' => VHOST,
                 'user' => USER,
                 'password' => PASS,
             ],
             [
                 'host' => HOST,
-                'port' => '5672',
+                'port' => PORT,
                 'vhost' => VHOST,
                 'user' => USER,
                 'password' => PASS,

--- a/tests/Functional/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Functional/Connection/AMQPStreamConnectionTest.php
@@ -4,6 +4,7 @@ namespace PhpAmqpLib\Tests\Functional\Connection;
 
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+use PhpAmqpLib\Channel\AMQPChannel;
 
 class AMQPStreamConnectionTest extends AbstractConnectionTest
 {

--- a/tests/Functional/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Functional/Connection/AMQPStreamConnectionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Connection;
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+
+class AMQPStreamConnectionTest extends AbstractConnectionTest
+{
+    /** @test */
+    public function it_should_fallback_to_second_node_on_first_node_failure()
+    {
+        $connection = AMQPStreamConnection::create_connection([
+            [
+                'host' => HOST,
+                'port' => '5671',
+                'vhost' => VHOST,
+                'user' => USER,
+                'password' => PASS,
+            ],
+            [
+                'host' => HOST,
+                'port' => '5672',
+                'vhost' => VHOST,
+                'user' => USER,
+                'password' => PASS,
+            ],
+        ]);
+
+        $channel = $connection->channel();
+        $this->queue_bind($channel, $exchange_name = 'test_exchange', $queue_name);
+        $message = new AMQPMessage('', ['content_type' => 'application/json']);
+        $channel->basic_publish($message, $exchange_name, $queue_name);
+    }
+}

--- a/tests/Functional/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Functional/Connection/AMQPStreamConnectionTest.php
@@ -3,7 +3,6 @@
 namespace PhpAmqpLib\Tests\Functional\Connection;
 
 use PhpAmqpLib\Connection\AMQPStreamConnection;
-use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
 
 class AMQPStreamConnectionTest extends AbstractConnectionTest
@@ -29,8 +28,6 @@ class AMQPStreamConnectionTest extends AbstractConnectionTest
         ]);
 
         $channel = $connection->channel();
-        $this->queue_bind($channel, $exchange_name = 'test_exchange', $queue_name);
-        $message = new AMQPMessage('', ['content_type' => 'application/json']);
-        $channel->basic_publish($message, $exchange_name, $queue_name);
+        $this->assertInstanceOf(AMQPChannel::class, $channel);
     }
 }


### PR DESCRIPTION
This PR aims to allow AMQPLazyConnection to support RabbitMQ clusters (multiple hosts).

Since AMQPLazyConnection does not connect on construct, support for multiple hosts was not available here. By catching failures on (actual) connect, we try to re-initialize IO, allowing to connect to other nodes.

Important: since `user`, `pass` and `vhost` are stored on the `AbstractConnection` object and we are only re-initializing IO, this will only work if different nodes have the same credentials. (which is most likely the case)

In order to run the included extra tests successfully, the rabbitmq node defined in docker-compose needs to be running.