### PR TITLE
Implement \ArrayAccess in AMQPAbstractCollection

### DIFF
--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -9,7 +9,7 @@ use PhpAmqpLib\Wire;
 /**
  * Iterator implemented for transparent integration with AMQPWriter::write_[array|table]()
  */
-abstract class AMQPAbstractCollection implements \Iterator
+abstract class AMQPAbstractCollection implements \Iterator, \ArrayAccess
 {
     //protocol defines available field types and their corresponding symbols
     /** @deprecated */
@@ -191,6 +191,28 @@ abstract class AMQPAbstractCollection implements \Iterator
         }
 
         return $val;
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        $value = isset($this->data[$offset]) ? $this->data[$offset] : null;
+
+        return is_array($value) ? $value[1] : $value;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->setValue($value, null, $offset);
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
     }
 
     /**

--- a/tests/Unit/Wire/AMQPCollectionTest.php
+++ b/tests/Unit/Wire/AMQPCollectionTest.php
@@ -613,6 +613,23 @@ class AMQPCollectionTest extends TestCase
         }
     }
 
+    /**
+     * @test
+     */
+    public function work_with_table_as_array()
+    {
+        $a = new Wire\AMQPTable();
+        $a['test'] = 'value';
+        $a['unset'] = 'value';
+        unset($a['unset']);
+
+        $this->assertInstanceOf(\ArrayAccess::class, $a);
+        $this->assertTrue(isset($a['test']));
+        $this->assertEquals('value', $a['test']);
+        $this->assertArrayNotHasKey('unset', $a);
+        $this->assertNull($a['undefined_key']);
+    }
+
     protected function setProtoVersion($proto)
     {
         $r = new \ReflectionProperty('\\PhpAmqpLib\\Wire\\AMQPAbstractCollection', '_protocol');


### PR DESCRIPTION
Implement \ArrayAccess in AMQPAbstractCollection, so we can use AMQPTable as array, for example:
```php
        $a = new Wire\AMQPTable();
        $a['test'] = 'value';
        unset($a['test']);
```