### PR TITLE
Improved examples and dosc

### DIFF
--- a/demo/basic_get.php
+++ b/demo/basic_get.php
@@ -42,8 +42,7 @@ $toSend = new AMQPMessage('test message', array('content_type' => 'text/plain', 
 $channel->basic_publish($toSend, $exchange);
 
 $message = $channel->basic_get($queue);
-
-$channel->basic_ack($message->delivery_info['delivery_tag']);
+$message->ack();
 
 var_dump($message->body);
 

--- a/demo/basic_qos.php
+++ b/demo/basic_qos.php
@@ -14,7 +14,7 @@ $channel->basic_qos(null, 10000, null);
 
 function process_message($message)
 {
-    $message->delivery_info['channel']->basic_ack($message->delivery_info['delivery_tag']);
+    $message->ack();
 }
 
 $channel->basic_consume('qos_queue', '', false, false, false, false, 'process_message');

--- a/doc/AMQPMessage.md
+++ b/doc/AMQPMessage.md
@@ -38,8 +38,12 @@ Getting message properties:
 
 You can acknowledge messages by sending a `basic_ack` on the channel:
 
-    $msg->delivery_info['channel']->
-        basic_ack($msg->delivery_info['delivery_tag']);
+    $msg->getChannel()->
+        basic_ack($msg->getDeliveryTag());
+
+Or by sending `ack` method on the message:
+
+    $msg->ack();
 
 Keep in mind that the `delivery_tag` has to be valid so most of the time just use the one provide by the server.
 


### PR DESCRIPTION
Removed using of internal property `AMQPMessage::delivery_info` from docs and examples.