### PR TITLE
Fix unexpected missed heartbeat exception

### DIFF
--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -130,18 +130,12 @@ abstract class AbstractIO
     {
         // ignore unless heartbeat interval is set
         if ($this->heartbeat !== 0 && $this->last_read > 0 && $this->last_write > 0) {
-            $t = microtime(true);
-            $t_read = round($t - $this->last_read);
-            $t_write = round($t - $this->last_write);
-
             // server has gone away
-            if (($this->heartbeat * 2) < $t_read) {
-                $this->close();
-                throw new AMQPHeartbeatMissedException('Missed server heartbeat');
-            }
+            $this->checkBrokerHeartbeat();
 
             // time for client to send a heartbeat
-            if (($this->heartbeat / 2) < $t_write) {
+            $now = microtime(true);
+            if (($this->heartbeat / 2) < $now - $this->last_write) {
                 $this->write_heartbeat();
             }
         }
@@ -152,9 +146,10 @@ abstract class AbstractIO
      */
     protected function checkBrokerHeartbeat()
     {
-        if ($this->heartbeat > 0 && $this->last_read > 0) {
+        if ($this->heartbeat > 0 && ($this->last_read > 0 || $this->last_write > 0)) {
+            $lastActivity = max($this->last_read, $this->last_write);
             $now = microtime(true);
-            if (($now - $this->last_read) > $this->heartbeat * 2) {
+            if (($now - $lastActivity) > $this->heartbeat * 2 + 1) {
                 $this->close();
                 throw new AMQPHeartbeatMissedException('Missed server heartbeat');
             }

--- a/tests/Functional/AbstractConnectionTest.php
+++ b/tests/Functional/AbstractConnectionTest.php
@@ -81,6 +81,20 @@ abstract class AbstractConnectionTest extends TestCase
     }
 
     /**
+     * @param string $connectionType
+     * @param array $options
+     * @return AMQPChannel
+     */
+    protected function channel_create($connectionType, $options = [])
+    {
+        $connection = $this->conection_create($connectionType, HOST, PORT, $options);
+        $channel = $connection->channel();
+        $this->assertTrue($channel->is_open());
+
+        return $channel;
+    }
+
+    /**
      * @param string $name
      * @return ToxiProxy
      */


### PR DESCRIPTION
Check last read & write activity before throwing missed broker heartbeat exception.
fix #793 