### PR TITLE
fix: ensure hosts is an array, otherwise latest_exception can be null

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -1058,8 +1058,18 @@ class AbstractConnection extends AbstractChannel
         return self::$LIBRARY_PROPERTIES;
     }
 
+    /**
+     * @param array $hosts
+     * @param array $options
+     *
+     * @return mixed
+     * @throws \Exception
+     */
     public static function create_connection($hosts, $options = array()){
-        $latest_exception = null;
+        if (!is_array($hosts) || count($hosts) < 1) {
+            throw new \InvalidArgumentException('An array of hosts are required when attempting to create a connection');
+        }
+
         foreach ($hosts as $hostdef) {
             AbstractConnection::validate_host($hostdef);
             $host = $hostdef['host'];


### PR DESCRIPTION
I ran into a scenario where I was accidentally passing an empty array of hosts to `AbstractConnection::create_connection`. 

In this case, the error presented to me was `Error: Can only throw objects`, because `$latest_exception` was `null`. 