### PR TITLE
Change php required version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.0|~8.0.0",
         "ext-sockets": "*",
         "ext-mbstring": "*",
         "phpseclib/phpseclib": "^2.0|^3.0"


### PR DESCRIPTION
Future versions of PHP (8.1, 9, ...) might break the code.
We need to be more specific on the list of supported php versions and
add the new versions when they will be released and tested.