### PR TITLE
Enable TLS SNI by setting peer_name to $host in $ssl_options

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -23,6 +23,9 @@ class AMQPSSLConnection extends AMQPStreamConnection
         $options = array(),
         $ssl_protocol = 'ssl'
     ) {
+        if (!isset($ssl_options['peer_name'])) {
+            $ssl_options['peer_name'] = $host;
+        }
         $ssl_context = empty($ssl_options) ? null : $this->create_ssl_context($ssl_options);
         parent::__construct(
             $host,

--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -23,8 +23,8 @@ class AMQPSSLConnection extends AMQPStreamConnection
         $options = array(),
         $ssl_protocol = 'ssl'
     ) {
-        if (!isset($ssl_options['peer_name'])) {
-            $ssl_options['peer_name'] = $host;
+        if (!isset($ssl_options['SNI_enabled'])) {
+            $ssl_options['SNI_enabled'] = true;
         }
         $ssl_context = empty($ssl_options) ? null : $this->create_ssl_context($ssl_options);
         parent::__construct(


### PR DESCRIPTION
Required if multiple AMQP servers are behind a TLS termintator/load-balancer. 