### PR TITLE
Exclude non-essential files from dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,18 +2,20 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
-/.editorconfig export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.travis.yml export-ignore
-/.scrutinizer.yml export-ignore
+/.* export-ignore
 /appveyor.yml export-ignore
-/docker-compose.yml
+/benchmark export-ignore
+/CONTRIBUTING.md export-ignore
+/CREDITS export-ignore
+/docker-compose.yaml export-ignore
 /Makefile export-ignore
 /NOTE.DEVELOPMENT.NOV.2011.md export-ignore
 /NOTE.THENETCIRCLE.md export-ignore
 /benchmark export-ignore
 /demo export-ignore
 /doc export-ignore
+/docker export-ignore
+/docs export-ignore
 /phpunit.xml.dist export-ignore
+/spec export-ignore
 /tests export-ignore


### PR DESCRIPTION
Excludes files and dirs:

- .github/
- docker/
- docs/
- spec/
- .gitmodules
- CONTRIBUTING.md
- CREDITS
- docker-compose.yaml
