### PR TITLE
Fix PHP 8.1 deprecation in stream_select

### DIFF
--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -123,7 +123,7 @@ class AMQPReader extends AbstractClient
         } else {
             // wait indefinitely for data if timeout=0
             $sec = null;
-            $usec = 0;
+            $usec = null;
         }
 
         $result = $this->io->select($sec, $usec);

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -84,7 +84,7 @@ abstract class AbstractIO
         $this->check_heartbeat();
         $this->set_error_handler();
         try {
-            $result = $this->do_select($sec, $usec);
+            $result = $this->do_select($sec, $sec === null ? null : $usec);
             $this->cleanup_error_handler();
         } catch (\ErrorException $e) {
             throw new AMQPIOWaitException($e->getMessage(), $e->getCode(), $e);


### PR DESCRIPTION
When the timeout is `0`, `AMQPReader` uses `io->select(null, 0)`, which has been deprecated in php 8.1 throwing the following exception:

```
stream_select: Argument #5 ($microseconds) should be null instead of 0 when argument #4 ($seconds) is null
```

I could not find this deprecation in the documentation, but you can check it out here:
https://github.com/php/php-src/blob/5e7e654514636f3cf9a07938825f83fb13317535/ext/standard/streamsfuncs.c#L794