### PR TITLE
Fix phpunit tests reported as risked

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,5 +20,4 @@ checks:
 
 tools:
     external_code_coverage:
-        timeout: 1020
-        runs: 6
+        timeout: 1200

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+      env: COVERAGE=true
     - php: 7.4snapshot
+  fast_finish: true
   allow_failures:
     - php: 7.4snapshot
 
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
+git:
+    depth: 1
 
 services:
   - docker
@@ -32,6 +33,7 @@ before_install:
   - docker pull shopify/toxiproxy
   - docker run -d --rm --net=host -p 8474:8474 -p 5673:5673 shopify/toxiproxy
   - docker ps -a
+  - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
 
 env:
   global:
@@ -41,11 +43,10 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/phpunit -d zend.enable_gc=0 --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit -d zend.enable_gc=0 --exclude-group management --coverage-text --coverage-clover=coverage.clover
 
-after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-
-services:
-  rabbitmq
+after_success: >
+    if [[ $COVERAGE = true ]]; then
+        wget https://scrutinizer-ci.com/ocular.phar
+        php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+    fi

--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -650,7 +650,7 @@ class AMQPChannel extends AbstractChannel
      * @param array|\PhpAmqpLib\Wire\AMQPTable $arguments
      * @param int|null $ticket
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
-     * @return mixed|null
+     * @return array|null
      */
     public function queue_declare(
         $queue = '',

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,4 +52,4 @@ install:
 test_script:
     - cd %APPVEYOR_BUILD_FOLDER%
     - php tests/phpinfo.php
-    - vendor/bin/phpunit --exclude-group proxy,signals
+    - vendor/bin/phpunit --exclude-group proxy,signals,linux

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,9 @@
             </exclude>
         </whitelist>
     </filter>
+    <php>
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
     <logging>
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>

--- a/tests/Functional/Channel/ChannelWaitTest.php
+++ b/tests/Functional/Channel/ChannelWaitTest.php
@@ -25,13 +25,15 @@ class ChannelWaitTest extends TestCase
         $this->deferSignal(0.5);
         /** @var AMQPChannel $channel */
         $channel = $factory();
+        $result = false;
         try {
-            $channel->wait();
+            $result = $channel->wait();
         } catch (\Exception $exception) {
             $this->fail($exception->getMessage());
         }
 
         $this->closeChannel($channel);
+        $this->assertNull($result);
     }
 
     /**

--- a/tests/Functional/Connection/ConnectionAuthTest.php
+++ b/tests/Functional/Connection/ConnectionAuthTest.php
@@ -15,8 +15,8 @@ class ConnectionAuthTest extends AbstractConnectionTest
     /**
      * @test
      * @group connection
+     * @group management
      * @covers \PhpAmqpLib\Connection\AbstractConnection::__construct()
-     *
      */
     public function plain_auth_passwordless_must_fail()
     {

--- a/tests/Unit/Wire/IO/SocketIOTest.php
+++ b/tests/Unit/Wire/IO/SocketIOTest.php
@@ -17,6 +17,8 @@ class SocketIOTest extends TestCase
     {
         $socketIO = new SocketIO(HOST, PORT, 20, true, 20, 9);
         $socketIO->connect();
+        $ready = $socketIO->select(0, 0);
+        $this->assertEquals(0, $ready);
 
         return $socketIO;
     }

--- a/tests/Unit/Wire/IO/StreamIOTest.php
+++ b/tests/Unit/Wire/IO/StreamIOTest.php
@@ -31,6 +31,7 @@ class StreamIOTest extends TestCase
 
     /**
      * @test
+     * @group linux
      * @expectedException \PhpAmqpLib\Exception\AMQPIOWaitException
      * @requires OS Linux
      */


### PR DESCRIPTION
- some tests does not have any asserts and gets reported by phpunit
- exclude more incompatible tests for travis and appveyor
- report all errors types during tests, including notices and deprecations
- perform code coverage only once per build
- other minor improvements and style fixes