### PR TITLE
validate basic_consume() arguments and avoid invalid callbacks

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -944,7 +944,10 @@ class AMQPChannel extends AbstractChannel
     }
 
     /**
-     * Starts a queue consumer
+     * Start a queue consumer.
+     * This method asks the server to start a "consumer", which is a transient request for messages from a specific queue.
+     * Consumers last as long as the channel they were declared on, or until the client cancels them.
+     * @link https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
      *
      * @param string $queue
      * @param string $consumer_tag
@@ -957,7 +960,7 @@ class AMQPChannel extends AbstractChannel
      * @param array $arguments
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @throws \InvalidArgumentException
-     * @return mixed|string
+     * @return string
      */
     public function basic_consume(
         $queue = '',
@@ -972,6 +975,12 @@ class AMQPChannel extends AbstractChannel
     ) {
         if (null !== $callback) {
             Assert::isCallable($callback);
+        }
+        if ($nowait && empty($consumer_tag)) {
+            throw new \InvalidArgumentException('Cannot start consumer without consumer_tag and no-wait=true');
+        }
+        if (!empty($consumer_tag) && array_key_exists($consumer_tag, $this->callbacks)) {
+            throw new \InvalidArgumentException('This consumer tag is already registered.');
         }
 
         $ticket = $this->getTicket($ticket);

--- a/tests/Functional/Channel/ChannelConsumeTest.php
+++ b/tests/Functional/Channel/ChannelConsumeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Channel;
+
+class ChannelConsumeTest extends ChannelTestCase
+{
+    /**
+     * @test
+     */
+    public function basic_consume_same_tag_thros_exception()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        list($queue, ,) = $this->channel->queue_declare();
+        $consumerTag = $this->channel->basic_consume($queue, '');
+        $this->channel->basic_consume($queue, $consumerTag);
+    }
+}

--- a/tests/Unit/Channel/AMQPChannelTest.php
+++ b/tests/Unit/Channel/AMQPChannelTest.php
@@ -52,6 +52,18 @@ class AMQPChannelTest extends TestCase
                 ],
                 \InvalidArgumentException::class,
             ],
+            [
+                [
+                    '',
+                    '',
+                    false,
+                    false,
+                    false,
+                    true,
+                    'sleep',
+                ],
+                \InvalidArgumentException::class,
+            ]
         ];
     }
 }


### PR DESCRIPTION
This will prevent from cases, when `AMQPChannel::basic_consume()` with empty `$consumer_tag` and `$nowait=true` can overwrite previous callback or callback won't be called on new message.
Also, improved doc block and tests.

Should be last for bugfix version 2.12.1