### PR TITLE
Remove phpDocumentator from dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 phpunit.xml
 build/
 docs/
+phpDocumentor.phar

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ test:
 	./vendor/bin/phpunit
 .PHONY: docs
 docs:
-	./vendor/bin/phpdoc --template=responsive-twig --defaultpackagename=PhpAmqpLib --title='php-amqplib' -d ./PhpAmqpLib -t ./docs
+	wget -qN https://github.com/phpDocumentor/phpDocumentor2/releases/download/v2.9.0/phpDocumentor.phar
+	php ./phpDocumentor.phar --template=responsive-twig --defaultpackagename=PhpAmqpLib --title='php-amqplib' -d ./PhpAmqpLib -t ./docs
 .PHONY: benchmark
 benchmark:
 	@echo "Publishing 4000 msgs with 1KB of content:"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "ext-curl": "*",
         "phpunit/phpunit": "^5.7|^6.5|^7.0",
         "squizlabs/php_codesniffer": "^2.5",
-        "phpdocumentor/phpdocumentor": "dev-master",
         "nategood/httpful": "^0.2.20"
     },
     "autoload": {


### PR DESCRIPTION
Let's remove rarely used phpDocumentator and long list of conflicting dependencies. We can download this tool on demand, just before documentation is being generated.
Improves CI build time.