### PR TITLE
Restrict PHP 7.4.0 - 7.4.1 due to a PHP bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
         "squizlabs/php_codesniffer": "^2.5",
         "nategood/httpful": "^0.2.20"
     },
+    "conflict": {
+        "php": "7.4.0 - 7.4.1"
+    },
     "autoload": {
         "psr-4": {
             "PhpAmqpLib\\": "PhpAmqpLib/"


### PR DESCRIPTION
To avoid other people hitting the issue with stream error handling reported in #764, this PR adds conflict with PHP >=7.4.0 && <7.4.2.

Upstream bug report: https://bugs.php.net/bug.php?id=79000

Closes #764.