### PR TITLE
Run phpunit on appveyor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,8 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /.scrutinizer.yml export-ignore
+/appveyor.yml export-ignore
+/docker-compose.yml
 /Makefile export-ignore
 /NOTE.DEVELOPMENT.NOV.2011.md export-ignore
 /NOTE.THENETCIRCLE.md export-ignore

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -736,7 +736,7 @@ class AbstractConnection extends AbstractChannel
 
         $this->x_close_ok();
 
-        throw new AMQPConnectionClosedException($code, $reason);
+        throw new AMQPConnectionClosedException($reason, $code);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Software License][ico-license]](LICENSE)
 [![Build Status][ico-travis]][link-travis]
-[![Build status](https://ci.appveyor.com/api/projects/status/github/php-amqplib/php-amqplib?svg=true)](https://ci.appveyor.com/api/projects/status/php-amqplib/php-amqplib)
 [![Coverage Status][ico-scrutinizer]][link-scrutinizer]
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Software License][ico-license]](LICENSE)
 [![Build Status][ico-travis]][link-travis]
+[![Build status](https://ci.appveyor.com/api/projects/status/github/php-amqplib/php-amqplib?svg=true)](https://ci.appveyor.com/api/projects/status/php-amqplib/php-amqplib)
 [![Coverage Status][ico-scrutinizer]][link-scrutinizer]
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+build: false
+platform:
+  - x64
+  - x86
+
+image: Visual Studio 2017
+
+## Build matrix for lowest and highest possible targets
+environment:
+  matrix:
+  - dependencies: lowest
+    PHP_VERSION: 5.6
+  - dependencies: lowest
+    PHP_VERSION: 7.0
+  - dependencies: current
+    PHP_VERSION: 7.1
+  - dependencies: current
+    PHP_VERSION: 7.2
+  - dependencies: highest
+    PHP_VERSION: 7.3
+  COMPOSER_CACHE: "%USERPROFILE%\\composer"
+  RABBITMQ_VERSION: 3.7.17
+  ERLANG_VERSION: 10.4
+
+## Cache CI dependencies
+cache:
+    - '%COMPOSER_CACHE% -> composer.json'
+    - "%USERPROFILE%\\packages"
+
+## Set up environment variables
+init:
+    - SET ANSICON=121x90 (121x90)
+
+## Install PHP and composer, and run the appropriate composer command
+install:
+    - choco config set cacheLocation "%USERPROFILE%\\packages"
+    - ps: Invoke-WebRequest "https://raw.githubusercontent.com/ChadSikorra/ps-install-php/master/Install-PHP.ps1" -OutFile "Install-PHP.ps1"
+    - ps: .\Install-PHP.ps1 -Version $Env:PHP_VERSION -Highest -Arch $Env:PLATFORM -Extensions mbstring,intl,openssl,curl,sockets
+    - cinst composer -i -y
+    - refreshenv
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET COMPOSER_CACHE_DIR=%COMPOSER_CACHE%
+    - IF %dependencies%==lowest composer update --prefer-lowest --no-progress
+    - IF %dependencies%==current composer update --prefer-stable --no-progress
+    - IF %dependencies%==highest composer update --no-progress --prefer-dist
+    - ps: Invoke-WebRequest "https://raw.githubusercontent.com/ramunasd/appveyor-rabbitmq/v1.2/install.ps1" -OutFile "install-rabbitmq.ps1"
+    - ps: .\install-rabbitmq.ps1
+
+## Run the actual test
+test_script:
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - php tests/phpinfo.php
+    - vendor/bin/phpunit --exclude-group proxy,signals

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+## https://ci.appveyor.com/project/ramunasd/php-amqplib
 build: false
 platform:
   - x64

--- a/tests/Functional/Bug/Bug256Test.php
+++ b/tests/Functional/Bug/Bug256Test.php
@@ -8,6 +8,9 @@ use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
 use PhpAmqpLib\Wire\AMQPTable;
 
+/**
+ * @group connection
+ */
 class Bug256Test extends AbstractConnectionTest
 {
     protected $exchangeName = 'test_exchange';

--- a/tests/Functional/Bug/Bug40Test.php
+++ b/tests/Functional/Bug/Bug40Test.php
@@ -7,6 +7,9 @@ use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class Bug40Test extends TestCase
 {
     protected $exchangeName = 'test_exchange';

--- a/tests/Functional/Bug/Bug458Test.php
+++ b/tests/Functional/Bug/Bug458Test.php
@@ -5,6 +5,10 @@ namespace PhpAmqpLib\Tests\Functional\Bug;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ * @group signals
+ */
 class Bug458Test extends TestCase
 {
     private $channel;

--- a/tests/Functional/Bug/Bug49Test.php
+++ b/tests/Functional/Bug/Bug49Test.php
@@ -7,6 +7,9 @@ use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Exception\AMQPProtocolException;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class Bug49Test extends TestCase
 {
     protected $connection;

--- a/tests/Functional/Channel/ChannelTestCase.php
+++ b/tests/Functional/Channel/ChannelTestCase.php
@@ -7,6 +7,9 @@ use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Connection\AMQPSocketConnection;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 abstract class ChannelTestCase extends TestCase
 {
     /** @var AbstractConnection */
@@ -46,9 +49,13 @@ abstract class ChannelTestCase extends TestCase
 
     public function tearDown()
     {
-        $this->channel->close();
-        $this->channel = null;
-        $this->connection->close();
-        $this->connection = null;
+        if ($this->channel) {
+            $this->channel->close();
+            $this->channel = null;
+        }
+        if ($this->connection) {
+            $this->connection->close();
+            $this->connection = null;
+        }
     }
 }

--- a/tests/Functional/Channel/ChannelTimeoutTest.php
+++ b/tests/Functional/Channel/ChannelTimeoutTest.php
@@ -1,18 +1,18 @@
 <?php
-namespace PhpAmqpLib\Tests\Unit\Channel;
+namespace PhpAmqpLib\Tests\Functional\Channel;
 
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Helper\MiscHelper;
 use PhpAmqpLib\Wire\IO\AbstractIO;
+use PhpAmqpLib\Wire\IO\StreamIO;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class ChannelTimeoutTest extends TestCase
 {
-
-    /** @var float $channel_rpc_timeout */
-    private $channel_rpc_timeout;
-
     /** @var int $channel_rpc_timeout */
     private $channel_rpc_timeout_seconds;
 
@@ -30,19 +30,17 @@ class ChannelTimeoutTest extends TestCase
 
     protected function setUp()
     {
-        parent::setUp();
-
-        $this->channel_rpc_timeout = 3.5;
+        $channel_rpc_timeout = 3.5;
 
         list( $this->channel_rpc_timeout_seconds, $this->channel_rpc_timeout_microseconds ) =
-            MiscHelper::splitSecondsMicroseconds( $this->channel_rpc_timeout );
+            MiscHelper::splitSecondsMicroseconds( $channel_rpc_timeout );
 
-        $this->io = $this->getMockBuilder('\PhpAmqpLib\Wire\IO\StreamIO')
+        $this->io = $this->getMockBuilder(StreamIO::class)
             ->setConstructorArgs(array(HOST, PORT, 3, 3, null, false, 0))
             ->setMethods(array('select'))
             ->getMock();
-        $this->connection = $this->getMockBuilder('\PhpAmqpLib\Connection\AbstractConnection')
-            ->setConstructorArgs(array(USER, PASS, '/', false, 'AMQPLAIN', null, 'en_US', $this->io, 0, 0, $this->channel_rpc_timeout))
+        $this->connection = $this->getMockBuilder(AbstractConnection::class)
+            ->setConstructorArgs(array(USER, PASS, '/', false, 'AMQPLAIN', null, 'en_US', $this->io, 0, 0, $channel_rpc_timeout))
             ->setMethods(array())
             ->getMockForAbstractClass();
 
@@ -85,10 +83,13 @@ class ChannelTimeoutTest extends TestCase
 
     protected function tearDown()
     {
-        parent::tearDown();
-        $this->channel->close();
+        if ($this->channel) {
+            $this->channel->close();
+        }
         $this->channel = null;
-        $this->connection->close();
+        if ($this->connection) {
+            $this->connection->close();
+        }
         $this->connection = null;
     }
 }

--- a/tests/Functional/Channel/ChannelWaitTest.php
+++ b/tests/Functional/Channel/ChannelWaitTest.php
@@ -8,11 +8,15 @@ use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class ChannelWaitTest extends TestCase
 {
     /**
      * @test
      * @small
+     * @group signals
      * @dataProvider provide_channels
      * @param callable $factory
      */

--- a/tests/Functional/Channel/DirectExchangeTest.php
+++ b/tests/Functional/Channel/DirectExchangeTest.php
@@ -5,6 +5,9 @@ namespace PhpAmqpLib\Tests\Functional;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Tests\Functional\Channel\ChannelTestCase;
 
+/**
+ * @group connection
+ */
 class DirectExchangeTest extends ChannelTestCase
 {
     public function setUp()

--- a/tests/Functional/Channel/HeadersExchangeTest.php
+++ b/tests/Functional/Channel/HeadersExchangeTest.php
@@ -5,6 +5,9 @@ namespace PhpAmqpLib\Tests\Functional\Channel;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 
+/**
+ * @group connection
+ */
 class HeadersExchangeTest extends ChannelTestCase
 {
     public function setUp()

--- a/tests/Functional/Channel/TopicExchangeTest.php
+++ b/tests/Functional/Channel/TopicExchangeTest.php
@@ -6,6 +6,9 @@ use PhpAmqpLib\Connection\AMQPSocketConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Tests\Functional\Channel\ChannelTestCase;
 
+/**
+ * @group connection
+ */
 class TopicExchangeTest extends ChannelTestCase
 {
     public function setUp()

--- a/tests/Functional/Connection/ConnectionUnresponsiveTest.php
+++ b/tests/Functional/Connection/ConnectionUnresponsiveTest.php
@@ -6,13 +6,15 @@ use PhpAmqpLib\Exception;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
 
+/**
+ * @group connection
+ */
 class ConnectionUnresponsiveTest extends AbstractConnectionTest
 {
     /**
      * Use mocked write functions to simulate completely blocked connections.
      * @test
      * @small
-     * @group connection
      * @testWith ["stream"]
      *           ["socket"]
      * @covers \PhpAmqpLib\Wire\IO\StreamIO::write()
@@ -51,8 +53,8 @@ class ConnectionUnresponsiveTest extends AbstractConnectionTest
 
     /**
      * @test
-     * @group connection
      * @testWith ["stream"]
+     * @group proxy
      * @covers \PhpAmqpLib\Connection\AbstractConnection::connect()
      * @param string $type
      */

--- a/tests/Functional/FileTransferTest.php
+++ b/tests/Functional/FileTransferTest.php
@@ -7,6 +7,9 @@ use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class FileTransferTest extends TestCase
 {
     protected $exchangeName = 'test_exchange';

--- a/tests/Functional/ReconnectConnectionTest.php
+++ b/tests/Functional/ReconnectConnectionTest.php
@@ -9,6 +9,9 @@ use PhpAmqpLib\Connection\AMQPSocketConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class ReconnectConnectionTest extends TestCase
 {
     protected $connection = null;

--- a/tests/Functional/StreamIOTest.php
+++ b/tests/Functional/StreamIOTest.php
@@ -5,6 +5,9 @@ namespace PhpAmqpLib\Tests\Functional;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class StreamIOTest extends TestCase
 {
     /** @var array|null */

--- a/tests/Functional/ToxiProxy.php
+++ b/tests/Functional/ToxiProxy.php
@@ -18,6 +18,9 @@ class ToxiProxy
     /** @var int */
     private $listen;
 
+    /** @var bool */
+    private $isOpen = false;
+
     /**
      * @param string $name
      * @param string $host
@@ -32,7 +35,9 @@ class ToxiProxy
 
     public function __destruct()
     {
-        $this->close();
+        if ($this->isOpen) {
+            $this->close();
+        }
     }
 
     /**
@@ -56,6 +61,7 @@ class ToxiProxy
             throw new \RuntimeException('Cannot create Toxiproxy connection');
         }
         $this->listen = $listen;
+        $this->isOpen = true;
     }
 
     /**

--- a/tests/Unit/Wire/IO/SocketIOTest.php
+++ b/tests/Unit/Wire/IO/SocketIOTest.php
@@ -5,6 +5,9 @@ namespace PhpAmqpLib\Tests\Unit\Wire\IO;
 use PhpAmqpLib\Wire\IO\SocketIO;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class SocketIOTest extends TestCase
 {
     /**

--- a/tests/Unit/Wire/IO/StreamIOTest.php
+++ b/tests/Unit/Wire/IO/StreamIOTest.php
@@ -5,6 +5,9 @@ namespace PhpAmqpLib\Tests\Unit\Wire\IO;
 use PhpAmqpLib\Wire\IO\StreamIO;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group connection
+ */
 class StreamIOTest extends TestCase
 {
     /**
@@ -29,10 +32,11 @@ class StreamIOTest extends TestCase
     /**
      * @test
      * @expectedException \PhpAmqpLib\Exception\AMQPIOWaitException
+     * @requires OS Linux
      */
     public function select_must_throw_io_exception()
     {
-        $property = new \ReflectionProperty('PhpAmqpLib\Wire\IO\StreamIO', 'sock');
+        $property = new \ReflectionProperty(StreamIO::class, 'sock');
         $property->setAccessible(true);
 
         $resource = fopen('php://temp', 'r');

--- a/tests/phpinfo.php
+++ b/tests/phpinfo.php
@@ -5,8 +5,11 @@ phpinfo(INFO_GENERAL);
 echo PHP_EOL;
 
 echo '# Extensions', PHP_EOL;
-print_r(array_intersect(get_loaded_extensions(), ['sockets', 'bcmath']));
+print_r(array_intersect(get_loaded_extensions(), ['sockets', 'bcmath', 'mbstring', 'pcntl']));
 echo PHP_EOL;
+
+echo 'PHP_INT_SIZE=', PHP_INT_SIZE, PHP_EOL;
+echo 'PHP_INT_MAX=', PHP_INT_MAX, PHP_EOL;
 
 echo '# Constants', PHP_EOL;
 $constants = get_defined_constants(true);


### PR DESCRIPTION
Run phpunit tests on AppVeyor CI platform.
- against all supported php versions
- use 64 and 32 bit windows platforms
- partly based on pika appveyor scripts
- imaproved phpunit annotations
- output PHP integer size as general info