### PR TITLE
Add support for floating point values in tables/array

### DIFF
--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -37,6 +37,10 @@ abstract class AMQPAbstractCollection implements \Iterator, \ArrayAccess
     const T_TABLE = 16;
 
     const T_BYTES = 17;
+
+    const T_FLOAT = 18;
+    const T_DOUBLE = 19;
+
     /**
      * @var string
      */
@@ -46,6 +50,7 @@ abstract class AMQPAbstractCollection implements \Iterator, \ArrayAccess
      * Field types messy mess http://www.rabbitmq.com/amqp-0-9-1-errata.html#section_3
      * Default behaviour is to use rabbitMQ compatible field-set
      * Define AMQP_STRICT_FLD_TYPES=true to use strict AMQP instead
+     * @var array<int, string>
      */
     private static $types_080 = array(
         self::T_INT_LONG => 'I',
@@ -56,7 +61,7 @@ abstract class AMQPAbstractCollection implements \Iterator, \ArrayAccess
     );
 
     /**
-     * @var array
+     * @var array<int, string>
      */
     private static $types_091 = array(
         self::T_INT_SHORTSHORT => 'b',
@@ -67,6 +72,8 @@ abstract class AMQPAbstractCollection implements \Iterator, \ArrayAccess
         self::T_INT_LONG_U => 'i',
         self::T_INT_LONGLONG => 'L',
         self::T_INT_LONGLONG_U => 'l',
+        self::T_FLOAT => 'f',
+        self::T_DOUBLE => 'd',
         self::T_DECIMAL => 'D',
         self::T_TIMESTAMP => 'T',
         self::T_VOID => 'V',
@@ -79,13 +86,18 @@ abstract class AMQPAbstractCollection implements \Iterator, \ArrayAccess
     );
 
     /**
-     * @var array
+     * @var array<int, string>
      */
     private static $types_rabbit = array(
         self::T_INT_SHORTSHORT => 'b',
+        self::T_INT_SHORTSHORT_U => 'B',
         self::T_INT_SHORT => 's',
+        self::T_INT_SHORT_U => 'u',
         self::T_INT_LONG => 'I',
+        self::T_INT_LONG_U => 'i',
         self::T_INT_LONGLONG => 'l',
+        self::T_FLOAT => 'f',
+        self::T_DOUBLE => 'd',
         self::T_DECIMAL => 'D',
         self::T_TIMESTAMP => 'T',
         self::T_VOID => 'V',

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -354,6 +354,28 @@ class AMQPReader extends AbstractClient
     }
 
     /**
+     * @return float
+     */
+    public function read_float()
+    {
+        $this->resetCounters();
+        list(, $res) = unpack('G', $this->rawread(4));
+
+        return (float)$res;
+    }
+
+    /**
+     * @return float
+     */
+    public function read_double()
+    {
+        $this->resetCounters();
+        list(, $res) = unpack('E', $this->rawread(8));
+
+        return (float)$res;
+    }
+
+    /**
      * Read a utf-8 encoded string that's stored in up to
      * 255 bytes.  Return it decoded as a PHP unicode object.
      * @return string
@@ -528,6 +550,12 @@ class AMQPReader extends AbstractClient
                 break;
             case AMQPAbstractCollection::T_VOID:
                 $val = null;
+                break;
+            case AMQPAbstractCollection::T_FLOAT:
+                $val = $this->read_float();
+                break;
+            case AMQPAbstractCollection::T_DOUBLE:
+                $val = $this->read_double();
                 break;
             default:
                 throw new AMQPInvalidArgumentException(sprintf(

--- a/tests/Unit/Wire/AMQPCollectionTest.php
+++ b/tests/Unit/Wire/AMQPCollectionTest.php
@@ -2,6 +2,9 @@
 
 namespace PhpAmqpLib\Tests\Unit\Wire;
 
+use PhpAmqpLib\Exception\AMQPInvalidArgumentException;
+use PhpAmqpLib\Exception\AMQPOutOfBoundsException;
+use PhpAmqpLib\Exception\AMQPOutOfRangeException;
 use PhpAmqpLib\Wire;
 use PHPUnit\Framework\TestCase;
 
@@ -121,9 +124,11 @@ class AMQPCollectionTest extends TestCase
             ['foo' => 'bar'],
             ['foo'],
             [],
+            .9999,
+            -.9999,
         ]);
 
-        $is64 = PHP_INT_SIZE == 8;
+        $is64 = PHP_INT_SIZE === 8;
 
         $this->assertEquals(
             [
@@ -181,6 +186,14 @@ class AMQPCollectionTest extends TestCase
                     Wire\AMQPAbstractCollection::getDataTypeForSymbol('A'),
                     [],
                 ],
+                [
+                    Wire\AMQPAbstractCollection::getDataTypeForSymbol('S'),
+                    '0.9999',
+                ],
+                [
+                    Wire\AMQPAbstractCollection::getDataTypeForSymbol('S'),
+                    '-0.9999',
+                ],
             ],
             $this->getEncodedRawData($a)
         );
@@ -210,9 +223,11 @@ class AMQPCollectionTest extends TestCase
             ['foo' => 'bar'],
             ['foo'],
             [],
+            .9999,
+            -.9999,
         ]);
 
-        $is64 = PHP_INT_SIZE == 8;
+        $is64 = PHP_INT_SIZE === 8;
 
         $this->assertEquals(
             [
@@ -270,6 +285,14 @@ class AMQPCollectionTest extends TestCase
                     Wire\AMQPAbstractCollection::getDataTypeForSymbol('A'),
                     [],
                 ],
+                [
+                    Wire\AMQPAbstractCollection::getDataTypeForSymbol('S'),
+                    '0.9999',
+                ],
+                [
+                    Wire\AMQPAbstractCollection::getDataTypeForSymbol('S'),
+                    '-0.9999',
+                ],
             ],
             $this->getEncodedRawData($a)
         );
@@ -286,8 +309,8 @@ class AMQPCollectionTest extends TestCase
      */
     public function encode_unknown_data_type()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPOutOfBoundsException::class);
