### PR TITLE
fix PCNTL heartbeat signal registration

### DIFF
--- a/PhpAmqpLib/Connection/Heartbeat/PCNTLHeartbeatSender.php
+++ b/PhpAmqpLib/Connection/Heartbeat/PCNTLHeartbeatSender.php
@@ -76,12 +76,17 @@ final class PCNTLHeartbeatSender
     private function registerListener($interval)
     {
         pcntl_signal(SIGALRM, function () use ($interval) {
-            if (!$this->connection || $this->connection->isWriting()) {
+            if (!$this->connection) {
                 return;
             }
 
             if (!$this->connection->isConnected()) {
                 $this->unregister();
+                return;
+            }
+
+            if ($this->connection->isWriting()) {
+                pcntl_alarm($interval);
                 return;
             }
 

--- a/tests/Functional/Connection/Heartbeat/PCNTLHeartbeatSenderTest.php
+++ b/tests/Functional/Connection/Heartbeat/PCNTLHeartbeatSenderTest.php
@@ -125,7 +125,7 @@ class PCNTLHeartbeatSenderTest extends AbstractConnectionTest
         $sender = new PCNTLHeartbeatSender($connection);
         $sender->register();
 
-        $timeLeft = $this->heartbeatTimeout;
+        $timeLeft = $this->heartbeatTimeout + 1;
         while ($timeLeft > 0) {
             $timeLeft = sleep($timeLeft);
         }


### PR DESCRIPTION
This is a fix for PCNTL heartbeat signal registration/chaining issue described in https://github.com/php-amqplib/php-amqplib/issues/865