### PR TITLE
Remove bcmath dependency

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -866,6 +866,7 @@ class AMQPChannel extends AbstractChannel
      */
     protected function get_keys_less_or_equal(array $messages, $value)
     {
+        $value = (int) $value;
         $keys = array_reduce(
             array_keys($messages),
 
@@ -873,7 +874,7 @@ class AMQPChannel extends AbstractChannel
              * @param string $key
              */
             function ($keys, $key) use ($value) {
-                if (bccomp($key, $value, 0) <= 0) {
+                if ($key <= $value) {
                     $keys[] = $key;
                 }
 
@@ -1181,7 +1182,7 @@ class AMQPChannel extends AbstractChannel
 
         if ($this->next_delivery_tag > 0) {
             $this->published_messages[$this->next_delivery_tag] = $msg;
-            $this->next_delivery_tag = bcadd($this->next_delivery_tag, '1', 0);
+            $this->next_delivery_tag++;
         }
     }
 
@@ -1241,7 +1242,7 @@ class AMQPChannel extends AbstractChannel
 
             if ($this->next_delivery_tag > 0) {
                 $this->published_messages[$this->next_delivery_tag] = $msg;
-                $this->next_delivery_tag = bcadd($this->next_delivery_tag, '1', 0);
+                $this->next_delivery_tag++;
             }
         }
 

--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -299,11 +299,11 @@ abstract class AbstractChannel
             ->load_properties($propertyReader)
             ->setBodySize($contentReader->read_longlong());
 
-        while (bccomp($message->getBodySize(), $bodyReceivedBytes, 0) == 1) {
+        while ($message->getBodySize() > $bodyReceivedBytes) {
             list($frame_type, $payload) = $this->next_frame();
 
             $this->validate_body_frame($frame_type);
-            $bodyReceivedBytes = bcadd($bodyReceivedBytes, mb_strlen($payload, 'ASCII'), 0);
+            $bodyReceivedBytes += mb_strlen($payload, 'ASCII');
 
             if (is_int($this->maxBodySize) && $bodyReceivedBytes > $this->maxBodySize ) {
                 $message->setIsTruncated(true);

--- a/PhpAmqpLib/Wire/AMQPDecimal.php
+++ b/PhpAmqpLib/Wire/AMQPDecimal.php
@@ -2,6 +2,7 @@
 namespace PhpAmqpLib\Wire;
 
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
+use phpseclib\Math\BigInteger;
 
 /**
  * AMQP protocol decimal value.
@@ -42,7 +43,10 @@ class AMQPDecimal
      */
     public function asBCvalue()
     {
-        return bcdiv($this->n, bcpow(10, $this->e));
+        $n = new BigInteger($this->n);
+        $e = new BigInteger('1' . str_repeat('0', $this->e));
+        list($q) = $n->divide($e);
+        return $q->toString();
     }
 
     /**

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -1,14 +1,16 @@
 <?php
+
 namespace PhpAmqpLib\Wire;
 
 use PhpAmqpLib\Exception\AMQPDataReadException;
 use PhpAmqpLib\Exception\AMQPInvalidArgumentException;
+use PhpAmqpLib\Exception\AMQPIOWaitException;
 use PhpAmqpLib\Exception\AMQPNoDataException;
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
-use PhpAmqpLib\Exception\AMQPIOWaitException;
 use PhpAmqpLib\Helper\MiscHelper;
 use PhpAmqpLib\Wire\IO\AbstractIO;
+use phpseclib\Math\BigInteger;
 
 /**
  * This class can read from a string or from a stream
@@ -28,43 +30,40 @@ class AMQPReader extends AbstractClient
     const TIMESTAMP = 8;
 
     /** @var string */
-    protected $str;
+    protected $str = '';
 
     /** @var int */
-    protected $str_length;
+    protected $str_length = 0;
 
     /** @var int */
-    protected $offset;
+    protected $offset = 0;
 
     /** @var int */
-    protected $bitcount;
-
-    /** @var bool */
-    protected $is64bits;
+    protected $bitcount = 0;
 
     /** @var int|float|null */
     protected $timeout;
 
     /** @var int */
-    protected $bits;
+    protected $bits = 0;
 
-    /** @var \PhpAmqpLib\Wire\IO\AbstractIO */
+    /** @var null|\PhpAmqpLib\Wire\IO\AbstractIO */
     protected $io;
 
     /**
-     * @param string $str
+     * @param string|null $str
      * @param AbstractIO $io
-     * @param int $timeout
+     * @param int|float $timeout
      */
     public function __construct($str, AbstractIO $io = null, $timeout = 0)
     {
         parent::__construct();
 
-        $this->str = is_string($str) ? $str : '';
-        $this->str_length = mb_strlen($this->str, 'ASCII');
+        if (is_string($str)) {
+            $this->str = (string)$str;
+            $this->str_length = mb_strlen($this->str, 'ASCII');
+        }
         $this->io = $io;
-        $this->offset = 0;
-        $this->bitcount = $this->bits = 0;
         $this->timeout = $timeout;
     }
 
@@ -83,7 +82,7 @@ class AMQPReader extends AbstractClient
         $this->str = $str;
         $this->str_length = mb_strlen($this->str, 'ASCII');
         $this->offset = 0;
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
     }
 
     /**
@@ -102,7 +101,7 @@ class AMQPReader extends AbstractClient
      */
     public function read($n)
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
 
         return $this->rawread($n);
     }
@@ -159,6 +158,7 @@ class AMQPReader extends AbstractClient
     protected function rawread($n)
     {
         if ($this->io) {
+            $res = '';
             while (true) {
                 $this->wait();
                 try {
@@ -183,7 +183,7 @@ class AMQPReader extends AbstractClient
         }
 
         $res = mb_substr($this->str, 0, $n, 'ASCII');
-        $this->str = mb_substr($this->str, $n, mb_strlen($this->str, 'ASCII') - $n, 'ASCII');
+        $this->str = mb_substr($this->str, $n, null, 'ASCII');
         $this->str_length -= $n;
         $this->offset += $n;
 
@@ -200,9 +200,9 @@ class AMQPReader extends AbstractClient
             $this->bitcount = 8;
         }
 
-        $result = ($this->bits & 1) == 1;
+        $result = ($this->bits & 1) === 1;
         $this->bits >>= 1;
-        $this->bitcount -= 1;
+        $this->bitcount--;
 
         return $result;
     }
@@ -212,7 +212,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_octet()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         list(, $res) = unpack('C', $this->rawread(1));
 
         return $res;
@@ -223,7 +223,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_signed_octet()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         list(, $res) = unpack('c', $this->rawread(1));
 
         return $res;
@@ -234,7 +234,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_short()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         list(, $res) = unpack('n', $this->rawread(2));
 
         return $res;
@@ -245,7 +245,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_signed_short()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         list(, $res) = unpack('s', $this->correctEndianness($this->rawread(2)));
 
         return $res;
@@ -281,10 +281,13 @@ class AMQPReader extends AbstractClient
      */
     public function read_long()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         list(, $res) = unpack('N', $this->rawread(4));
+        if (!$this->is64bits && $this->getLongMSB($res)) {
+            return sprintf('%u', $res);
+        }
 
-        return empty($this->is64bits) && self::getLongMSB($res) ? sprintf('%u', $res) : $res;
+        return $res;
     }
 
     /**
@@ -292,61 +295,69 @@ class AMQPReader extends AbstractClient
      */
     private function read_signed_long()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         list(, $res) = unpack('l', $this->correctEndianness($this->rawread(4)));
 
         return $res;
     }
 
     /**
-     * Even on 64 bit systems PHP integers are singed.
-     * Since we need an unsigned value here we return it
-     * as a string.
+     * Even on 64 bit systems PHP integers are signed.
+     * Since we need an unsigned value here we return it as a string.
      *
-     * @return string
+     * @return int|string
      */
     public function read_longlong()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
+        $bytes = $this->rawread(8);
 
-        list(, $hi, $lo) = unpack('N2', $this->rawread(8));
-        $msb = self::getLongMSB($hi);
-
-        if (empty($this->is64bits)) {
-            if ($msb) {
-                $hi = sprintf('%u', $hi);
+        if ($this->is64bits) {
+            // we can "unpack" if MSB bit is 0 (at most 63 bit integer), fallback to BigInteger otherwise
+            if (!$this->getMSB($bytes)) {
+                $res = unpack('J', $bytes);
+                return $res[1];
             }
-            if (self::getLongMSB($lo)) {
-                $lo = sprintf('%u', $lo);
+        } else {
+            // on 32-bit systems we can "unpack" up to 31 bits integer
+            list(, $hi, $lo) = unpack('N2', $bytes);
+            if ($hi === 0 && $lo > 0) {
+                return $lo;
             }
         }
 
-        return bcadd($this->is64bits && !$msb ? $hi << 32 : bcmul($hi, '4294967296', 0), $lo, 0);
+        $var = new BigInteger($bytes, 256);
+
+        return $var->toString();
     }
 
     /**
-     * @return string
+     * @return int|string
      */
     public function read_signed_longlong()
     {
-        $this->bitcount = $this->bits = 0;
-
-        list(, $hi, $lo) = unpack('N2', $this->rawread(8));
+        $this->resetCounters();
+        $bytes = $this->rawread(8);
 
         if ($this->is64bits) {
-            return bcadd($hi << 32, $lo, 0);
+            $res = unpack('q', $this->correctEndianness($bytes));
+            return $res[1];
         } else {
-            return bcadd(bcmul($hi, '4294967296', 0), self::getLongMSB($lo) ? sprintf('%u', $lo) : $lo, 0);
+            // on 32-bit systems we can "unpack" up to 31 bits integer
+            list(, $hi, $lo) = unpack('N2', $bytes);
+            if ($hi === 0 && $lo > 0) {
+                // positive and less than 2^31-1
+                return $lo;
+            }
+            // negative and more than -2^31
+            if ($hi === -1 && $this->getLongMSB($lo)) {
+                return $lo;
+            }
         }
-    }
 
-    /**
-     * @param int $longInt
-     * @return bool
-     */
-    private static function getLongMSB($longInt)
-    {
-        return (bool) ($longInt & 0x80000000);
+        $var = new BigInteger($bytes, -256);
+
+        return $var->toString();
     }
 
     /**
@@ -355,7 +366,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_shortstr()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         list(, $slen) = unpack('C', $this->rawread(1));
 
         return $this->rawread($slen);
@@ -368,7 +379,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_longstr()
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         $slen = $this->read_php_int();
 
         if ($slen < 0) {
@@ -396,7 +407,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_table($returnObject = false)
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
         $tlen = $this->read_php_int();
 
         if ($tlen < 0) {
@@ -432,7 +443,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_array($returnObject = false)
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
 
         // Determine array length and its end position
         $arrayLength = $this->read_php_int();
@@ -468,7 +479,7 @@ class AMQPReader extends AbstractClient
      */
     public function read_value($fieldType, $collectionsAsObjects = false)
     {
-        $this->bitcount = $this->bits = 0;
+        $this->resetCounters();
 
         switch ($fieldType) {
             case AMQPAbstractCollection::T_INT_SHORTSHORT:
@@ -555,10 +566,15 @@ class AMQPReader extends AbstractClient
     }
 
     /**
-     * @return int|float
+     * @return int|float|null
      */
     public function getTimeout()
     {
         return $this->timeout;
+    }
+
+    private function resetCounters()
+    {
+        $this->bitcount = $this->bits = 0;
     }
 }

--- a/PhpAmqpLib/Wire/AbstractClient.php
+++ b/PhpAmqpLib/Wire/AbstractClient.php
@@ -1,36 +1,97 @@
 <?php
+
 namespace PhpAmqpLib\Wire;
 
+use phpseclib\Math\BigInteger;
 
 class AbstractClient
 {
-
     /**
      * @var bool
      */
     protected $is64bits;
 
+    /** @var BigInteger[][] */
+    protected static $bigIntegers = array();
+
     /**
      * @var bool
      */
-    protected $isLittleEndian;
+    protected static $isLittleEndian;
 
     public function __construct()
     {
-        $this->is64bits = PHP_INT_SIZE == 8;
-
-        $tmp = unpack('S', "\x01\x00"); // to maintain 5.3 compatibility
-        $this->isLittleEndian = $tmp[1] == 1;
+        $this->is64bits = PHP_INT_SIZE === 8;
     }
 
     /**
      * Converts byte-string between native and network byte order, in both directions
      *
-     * @param string $byteStr
+     * @param string $bytes
      * @return string
      */
-    protected function correctEndianness($byteStr)
+    protected function correctEndianness($bytes)
     {
-        return $this->isLittleEndian ? strrev($byteStr) : $byteStr;
+        return self::isLittleEndian() ? $this->convertByteOrder($bytes) : $bytes;
+    }
+
+    /**
+     * @param string $bytes
+     * @return string
+     */
+    protected function convertByteOrder($bytes)
+    {
+        return strrev($bytes);
+    }
+
+    /**
+     * @param int $longInt
+     * @return bool
+     */
+    protected function getLongMSB($longInt)
+    {
+        return (bool) ($longInt & 0x80000000);
+    }
+
+    /**
+     * @param string $bytes
+     * @return bool
+     */
+    protected function getMSB($bytes)
+    {
+        return ord($bytes[0]) > 127;
+    }
+
+    /**
+     * @return bool
+     */
+    protected static function isLittleEndian()
+    {
+        if (self::$isLittleEndian === null) {
+            $tmp = unpack('S', "\x01\x00"); // to maintain 5.3 compatibility
+            self::$isLittleEndian = $tmp[1] === 1;
+        }
+
+        return self::$isLittleEndian;
+    }
+
+    /**
+     * @param string $value
+     * @param int $base
+     * @return BigInteger
+     */
+    protected static function getBigInteger($value, $base = 10)
+    {
+        if (!isset(self::$bigIntegers[$base])) {
+            self::$bigIntegers[$base] = array();
+        }
+        if (isset(self::$bigIntegers[$base][$value])) {
+            return self::$bigIntegers[$base][$value];
+        }
+
+        $integer = new BigInteger($value, $base);
+        self::$bigIntegers[$base][$value] = $integer;
+
+        return $integer;
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@
 This library is a _pure PHP_ implementation of the [AMQP 0-9-1 protocol](http://www.rabbitmq.com/tutorials/amqp-concepts.html).
 It's been tested against [RabbitMQ](http://www.rabbitmq.com/).
 
-**Requirements: bcmath extension** This library utilizes the bcmath PHP extension. The installation steps vary per PHP version and the underlying OS. The following example shows how to add to an existing PHP installation on Ubuntu 15.10:
-
-```bash
-sudo apt-get install php7.0-bcmath
-```
-
 The library was used for the PHP examples of [RabbitMQ in Action](http://manning.com/videla/) and the [official RabbitMQ tutorials](http://www.rabbitmq.com/tutorials/tutorial-one-php.html).
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,10 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
-        "ext-bcmath": "*",
-        "ext-sockets": "*"
+        "php": ">=5.6.3",
+        "ext-sockets": "*",
+        "ext-mbstring": "*",
+        "phpseclib/phpseclib": "^2.0.0"
     },
     "require-dev": {
         "ext-curl": "*",
@@ -53,7 +54,7 @@
     "license": "LGPL-2.1-or-later",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.10-dev"
+            "dev-master": "2.11-dev"
         }
     }
 }

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6-cli
 
 RUN apt update && \
     apt -qy install git unzip zlib1g-dev && \
-    docker-php-ext-install bcmath sockets pcntl zip
+    docker-php-ext-install sockets pcntl zip
 
 WORKDIR /src
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \

--- a/tests/Unit/Wire/AMQPReaderTest.php
+++ b/tests/Unit/Wire/AMQPReaderTest.php
@@ -35,4 +35,27 @@ class AMQPReaderTest extends TestCase
         $parsed = $reader->read_table();
         $this->assertEquals($expected, $parsed);
     }
+
+    public function test32bitSignedIntegerOverflow()
+    {
+        $data = hex2bin('0000000080000000');
+        $reader = new AMQPReader($data);
+        $parsed = $reader->read_signed_longlong();
+        if (PHP_INT_SIZE === 8) {
+            $this->assertInternalType('integer', $parsed);
+            $this->assertEquals(0x80000000, $parsed);
+        } else {
+            $this->assertInternalType('string', $parsed);
+            $this->assertEquals('2147483648', $parsed);
+        }
+    }
+
+    public function test64bitUnsignedIntegerOverflow()
+    {
+        $data = hex2bin(str_repeat('f', 16));
+        $reader = new AMQPReader($data);
+        $parsed = $reader->read_longlong();
+        $this->assertInternalType('string', $parsed);
+        $this->assertEquals('18446744073709551615', $parsed);
+    }
 }

--- a/tests/Unit/WireTest.php
+++ b/tests/Unit/WireTest.php
@@ -495,11 +495,15 @@ class WireTest extends TestCase
 
     public function longWrData()
     {
-        $max = PHP_INT_SIZE == 8 ? 4294967295 : PHP_INT_MAX;
+        $max = PHP_INT_SIZE === 8 ? 4294967295 : PHP_INT_MAX;
 
         return [
             [0],
             [1],
+            [2],
+            [2147483646],
+            [2147483647],
+            [2147483648],
             [$max - 1],
             [$max],
             ['0'],
@@ -519,6 +523,11 @@ class WireTest extends TestCase
         return [
             [-2147483648],
             [-2147483647],
+            [-2],
+            [-1],
+            [0],
+            [1],
+            [2],
             [2147483646],
             [2147483647],
             ['-2147483648'],
@@ -540,6 +549,7 @@ class WireTest extends TestCase
         return [
             [0],
             [1],
+            [2],
             [PHP_INT_MAX - 1],
             [PHP_INT_MAX],
             ['0'],
@@ -562,11 +572,10 @@ class WireTest extends TestCase
 
     public function signedLonglongWrData()
     {
+        $min = defined('PHP_INT_MIN') ? PHP_INT_MIN : ~PHP_INT_MAX;
         return [
-            [-PHP_INT_MAX - 1],
-            [-PHP_INT_MAX],
-            [PHP_INT_MAX - 1],
-            [PHP_INT_MAX],
+            [$min],
+            [$min + 1],
             ['-9223372036854775808'],
             ['-9223372036854775807'],
             ['-9223372036854775806'],
@@ -578,18 +587,26 @@ class WireTest extends TestCase
             ['-2147483647'],
             ['-2'],
             ['-1'],
+            [-1],
             ['0'],
+            [0],
             ['1'],
+            [1],
             ['2'],
             ['2147483646'],
+            [2147483646],
             ['2147483647'],
+            [2147483647], // 32-bit PHP_INT_MAX
             ['2147483648'],
+            [2147483648], // float on 32-bit systems
             ['4294967294'],
             ['4294967295'],
             ['4294967296'],
             ['9223372036854775805'],
             ['9223372036854775806'],
             ['9223372036854775807'],
+            [PHP_INT_MAX - 1],
+            [PHP_INT_MAX],
         ];
     }
 
@@ -632,6 +649,10 @@ class WireTest extends TestCase
             $readValue = $reader->{$read_method}();
         }
 
-        $this->assertEquals($value, $readValue);
+        $this->assertEquals(
+            $value,
+            $readValue,
+            'Written: ' . bin2hex($writer->getvalue()) . ', read: ' . bin2hex($readValue)
+        );
     }
 }


### PR DESCRIPTION
Based on #737 by @terrafrost
* completely remove all bcmath functions
* take advantage of pack/unpack modifiers available since PHP 5.6.3 on 64-bit systems
* try to parse values between PHP_INT_MIN and PHP_INT_MAX if possible
* fallback to BigInteger if cannot encode/decode to native integer, phpseclib added as dependency
* cache in memory repetitive BigInteger values to minimize heavy constructor impact
* tested on native 32 bit platform RaspberryPi
* tested on Windows(appveyor), both 32 and 64 bits https://ci.appveyor.com/project/ramunasd/php-amqplib/builds/28751717
* increased `basic_publish()` performance `time php benchmark/producer.php 10000` user time 0.26s vs. 0.34s