### PR TITLE
Add support for next major version of phpseclib/phpseclib

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,13 +4,24 @@ on: [push, pull_request]
 
 jobs:
   run:
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       matrix:
-        operating-system: [ubuntu-latest]
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '7.4']
+        include:
+            - php: '5.6'
+              phpseclib: '^2.0'
+            - php: '7.0'
+              phpseclib: '^2.0'
+            - php: '7.1'
+              phpseclib: '^2.0'
+            - php: '7.2'
+              phpseclib: '^2.0'
+            - php: '7.3'
+              phpseclib: '^3.0'
+            - php: '7.4'
+              phpseclib: '^3.0'
     services:
       rabbitmq:
         image: rabbitmq:3-management
@@ -43,7 +54,7 @@ jobs:
     - name: Start broker service
       run: docker start ${{ job.services.rabbitmq.id }}
     - name: Composer install
-      run: composer update --prefer-dist --no-progress --no-suggest
+      run: composer require --prefer-dist --no-progress --no-suggest phpseclib/phpseclib ${{ matrix.phpseclib }}
     - name: Wait for broker service
       run: php ./tests/wait_broker.php
     - name: PHPUnit tests

--- a/PhpAmqpLib/Helper/BigInteger.php
+++ b/PhpAmqpLib/Helper/BigInteger.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpAmqpLib\Helper;
+
+if (class_exists('phpseclib\Math\BigInteger')) {
+    class_alias('phpseclib\Math\BigInteger', 'PhpAmqpLib\Helper\BigInteger');
+} elseif (class_exists('phpseclib3\Math\BigInteger')) {
+    class_alias('phpseclib3\Math\BigInteger', 'PhpAmqpLib\Helper\BigInteger');
+} else {
+    throw new \RuntimeException('Cannot find supported phpseclib/phpseclib library');
+}

--- a/PhpAmqpLib/Wire/AMQPDecimal.php
+++ b/PhpAmqpLib/Wire/AMQPDecimal.php
@@ -3,7 +3,7 @@
 namespace PhpAmqpLib\Wire;
 
 use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
-use phpseclib\Math\BigInteger;
+use PhpAmqpLib\Helper\BigInteger;
 
 /**
  * AMQP protocol decimal value.

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -10,7 +10,7 @@ use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Helper\MiscHelper;
 use PhpAmqpLib\Wire\IO\AbstractIO;
-use phpseclib\Math\BigInteger;
+use PhpAmqpLib\Helper\BigInteger;
 
 /**
  * This class can read from a string or from a stream

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -4,7 +4,7 @@ namespace PhpAmqpLib\Wire;
 
 use PhpAmqpLib\Exception\AMQPInvalidArgumentException;
 use PhpAmqpLib\Exception\AMQPOutOfRangeException;
-use phpseclib\Math\BigInteger;
+use PhpAmqpLib\Helper\BigInteger;
 
 class AMQPWriter extends AbstractClient
 {

--- a/PhpAmqpLib/Wire/AbstractClient.php
+++ b/PhpAmqpLib/Wire/AbstractClient.php
@@ -2,7 +2,7 @@
 
 namespace PhpAmqpLib\Wire;
 
-use phpseclib\Math\BigInteger;
+use PhpAmqpLib\Helper\BigInteger;
 
 class AbstractClient
 {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php": ">=5.6.3,<8.0",
         "ext-sockets": "*",
         "ext-mbstring": "*",
-        "phpseclib/phpseclib": "^2.0.0"
+        "phpseclib/phpseclib": "^2.0|^3.0"
     },
     "require-dev": {
         "ext-curl": "*",


### PR DESCRIPTION
By using class aliases, we can make this library compatible with any of two latest major versions of phpseclib/phpseclib. So we neither block or enforce any upgrades, users can choose which version works best for them.

Tested on 32-bit windows and ARM platforms.

fixes #867