### PR TITLE
fix annotation when AMQPTable is allowed variable type

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -13,6 +13,7 @@ use PhpAmqpLib\Helper\Assert;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire;
 use PhpAmqpLib\Wire\AMQPReader;
+use PhpAmqpLib\Wire\AMQPTable;
 use PhpAmqpLib\Wire\AMQPWriter;
 
 class AMQPChannel extends AbstractChannel
@@ -353,7 +354,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $auto_delete
      * @param bool $internal
      * @param bool $nowait
-     * @param array $arguments
+     * @param AMQPTable|array $arguments
      * @param int|null $ticket
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
@@ -450,7 +451,7 @@ class AMQPChannel extends AbstractChannel
      * @param string $source
      * @param string $routing_key
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @param int|null $ticket
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
@@ -499,7 +500,7 @@ class AMQPChannel extends AbstractChannel
      * @param string $source
      * @param string $routing_key
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @param int|null $ticket
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
@@ -544,7 +545,7 @@ class AMQPChannel extends AbstractChannel
      * @param string $exchange
      * @param string $routing_key
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @param int|null $ticket
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed|null
@@ -592,7 +593,7 @@ class AMQPChannel extends AbstractChannel
      * @param string $queue
      * @param string $exchange
      * @param string $routing_key
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @param int|null $ticket
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return mixed
@@ -637,10 +638,10 @@ class AMQPChannel extends AbstractChannel
      * @param bool $exclusive
      * @param bool $auto_delete
      * @param bool $nowait
-     * @param array|\PhpAmqpLib\Wire\AMQPTable $arguments
+     * @param array|AMQPTable $arguments
      * @param int|null $ticket
