### PR TITLE
Update AbstractIO.php

### DIFF
--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -180,7 +180,13 @@ abstract class AbstractIO
     public function reenableHeartbeat()
     {
         $this->heartbeat = $this->initial_heartbeat;
-
+        
+        // check if it is time for client to send a heartbeat
+        $now = microtime(true);
+        if (($this->heartbeat / 2) < $now - $this->last_write) {
+            $this->write_heartbeat();
+        }
+        
         return $this;
     }
 

--- a/tests/Functional/Connection/ConnectionClosedTest.php
+++ b/tests/Functional/Connection/ConnectionClosedTest.php
@@ -188,9 +188,9 @@ class ConnectionClosedTest extends AbstractConnectionTest
     public function must_not_throw_exception_missed_heartbeat_disabled($type, $size)
     {
         $channel = $this->channel_create($type, [
-            'keepalive' => false,
+            'keepalive' => true,
             'heartbeat' => $heartbeat = 1,
-            'timeout' => 3,
+            'timeout' => 10,
         ]);
         $io = $channel->getConnection()->getIO();
 

--- a/tests/Functional/Connection/ConnectionClosedTest.php
+++ b/tests/Functional/Connection/ConnectionClosedTest.php
@@ -189,8 +189,8 @@ class ConnectionClosedTest extends AbstractConnectionTest
     {
         $channel = $this->channel_create($type, [
             'keepalive' => true,
-            'heartbeat' => $heartbeat = 1,
-            'timeout' => 10,
+            'heartbeat' => $heartbeat = 15,
+            'timeout' => 60,
         ]);
         $io = $channel->getConnection()->getIO();
 

--- a/tests/Functional/Connection/ConnectionClosedTest.php
+++ b/tests/Functional/Connection/ConnectionClosedTest.php
@@ -171,6 +171,56 @@ class ConnectionClosedTest extends AbstractConnectionTest
     }
 
     /**
+     * Try to write(publish) to connection after heartbeat was temporarily disabled
+     * @test
+     * @medium
+     * @group connection
+     * @testWith ["stream", 1024]
+     *           ["stream", 32768]
+     *           ["socket", 1024]
+     *           ["socket", 32768]
+     * @covers \PhpAmqpLib\Wire\IO\StreamIO::write()
+     * @covers \PhpAmqpLib\Wire\IO\SocketIO::write()
+     *
+     * @param string $type
+     * @param int $size
+     */
+    public function must_not_throw_exception_missed_heartbeat_disabled($type, $size)
+    {
+        $channel = $this->channel_create($type, [
+            'keepalive' => false,
+            'heartbeat' => $heartbeat = 1,
+            'timeout' => 3,
+        ]);
+        $connection = $channel->getConnection();
+
+        $this->queue_bind($channel, $exchange_name = 'test_exchange_broken', $queue_name);
+        $message = new AMQPMessage(
+            str_repeat('0', $size),
+            ['delivery_mode' => AMQPMessage::DELIVERY_MODE_NON_PERSISTENT]
+        );
+
+        // Disable heartbeat
+        $connection->disableHeartbeat();
+
+        // miss heartbeat
+        sleep($heartbeat * 2 + 1);
+
+        // Reenable heartbeat
+        $connection->reenableHeartbeat();
+
+        $exception = null;
+        try {
+            $channel->basic_publish($message, $exchange_name);
+        } catch (\PHPUnit_Exception $exception) {
+            throw $exception;
+        } catch (\Exception $exception) {
+        }
+
+        $this->assertEquals(null, $exception);
+    }
+
+    /**
      * When client constantly publish messages in async manner and broker does not send heartbeats.
      * @test
      * @medium

--- a/tests/Functional/Connection/ConnectionClosedTest.php
+++ b/tests/Functional/Connection/ConnectionClosedTest.php
@@ -192,7 +192,7 @@ class ConnectionClosedTest extends AbstractConnectionTest
             'heartbeat' => $heartbeat = 1,
             'timeout' => 3,
         ]);
-        $connection = $channel->getConnection();
+        $io = $channel->getConnection()->getIO();
 
         $this->queue_bind($channel, $exchange_name = 'test_exchange_broken', $queue_name);
         $message = new AMQPMessage(
@@ -201,13 +201,13 @@ class ConnectionClosedTest extends AbstractConnectionTest
         );
 
         // Disable heartbeat
-        $connection->disableHeartbeat();
+        $io->disableHeartbeat();
 
         // miss heartbeat
         sleep($heartbeat * 2 + 1);
 
         // Reenable heartbeat
-        $connection->reenableHeartbeat();
+        $io->reenableHeartbeat();
 
         $exception = null;
         try {


### PR DESCRIPTION
When running long-lasting tasks on a queue with heartbeat enabled, if you temporarily disable the heartbeat checks for the duration of the job being handled and then reenable heartbeats immediately after it would never be able to recover without manually writing a heartbeat to the stream. If we just send a heartbeat if one is necessary immediately after reenabling the heartbeat checks it should allow the following use case to work;

handling process consuming a job -> receives a job that is expected to last a long time -> disables heartbeats -> handles job -> reenables heartbeat -> continues listening for futher jobs