### PR TITLE
CI tests for PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: COVERAGE=true
     - php: 7.4
   fast_finish: true
-  allow_failures:
-    - php: 7.4
 
 git:
     depth: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,8 @@ environment:
     PHP_VERSION: 7.2
   - dependencies: highest
     PHP_VERSION: 7.3
+  - dependencies: highest
+    PHP_VERSION: 7.4
   COMPOSER_CACHE: "%USERPROFILE%\\composer"
   RABBITMQ_VERSION: 3.7.17
   ERLANG_VERSION: 10.4


### PR DESCRIPTION
PHP 7.4 as fully supported minro version, on linux and windows.

Link to successful windows builds:
https://ci.appveyor.com/project/ramunasd/php-amqplib/builds/33419583