-        $a = new Wire\AMQPArray(array(new \stdClass()));
+        $this->expectException(AMQPOutOfBoundsException::class);
+        new Wire\AMQPArray(array(new \stdClass()));
     }
 
     /**
@@ -295,12 +318,12 @@ class AMQPCollectionTest extends TestCase
      */
     public function push_unsupported_data_type_080()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPOutOfRangeException::class);
+        $this->expectException(AMQPOutOfRangeException::class);
 
         $this->setProtoVersion(Wire\Constants080::VERSION);
         $a = new Wire\AMQPArray();
 
-        $a->push(12345, Wire\AMQPArray::T_INT_LONGLONG);
+        $a->push(12345, Wire\AMQPAbstractCollection::T_INT_LONGLONG);
     }
 
     /**
@@ -308,7 +331,7 @@ class AMQPCollectionTest extends TestCase
      */
     public function push_unsupported_data_type_091()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPOutOfRangeException::class);
+        $this->expectException(AMQPOutOfRangeException::class);
 
         $this->setProtoVersion(Wire\Constants091::VERSION);
         $a = new Wire\AMQPArray();
@@ -321,12 +344,12 @@ class AMQPCollectionTest extends TestCase
      */
     public function push_unsupported_data_type_rabbit()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPOutOfRangeException::class);
+        $this->expectException(AMQPOutOfRangeException::class);
 
         $this->setProtoVersion(Wire\AMQPAbstractCollection::PROTOCOL_RBT);
         $a = new Wire\AMQPArray();
 
