### PR TITLE
Async heartbeats

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -1040,7 +1040,9 @@ class AMQPChannel extends AbstractChannel
         );
 
         if (isset($this->callbacks[$consumer_tag])) {
-            call_user_func($this->callbacks[$consumer_tag], $message);
+            $this->connection->executeWithAsyncHeartbeat(function () use ($consumer_tag, $message) {
+                call_user_func($this->callbacks[$consumer_tag], $message);
+            });
         }
     }
 

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -938,6 +938,21 @@ class AbstractConnection extends AbstractChannel
     }
 
     /**
+     * Execute callback with async heartbeats
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function executeWithAsyncHeartbeat(callable $callback)
+    {
+        $this->io->enableAsyncHeartbeat();
+        $result = $callback();
+        $this->io->disableAsyncHeartbeat();
+
+        return $result;
+    }
+
+    /**
      * Check connection heartbeat if enabled.
      * @throws AMQPHeartbeatMissedException If too much time passed since last connection activity.
      * @throws AMQPConnectionClosedException If connection was closed due to network issues or timeouts.


### PR DESCRIPTION
If time of processing message exceed heartbeat time, consumer will fall with exception.
With PR adds sending heartbeats to server during message processing.

Based on https://wiki.php.net/rfc/async_signals which was added in PHP 7.1