### PR TITLE
Fix: Required parameter $io follows optional parameter $vhost

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -181,11 +181,15 @@ abstract class AbstractConnection extends AbstractChannel
         $login_method = 'AMQPLAIN',
         $login_response = null,
         $locale = 'en_US',
-        AbstractIO $io,
+        AbstractIO $io = null,
         $heartbeat = 0,
         $connection_timeout = 0,
         $channel_rpc_timeout = 0.0
     ) {
+        if ($io === null) {
+            throw new \BadMethodCallException('The parameter $io is required.');
+        }
+
         // save the params for the use of __clone
         $this->construct_params = func_get_args();
 


### PR DESCRIPTION
Hi everyone,

This PR fixes an issue with PHP 8.0: "Required parameter $io follows optional parameter $vhost".

Because `$io` is now nullable I'm throwing an exception if it happens, to have similar behavior as before.

I've tested the branch with my service and it works as expected.

An alternative would be to move the `$io` parameter before optional ones because classes extending the abstract don't have that in their constructor but that would be a breaking change for external projects.

Best regards,

Olivier