### PR TITLE
Blocked connection check

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -71,7 +71,7 @@ abstract class AbstractChannel
     /** @var MethodMap080|MethodMap091 */
     protected $methodMap;
 
-    /** @var null|string */
+    /** @var int */
     protected $channel_id;
 
     /** @var AMQPReader */
@@ -85,7 +85,7 @@ abstract class AbstractChannel
 
     /**
      * @param AbstractConnection $connection
-     * @param string $channel_id
+     * @param int $channel_id
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      */
     public function __construct(AbstractConnection $connection, $channel_id)
@@ -525,7 +525,7 @@ abstract class AbstractChannel
      * @param callable $handler
      * @param array $arguments
      */
-    protected function dispatch_to_handler($handler, array $arguments)
+    protected function dispatch_to_handler($handler, array $arguments = [])
     {
         if (is_callable($handler)) {
             call_user_func_array($handler, $arguments);

--- a/PhpAmqpLib/Exception/AMQPConnectionBlockedException.php
+++ b/PhpAmqpLib/Exception/AMQPConnectionBlockedException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PhpAmqpLib\Exception;
+
+class AMQPConnectionBlockedException extends AMQPRuntimeException
+{
+    public function __construct($message = '', $code = 0, $previous = null)
+    {
+        if (empty($message)) {
+            $message = 'Connection is blocked due to low resources';
+        }
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/PhpAmqpLib/Helper/Assert.php
+++ b/PhpAmqpLib/Helper/Assert.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PhpAmqpLib\Helper;
+
+use InvalidArgumentException;
+
+class Assert
+{
+    /**
+     * @param mixed $argument
+     * @throws \InvalidArgumentException
+     */
+    public static function isCallable($argument)
+    {
+        if (!is_callable($argument)) {
+            throw new InvalidArgumentException(sprintf(
+                'Given argument "%s" should be callable. %s type was given.',
+                $argument,
+                gettype($argument)
+            ));
+        }
+    }
+}

--- a/demo/batch_publish.php
+++ b/demo/batch_publish.php
@@ -9,6 +9,7 @@ include(__DIR__ . '/config.php');
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Exception\AMQPConnectionBlockedException;
 
 $exchange = 'bench_exchange';
 $queue = 'bench_queue';
@@ -48,7 +49,14 @@ for ($i = 0; $i < $max; $i++) {
     $channel->batch_basic_publish($message, $exchange);
 
     if ($i % $batch == 0) {
-        $channel->publish_batch();
+        try {
+            $channel->publish_batch();
+        } catch (AMQPConnectionBlockedException $exception) {
+            do {
+                sleep(10);
+            } while ($connection->isBlocked());
+            $channel->publish_batch();
+        }
     }
 }
 

--- a/tests/Unit/Channel/AMQPChannelTest.php
+++ b/tests/Unit/Channel/AMQPChannelTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Unit\Channel;
+
+use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Tests\Unit\Test\BufferIO;
+use PhpAmqpLib\Tests\Unit\Test\TestChannel;
+use PhpAmqpLib\Tests\Unit\Test\TestConnection;
+use PHPUnit\Framework\TestCase;
+
+class AMQPChannelTest extends TestCase
+{
+    /**
+     * @test
+     * @expectedException \PhpAmqpLib\Exception\AMQPConnectionBlockedException
+     */
+    public function blocked_connection_exception_on_publish()
+    {
+        $connection = new TestConnection('user', 'pass', '/', false, 'PLAIN', null, '', new BufferIO());
+        $connection->setIsBlocked(true);
+        $channel = new TestChannel($connection, 1);
+        $channel->basic_publish(new AMQPMessage());
+    }
+}

--- a/tests/Unit/Test/BufferIO.php
+++ b/tests/Unit/Test/BufferIO.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Unit\Test;
+
+use PhpAmqpLib\Wire\IO\AbstractIO;
+
+class BufferIO extends AbstractIO
+{
+    private $buffer;
+
+    /**
+     * @inheritDoc
+     */
+    public function read($len)
+    {
+        return fread($this->buffer, $len);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function write($data)
+    {
+        fwrite($this->buffer, $data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close()
+    {
+        fclose($this->buffer);
+        $this->buffer = null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function do_select($sec, $usec)
+    {
+        return !feof($this->buffer);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function connect()
+    {
+        $this->buffer = fopen('php://memory', 'rb+');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSocket()
+    {
+        return $this->buffer;
+    }
+}

--- a/tests/Unit/Test/TestChannel.php
+++ b/tests/Unit/Test/TestChannel.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Unit\Test;
+
+use PhpAmqpLib\Channel\AbstractChannel;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AbstractConnection;
+
+class TestChannel extends AMQPChannel
+{
+    /**
+     * @param AbstractConnection $connection
+     * @param int|null $channel_id
+     * @param bool $auto_decode
+     * @param int|float $channel_rpc_timeout
+     */
+    public function __construct($connection, $channel_id = null, $auto_decode = true, $channel_rpc_timeout = 0)
+    {
+        if ($channel_id === null) {
+            $channel_id = $connection->get_free_channel_id();
+        }
+
+        AbstractChannel::__construct($connection, $channel_id);
+
+        $this->debug->debug_msg('using channel_id: ' . $channel_id);
+
+        $this->auto_decode = $auto_decode;
+        $this->channel_rpc_timeout = $channel_rpc_timeout;
+    }
+}

--- a/tests/Unit/Test/TestConnection.php
+++ b/tests/Unit/Test/TestConnection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Unit\Test;
+
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Wire\AMQPReader;
+
+class TestConnection extends AbstractConnection
+{
+    /**
+     * @inheritDoc
+     */
+    public function connectOnConstruct()
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isConnected()
+    {
+        return true;
+    }
+
+    public function setIsBlocked($blocked = true)
+    {
+        if ($blocked) {
+            $this->connection_blocked(new AMQPReader(hex2bin('0120')));
+        } else {
+            $this->connection_unblocked();
+        }
+    }
+}


### PR DESCRIPTION
This library has support for blocked connection. Hovewer it allows to publish new messages even if broker cannot accept more.

This PR introduces a new exception `AMQPConnectionBlockedException` which can be thrown in methods `basic_publish()` and `publish_batch()`.

Some minor style improvements.