-        $a->push(12345, Wire\AMQPArray::T_INT_LONGLONG_U);
+        $a->push(12345, Wire\AMQPAbstractCollection::T_INT_LONGLONG_U);
     }
 
     /**
@@ -425,7 +448,7 @@ class AMQPCollectionTest extends TestCase
      */
     public function set_empty_key()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPInvalidArgumentException::class);
+        $this->expectException(AMQPInvalidArgumentException::class);
         $this->expectExceptionMessage('Table key must be non-empty string up to 128 chars in length');
 
         $t = new Wire\AMQPTable();
@@ -438,7 +461,7 @@ class AMQPCollectionTest extends TestCase
      */
     public function set_long_key()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPInvalidArgumentException::class);
+        $this->expectException(AMQPInvalidArgumentException::class);
         $this->expectExceptionMessage('Table key must be non-empty string up to 128 chars in length');
 
         $t = new Wire\AMQPTable();
@@ -451,7 +474,7 @@ class AMQPCollectionTest extends TestCase
      */
     public function push_mismatched_type()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPInvalidArgumentException::class);
+        $this->expectException(AMQPInvalidArgumentException::class);
 
         $a = new Wire\AMQPArray();
 
@@ -463,7 +486,7 @@ class AMQPCollectionTest extends TestCase
      */
     public function push_raw_array_with_type()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPInvalidArgumentException::class);
+        $this->expectException(AMQPInvalidArgumentException::class);
         $this->expectExceptionMessage('Arrays must be passed as AMQPArray instance');
 
         $a = new Wire\AMQPArray();
@@ -476,7 +499,7 @@ class AMQPCollectionTest extends TestCase
      */
     public function push_raw_table_with_type()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPInvalidArgumentException::class);
+        $this->expectException(AMQPInvalidArgumentException::class);
         $this->expectExceptionMessage('Tables must be passed as AMQPTable instance');
 
         $a = new Wire\AMQPArray();
