### PR TITLE
fix ValueError on closed or broken socket

### DIFF
--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -2,6 +2,7 @@
 
 namespace PhpAmqpLib\Wire\IO;
 
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Exception\AMQPHeartbeatMissedException;
 use PhpAmqpLib\Exception\AMQPIOWaitException;
 use PhpAmqpLib\Wire\AMQPWriter;
@@ -105,6 +106,7 @@ abstract class AbstractIO
      * @param int|null $sec
      * @param int|null $usec
      * @return int|bool
+     * @throws AMQPConnectionClosedException
      */
     abstract protected function do_select($sec, $usec);
 

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -241,6 +241,11 @@ class SocketIO extends AbstractIO
      */
     protected function do_select($sec, $usec)
     {
+        if ($this->sock === null || !is_resource($this->sock)) {
+            $this->sock = null;
+            throw new AMQPConnectionClosedException('Broken pipe or closed connection', 0);
+        }
+
         $read = array($this->sock);
         $write = null;
         $except = null;

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -335,6 +335,11 @@ class StreamIO extends AbstractIO
      */
     protected function do_select($sec, $usec)
     {
+        if ($this->sock === null || !is_resource($this->sock)) {
+            $this->sock = null;
+            throw new AMQPConnectionClosedException('Broken pipe or closed connection', 0);
+        }
+
         $read = array($this->sock);
         $write = null;
         $except = null;

--- a/tests/Unit/Wire/IO/SocketIOTest.php
+++ b/tests/Unit/Wire/IO/SocketIOTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpAmqpLib\Tests\Unit\Wire\IO;
 
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Wire\IO\SocketIO;
 use PHPUnit\Framework\TestCase;
 
@@ -74,5 +75,25 @@ class SocketIOTest extends TestCase
     public function write_when_closed(SocketIO $socketIO)
     {
         $socketIO->write('data');
+    }
+
+    /**
+     * @test
+     * @group linux
+     * @requires OS Linux
+     */
+    public function select_must_throw_io_exception()
+    {
+        $this->expectException(AMQPConnectionClosedException::class);
+        $property = new \ReflectionProperty(SocketIO::class, 'sock');
+        $property->setAccessible(true);
+
+        $resource = fopen('php://temp', 'r');
+        fclose($resource);
+
+        $socket = new SocketIO('0.0.0.0', PORT, 0.1, 0.1, null, false, 0);
+        $property->setValue($socket, $resource);
+
+        $socket->select(0, 0);
     }
 }

--- a/tests/Unit/Wire/IO/StreamIOTest.php
+++ b/tests/Unit/Wire/IO/StreamIOTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpAmqpLib\Tests\Unit\Wire\IO;
 
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Wire\IO\StreamIO;
 use PHPUnit\Framework\TestCase;
 
@@ -32,11 +33,11 @@ class StreamIOTest extends TestCase
     /**
      * @test
      * @group linux
-     * @expectedException \PhpAmqpLib\Exception\AMQPIOWaitException
      * @requires OS Linux
      */
     public function select_must_throw_io_exception()
     {
+        $this->expectException(AMQPConnectionClosedException::class);
         $property = new \ReflectionProperty(StreamIO::class, 'sock');
         $property->setAccessible(true);
 


### PR DESCRIPTION
Since PHP8.0 stream_select() throws exception instead of warning if something is wrong with socket. This was noticed first in PR #858 
Now we will throw relevant exception in such cases.

More context: https://github.com/reactphp/event-loop/issues/220#issuecomment-763389310

fix #883 