-     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @return array|null
+     *@throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      */
     public function queue_declare(
         $queue = '',
@@ -957,7 +958,7 @@ class AMQPChannel extends AbstractChannel
      * @param bool $nowait
      * @param callable|null $callback
      * @param int|null $ticket
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      *
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
      * @throws \InvalidArgumentException

--- a/PhpAmqpLib/Helper/Protocol/Protocol080.php
+++ b/PhpAmqpLib/Helper/Protocol/Protocol080.php
@@ -209,7 +209,7 @@ class Protocol080
     /**
      * @param int $reply_code
      * @param string $reply_text
-     * @param array $details
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $details
      * @return array
      */
     public function channelAlert($reply_code, $reply_text = '', $details = array())
@@ -291,7 +291,7 @@ class Protocol080
      * @param bool $auto_delete
      * @param bool $internal
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function exchangeDeclare(
@@ -358,7 +358,7 @@ class Protocol080
      * @param bool $exclusive
      * @param bool $auto_delete
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function queueDeclare(
@@ -398,7 +398,7 @@ class Protocol080
      * @param string $exchange
      * @param string $routing_key
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function queueBind(
@@ -488,7 +488,7 @@ class Protocol080
      * @param string $queue
      * @param string $exchange
      * @param string $routing_key
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function queueUnbind($ticket = 1, $queue = '', $exchange, $routing_key = '', $arguments = array())
@@ -1215,7 +1215,7 @@ class Protocol080
     }
 
     /**
-     * @param mixed $meta_data
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $meta_data
      * @return array
      */
     public function tunnelRequest($meta_data)
@@ -1226,11 +1226,11 @@ class Protocol080
     }
 
     /**
-     * @param mixed $integer_1
+     * @param int $integer_1
      * @param int $integer_2
      * @param int $integer_3
      * @param int $integer_4
-     * @param mixed $operation
+     * @param int $operation
      * @return array
      */
     public function testInteger($integer_1, $integer_2, $integer_3, $integer_4, $operation)
@@ -1258,7 +1258,7 @@ class Protocol080
     /**
      * @param string $string_1
      * @param string $string_2
-     * @param mixed $operation
+     * @param int $operation
      * @return array
      */
     public function testString($string_1, $string_2, $operation)
@@ -1282,9 +1282,9 @@ class Protocol080
     }
 
     /**
-     * @param mixed $table
-     * @param mixed $integer_op
-     * @param mixed $string_op
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $table
+     * @param int $integer_op
+     * @param int $string_op
      * @return array
      */
     public function testTable($table, $integer_op, $string_op)

--- a/PhpAmqpLib/Helper/Protocol/Protocol091.php
+++ b/PhpAmqpLib/Helper/Protocol/Protocol091.php
@@ -285,7 +285,7 @@ class Protocol091
      * @param bool $auto_delete
      * @param bool $internal
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function exchangeDeclare(
@@ -350,7 +350,7 @@ class Protocol091
      * @param string $source
      * @param string $routing_key
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function exchangeBind(
@@ -387,7 +387,7 @@ class Protocol091
      * @param string $source
      * @param string $routing_key
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function exchangeUnbind(
@@ -426,7 +426,7 @@ class Protocol091
      * @param bool $exclusive
      * @param bool $auto_delete
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function queueDeclare(
@@ -466,7 +466,7 @@ class Protocol091
      * @param string $exchange
      * @param string $routing_key
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function queueBind(
@@ -556,7 +556,7 @@ class Protocol091
      * @param string $queue
      * @param string $exchange
      * @param string $routing_key
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function queueUnbind($ticket = 0, $queue = '', $exchange, $routing_key = '', $arguments = array())
@@ -613,7 +613,7 @@ class Protocol091
      * @param bool $no_ack
      * @param bool $exclusive
      * @param bool $nowait
-     * @param array $arguments
+     * @param \PhpAmqpLib\Wire\AMQPTable|array $arguments
      * @return array
      */
     public function basicConsume(

--- a/PhpAmqpLib/Wire/Constants080.php
+++ b/PhpAmqpLib/Wire/Constants080.php
@@ -12,7 +12,7 @@ final class Constants080 extends Constants
     /**
      * @var array
      */
-    protected static $FRAME_TYPES = array(
+    public static $FRAME_TYPES = array(
         1 => 'FRAME-METHOD',
         2 => 'FRAME-HEADER',
         3 => 'FRAME-BODY',
@@ -29,7 +29,7 @@ final class Constants080 extends Constants
     /**
      * @var array
      */
-    protected static $CONTENT_METHODS = array(
+    public static $CONTENT_METHODS = array(
         0 => '60,40',
         1 => '60,50',
         2 => '60,60',
@@ -47,7 +47,7 @@ final class Constants080 extends Constants
     /**
      * @var array
      */
-    protected static $CLOSE_METHODS = array(
+    public static $CLOSE_METHODS = array(
         0 => '10,60',
         1 => '20,40',
     );

--- a/spec/parser.php
+++ b/spec/parser.php
@@ -51,10 +51,10 @@ function addPhpDocParams($arguments)
 function translateType($argument)
 {
     $type = null;
-    if (array_key_exists('default-value', $argument)) {
-        $type = gettype($argument['default-value']);
-    } elseif (array_key_exists('type', $argument)) {
+    if (array_key_exists('type', $argument)) {
         $type = $argument['type'];
+    } elseif (array_key_exists('default-value', $argument)) {
+        $type = gettype($argument['default-value']);
     }
 
     switch ($type) {
@@ -63,6 +63,7 @@ function translateType($argument)
         case 'string':
             return 'string';
         case 'short':
+        case 'octet':
         case 'long':
         case 'longlong':
         case 'integer':
@@ -74,9 +75,12 @@ function translateType($argument)
             return 'bool';
         case 'array':
             return 'array';
+        case 'table':
+            return '\PhpAmqpLib\Wire\AMQPTable|array';
         default:
-            return 'mixed';
     }
+
+    return 'mixed';
 }
 
 function argument_default_val($arg)


### PR DESCRIPTION
As reported in #873, AMQPTable is allowed variable type in several methods.