### PR TITLE
Fixed composer php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     ],
     "require": {
-        "php": "^7.0|~8.0.0",
+        "php": "^7.0||~8.0.0",
         "ext-sockets": "*",
         "ext-mbstring": "*",
         "phpseclib/phpseclib": "^2.0|^3.0"


### PR DESCRIPTION
Can't install using php7.4.
See here: https://jubianchi.github.io/semver-check/#/^7.0|~8.0.0/7.4
Fix: https://jubianchi.github.io/semver-check/#/^7.0||~8.0.0/7.4