@@ -489,7 +512,7 @@ class AMQPCollectionTest extends TestCase
      */
     public function push_float_with_decimal_type()
     {
-        $this->expectException(\PhpAmqpLib\Exception\AMQPInvalidArgumentException::class);
+        $this->expectException(AMQPInvalidArgumentException::class);
         $this->expectExceptionMessage('Decimal values must be instance of AMQPDecimal');
 
         $a = new Wire\AMQPArray();
@@ -641,7 +664,7 @@ class AMQPCollectionTest extends TestCase
 
     protected function setProtoVersion($proto)
     {
-        $r = new \ReflectionProperty('\\PhpAmqpLib\\Wire\\AMQPAbstractCollection', 'protocol');
+        $r = new \ReflectionProperty(Wire\AMQPAbstractCollection::class, 'protocol');
         $r->setAccessible(true);
         $r->setValue(null, $proto);
     }

--- a/tests/Unit/Wire/AMQPReaderTest.php
+++ b/tests/Unit/Wire/AMQPReaderTest.php
@@ -5,10 +5,10 @@ namespace PhpAmqpLib\Tests\Unit\Wire;
 use PhpAmqpLib\Wire;
 use PhpAmqpLib\Wire\AMQPReader;
 use PhpAmqpLib\Tests\TestCaseCompat;
+use PhpAmqpLib\Wire\AMQPAbstractCollection;
 
 class AMQPReaderTest extends TestCaseCompat
 {
-
     protected function setUpCompat()
     {
         $this->setProtoVersion(Wire\Constants091::VERSION);
@@ -16,7 +16,7 @@ class AMQPReaderTest extends TestCaseCompat
 
     protected function setProtoVersion($proto)
     {
-        $r = new \ReflectionProperty('\\PhpAmqpLib\\Wire\\AMQPAbstractCollection', 'protocol');
+        $r = new \ReflectionProperty(AMQPAbstractCollection::class, 'protocol');
         $r->setAccessible(true);
         $r->setValue(null, $proto);
     }
@@ -53,5 +53,20 @@ class AMQPReaderTest extends TestCaseCompat
         $parsed = $reader->read_longlong();
         $this->assertIsString($parsed);
         $this->assertEquals('18446744073709551615', $parsed);
+    }
+
+    public function testDecodeFloatingPointValues()
+    {
+        $data = hex2bin('3a83126f');
+        $reader = new AMQPReader($data);
+        $parsed = $reader->read_value(AMQPAbstractCollection::T_FLOAT);
+        self::assertIsFloat($parsed);
+        self::assertEquals(0.001, $parsed);
+
+        $data = hex2bin('3feff7ced916872b');
+        $reader = new AMQPReader($data);
+        $parsed = $reader->read_value(AMQPAbstractCollection::T_DOUBLE);
+        self::assertIsFloat($parsed);
+        self::assertEquals(0.999, $parsed);
     }
 }

--- a/tests/Unit/WireTest.php
+++ b/tests/Unit/WireTest.php
@@ -2,14 +2,21 @@
 
 namespace PhpAmqpLib\Tests\Unit;
 
+use PhpAmqpLib\Tests\TestCaseCompat;
+use PhpAmqpLib\Wire\AMQPAbstractCollection;
 use PhpAmqpLib\Wire\AMQPArray;
 use PhpAmqpLib\Wire\AMQPReader;
 use PhpAmqpLib\Wire\AMQPTable;
 use PhpAmqpLib\Wire\AMQPWriter;
-use PHPUnit\Framework\TestCase;
 
-class WireTest extends TestCase
+class WireTest extends TestCaseCompat
 {
+    public function setUpCompat()
+    {
+        // TODO test other protocols as well
+        $this->setProtoVersion(AMQPAbstractCollection::PROTOCOL_RBT);
+    }
+
     /**
      * @dataProvider bitWrData
      * @test
@@ -656,5 +663,12 @@ class WireTest extends TestCase
             $readValue,
             'Written: ' . bin2hex($writer->getvalue()) . ', read: ' . bin2hex($readValue)
         );
+    }
+
+    protected function setProtoVersion($proto)
+    {
+        $r = new \ReflectionProperty(AMQPAbstractCollection::class, 'protocol');
+        $r->setAccessible(true);
+        $r->setValue(null, $proto);
     }
 }

--- a/tests/php_compat_70.php
+++ b/tests/php_compat_70.php
@@ -50,4 +50,9 @@ class TestCaseCompat extends \PHPUnit\Framework\TestCase
     {
         $this->assertInternalType('integer', $actual, $message);
     }
+
+    protected static function assertIsFloat($actual, $message = '')
+    {
+        self::assertInternalType('float', $actual, $message);
+    }
 }

--- a/tests/ssl.php
+++ b/tests/ssl.php
@@ -1,0 +1,29 @@
+<?php
+
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
+$certsPath = __DIR__ . '/certs';
+$options = [
+    'cafile' => $certsPath . '/ca_certificate.pem',
+    'local_cert' => $certsPath . '/client_certificate.pem',
+    'local_pk' => $certsPath . '/client_key.pem',
+    'verify_peer' => true,
+    'verify_peer_name' => false,
+];
+
+$context = stream_context_create();
+foreach ($options as $k => $v) {
+    stream_context_set_option($context, 'ssl', $k, $v);
+}
+
+$socket = stream_socket_client(
+    'tlsv1.2://rabbitmq:5671',
+    $errno,
+    $errstr,
+    1,
+    STREAM_CLIENT_CONNECT,
+    $context
+);
+
+var_dump($socket);


### PR DESCRIPTION
Historically this library had no support for floating point values(float, double) in data tables and arrays. Such PHP values where converted and encoded as strings.

This PR will add decoding support for floating point values. Encoding stays same as it would introduce breaking change. So full fix will appear in next major version 4.0.

Besides that, data type mapping was updated according to RabbitMQ and AMQP0.9 standard[1].

fix #924

[1] https://www.rabbitmq.com/amqp-0-9-1-errata.html