### PR TITLE
Returned connection can be null

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -162,7 +162,7 @@ abstract class AbstractChannel
     }
 
     /**
-     * @return AbstractConnection
+     * @return AbstractConnection|null
      */
     public function getConnection()
     {


### PR DESCRIPTION
Method getConnection may return `null`, therefore PHPDocs should be changed accordingly.