### PR TITLE
revert #785 'Enable TLS SNI by default'

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -23,9 +23,6 @@ class AMQPSSLConnection extends AMQPStreamConnection
         $options = array(),
         $ssl_protocol = 'ssl'
     ) {
-        if (!isset($ssl_options['SNI_enabled'])) {
-            $ssl_options['SNI_enabled'] = true;
-        }
         $ssl_context = empty($ssl_options) ? null : $this->create_ssl_context($ssl_options);
         parent::__construct(
             $host,


### PR DESCRIPTION
Looks like SSL context must be created with all esential options otherwise PHP fails to connect with "unknown error".
#785 introduced backward incompatible changes. Fix #825 