### PR TITLE
Add support for PLAIN authentication method

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -13,7 +13,7 @@ class AMQPSocketConnection extends AbstractConnection
      * @param string $vhost
      * @param bool $insist
      * @param string $login_method
-     * @param null $login_response
+     * @param null $login_response @deprecated
      * @param string $locale
      * @param float $read_timeout
      * @param bool $keepalive

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -13,7 +13,7 @@ class AMQPStreamConnection extends AbstractConnection
      * @param string $vhost
      * @param bool $insist
      * @param string $login_method
-     * @param null $login_response
+     * @param null $login_response @deprecated
      * @param string $locale
      * @param float $connection_timeout
      * @param float $read_write_timeout

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     entrypoint: ['tail', '-f', '/dev/null']
 
   rabbitmq:
-    image: rabbitmq:latest
+    image: rabbitmq:3-management
     ports:
       - "5672:5672"
 

--- a/tests/Functional/Channel/DirectExchangeTest.php
+++ b/tests/Functional/Channel/DirectExchangeTest.php
@@ -22,7 +22,7 @@ class DirectExchangeTest extends ChannelTestCase
     {
         $this->connection->close();
 
-        $this->channel->exchange_declare($this->exchange->name, 'direct', false, true, false);
+        $this->channel->exchange_declare($this->exchange->name, 'direct', false, false, false);
     }
 
     /**
@@ -33,7 +33,7 @@ class DirectExchangeTest extends ChannelTestCase
     {
         $this->channel->close();
 
-        $this->channel->exchange_declare($this->exchange->name, 'direct', false, true, false);
+        $this->channel->exchange_declare($this->exchange->name, 'direct', false, false, false);
     }
 
     /**

--- a/tests/Functional/Channel/TopicExchangeTest.php
+++ b/tests/Functional/Channel/TopicExchangeTest.php
@@ -23,7 +23,7 @@ class TopicExchangeTest extends ChannelTestCase
     {
         $this->connection->close();
 
-        $this->channel->exchange_declare($this->exchange->name, 'topic', false, true, false);
+        $this->channel->exchange_declare($this->exchange->name, 'topic');
     }
 
     /**
@@ -34,7 +34,7 @@ class TopicExchangeTest extends ChannelTestCase
     {
         $this->channel->close();
 
-        $this->channel->exchange_declare($this->exchange->name, 'topic', false, true, false);
+        $this->channel->exchange_declare($this->exchange->name, 'topic');
     }
 
     /**
@@ -42,7 +42,7 @@ class TopicExchangeTest extends ChannelTestCase
      */
     public function publish_with_confirm()
     {
-        $this->channel->exchange_declare($this->exchange->name, 'topic', false);
+        $this->channel->exchange_declare($this->exchange->name, 'topic');
 
         $deliveryTags = [];
 

--- a/tests/Functional/Connection/ConnectionAuthTest.php
+++ b/tests/Functional/Connection/ConnectionAuthTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Connection;
+
+use Httpful\Exception\ConnectionErrorException;
+use Httpful\Request;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Exception\AMQPExceptionInterface;
+use PhpAmqpLib\Exception\AMQPTimeoutException;
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+
+class ConnectionAuthTest extends AbstractConnectionTest
+{
+    /**
+     * @test
+     * @group connection
+     * @covers \PhpAmqpLib\Connection\AbstractConnection::__construct()
+     *
+     */
+    public function plain_auth_passwordless_must_fail()
+    {
+        $username = 'test_' . rand();
+        // Setting password_hash to "" will ensure the user cannot use a password to log in
+        $this->createUser($username, '');
+
+        try {
+            $connection = new AMQPStreamConnection(HOST, PORT, $username, '', '/', false, 'PLAIN', null, 'en_US', 1);
+            $this->assertInstanceOf(AMQPStreamConnection::class, $connection);
+            $this->assertTrue($connection->isConnected());
+        } catch (AMQPExceptionInterface $exception) {
+            // rabbitmq does not respond to wrong auth content due to empty password
+            $this->assertInstanceOf(AMQPTimeoutException::class, $exception);
+        } finally {
+            $this->deleteUser($username);
+        }
+
+        $this->createUser($username, $password = 'password');
+
+        try {
+            $connection = new AMQPStreamConnection(HOST, PORT, $username, $password, '/', false, 'PLAIN', null, 'en_US',
+                1);
+            $this->assertInstanceOf(AMQPStreamConnection::class, $connection);
+            $this->assertTrue($connection->isConnected());
+            $channel = $connection->channel();
+            $this->assertInstanceOf(AMQPChannel::class, $channel);
+            $connection->close();
+        } finally {
+            $this->deleteUser($username);
+        }
+    }
+
+    private function createUser($username, $password)
+    {
+        $userEndpoint = HOST . ':15672/api/users/' . $username;
+        $passwordHash = '';
+        if (!empty($password)) {
+            $salt = substr(md5(mt_rand()), 0, 4);
+            $passwordHash = base64_encode($salt . hash('sha256', $salt . $password, true));
+        }
+        $request = Request::put(
+            $userEndpoint,
+            json_encode([
+                'password_hash' => $passwordHash,
+                'tags' => '',
+                'hashing_algorithm' => 'rabbit_password_hashing_sha256',
+            ])
+        );
+        $request->expectsJson();
+        $request->basicAuth(USER, PASS);
+        $request->whenError(function ($error) {
+        });
+        try {
+            $response = $request->send();
+        } catch (ConnectionErrorException $exception) {
+            $this->markTestSkipped($exception->getMessage());
+        }
+        if ($response->code !== 201) {
+            $this->markTestSkipped('Cannot create temporary user');
+        }
+
+        $request = Request::put(
+            HOST . ':15672/api/permissions/%2f/' . $username,
+            json_encode(['configure' => '', 'write' => '.*', 'read' => '.*'])
+        );
+        $request->expectsJson();
+        $request->basicAuth(USER, PASS);
+        $response = $request->send();
+        if ($response->code !== 201) {
+            $this->markTestSkipped('Cannot set vhost permission');
+        }
+    }
+
+    private function deleteUser($username)
+    {
+        $userEndpoint = HOST . ':15672/api/users/' . $username;
+        $request = Request::delete($userEndpoint);
+        $request->expectsJson();
+        $request->basicAuth(USER, PASS);
+        $request->send();
+    }
+}


### PR DESCRIPTION
Current default and single availale authentication method is `AMQPLAIN` which is non standard and retained for BC. This PR adds support for standard simple `PLAIN` and other(non rabbitmq based) brokers.