### PR TITLE
Perform socket/stream select before data write

### DIFF
--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -148,6 +148,20 @@ abstract class AbstractIO
     }
 
     /**
+     * @throws \PhpAmqpLib\Exception\AMQPHeartbeatMissedException
+     */
+    protected function checkBrokerHeartbeat()
+    {
+        if ($this->heartbeat > 0 && $this->last_read > 0) {
+            $now = microtime(true);
+            if (($now - $this->last_read) > $this->heartbeat * 2) {
+                $this->close();
+                throw new AMQPHeartbeatMissedException('Missed server heartbeat');
+            }
+        }
+    }
+
+    /**
      * @return $this
      */
     public function disableHeartbeat()


### PR DESCRIPTION
Previously library executed `select` between data frames and never for small ones(<8kb). Without this check it is really possible to write to closed connection, actually OS buffer rather than real wire.

With this PR we will check connection with `select` before each write.

In summary:
- perform `select` before each write
- check for `EOF` before write to stream connection, like it is for read operations
- additional check for missed heartbeat before write
- tests and style improvements

Fix for #787

Known issues:
- there is no way to check for `EOF` for socket connections and is almost impossible to detect closed socket connection without access to low level OS internals