### PR TITLE
Use docker containers for broker and proxy in travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,12 @@ git:
 services:
   - docker
 
-addons:
-  apt:
-    packages:
-      - rabbitmq-server
-
 cache:
   directories:
     - $HOME/.composer
 
 before_install:
-  - docker pull shopify/toxiproxy
-  - docker run --detach --rm --net=host --publish 8474:8474 --publish 5673:5673 shopify/toxiproxy
+  - docker-compose -f docker-compose.yaml -f tests/docker-compose.travis.yaml up -d
   - docker ps --all
   - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
 
@@ -38,9 +32,10 @@ env:
 
 before_script:
   - travis_retry composer update --no-interaction --prefer-dist
+  - php tests/wait_broker.php
 
 script:
-  - vendor/bin/phpunit -d zend.enable_gc=0 --exclude-group management --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit -d zend.enable_gc=0 --coverage-text --coverage-clover=coverage.clover
 
 after_success: >
   if [[ $COVERAGE = true ]]; then

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,6 @@ services:
       - TEST_RABBITMQ_HOST=rabbitmq
       - TOXIPROXY_HOST=proxy
       - TOXIPROXY_AMQP_PORT=5673
-    links:
-      - rabbitmq
     depends_on:
       - rabbitmq
       - proxy
@@ -26,5 +24,5 @@ services:
     ports:
       - "8474:8474"
       - "5673:5673"
-    links:
+    depends_on:
       - rabbitmq

--- a/tests/docker-compose.travis.yaml
+++ b/tests/docker-compose.travis.yaml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  php:
+    network_mode: host
+  rabbitmq:
+    network_mode: host
+  proxy:
+    network_mode: host

--- a/tests/phpinfo.php
+++ b/tests/phpinfo.php
@@ -14,6 +14,7 @@ echo 'PHP_INT_MAX=', PHP_INT_MAX, PHP_EOL;
 echo '# Constants', PHP_EOL;
 $constants = get_defined_constants(true);
 $socketConstant = isset($constants['sockets']) ? $constants['sockets'] : array();
+ksort($socketConstant);
 foreach ($socketConstant as $name => $value) {
     echo sprintf('%-30s', $name), $value, PHP_EOL;
 }

--- a/tests/wait_broker.php
+++ b/tests/wait_broker.php
@@ -1,0 +1,34 @@
+<?php
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
+require __DIR__ . '/bootstrap.php';
+
+$exception = null;
+$timeout = isset($argv[1]) ? (int)$argv[1] : 30;
+$start = microtime(true);
+$until = $start + $timeout;
+
+do {
+    try {
+        $connection = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
+        if ($connection->isConnected()) {
+            echo 'Broker is ready to accept connections', PHP_EOL;
+            die;
+        }
+    } catch (Exception $exception) {
+        echo '.';
+        sleep(1);
+    }
+} while ($until > time());
+
+$end = microtime(true);
+if ($until < $end) {
+    echo sprintf('Broker wait timeout out after %.1f', $end - $start), PHP_EOL;
+    if ($exception) {
+        echo $exception->getCode(), ':', $exception->getMessage(), PHP_EOL;
+    }
+}


### PR DESCRIPTION
This will let us enable user authentication and secure connection tests much more easier. We will use broker and proxy instances in docker containers while PHP stays locally installed. That's why we need to have special network config for travis environment and broker wait script.