### PR TITLE
Heartbeat disable and reenable after missed heartbeat no longer throws.

### DIFF
--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -179,8 +179,14 @@ abstract class AbstractIO
      */
     public function reenableHeartbeat()
     {
-        $this->heartbeat = $this->initial_heartbeat;
+        // check if it is time for client to send a heartbeat
+        $now = microtime(true);
+        if (($this->initial_heartbeat / 2) < $now - $this->last_write) {
+            $this->write_heartbeat();
+        }
 
+        $this->heartbeat = $this->initial_heartbeat;
+        
         return $this;
     }
 


### PR DESCRIPTION
I inadvertently closed this PR https://github.com/php-amqplib/php-amqplib/pull/818 so reopening as new.

@ramunasd tagging I cannot reopen the old PR so I am here now. Hopefully this one is clean.