### PR TITLE
Fix phpseclib3 compatibility issue

### DIFF
--- a/PhpAmqpLib/Helper/BigInteger.php
+++ b/PhpAmqpLib/Helper/BigInteger.php
@@ -1,11 +1,15 @@
 <?php
-
+// phpcs:ignoreFile
 namespace PhpAmqpLib\Helper;
 
 if (class_exists('phpseclib\Math\BigInteger')) {
-    class_alias('phpseclib\Math\BigInteger', 'PhpAmqpLib\Helper\BigInteger');
+    class BigInteger extends \phpseclib\Math\BigInteger
+    {
+    }
 } elseif (class_exists('phpseclib3\Math\BigInteger')) {
-    class_alias('phpseclib3\Math\BigInteger', 'PhpAmqpLib\Helper\BigInteger');
+    class BigInteger extends \phpseclib3\Math\BigInteger
+    {
+    }
 } else {
     throw new \RuntimeException('Cannot find supported phpseclib/phpseclib library');
 }


### PR DESCRIPTION
Issue #885

Replace phpseclib class alias with defined classes, otherwise authoritative class maps does not work as expected.

Created from 2.x branch, without latest master commits. Should be merged back to 2.x branch and released as bugfix version 2.12.3
I will merge into master branch afterwards.