### PR TITLE
Fix Required parameter before optional parameter

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -180,7 +180,7 @@ abstract class AbstractConnection extends AbstractChannel
         $login_method = 'AMQPLAIN',
         $login_response = null,
         $locale = 'en_US',
-        AbstractIO $io,
+        AbstractIO $io = null,
         $heartbeat = 0,
         $connection_timeout = 0,
         $channel_rpc_timeout = 0.0

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -175,12 +175,12 @@ abstract class AbstractConnection extends AbstractChannel
     public function __construct(
         $user,
         $password,
-        $vhost = '/',
-        $insist = false,
-        $login_method = 'AMQPLAIN',
-        $login_response = null,
-        $locale = 'en_US',
-        AbstractIO $io = null,
+        $vhost,
+        $insist,
+        $login_method,
+        $login_response,
+        $locale,
+        AbstractIO $io,
         $heartbeat = 0,
         $connection_timeout = 0,
         $channel_rpc_timeout = 0.0


### PR DESCRIPTION
Fix warning Required parameter ``$io`` follows optional parameter ``$vhost`` showed at **PHP 8**