### PR TITLE
Fix docblocks as per PHPStan

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -776,7 +776,7 @@ class AMQPChannel extends AbstractChannel
     /**
      * Acknowledges one or more messages
      *
-     * @param int $delivery_tag
+     * @param int|string $delivery_tag
      * @param bool $multiple
      */
     public function basic_ack($delivery_tag, $multiple = false)
@@ -830,7 +830,7 @@ class AMQPChannel extends AbstractChannel
     /**
      * Handles the deletion of messages from this->publishedMessages and dispatches them to the $handler
      *
-     * @param int $delivery_tag
+     * @param int|string $delivery_tag
      * @param bool $multiple
      * @param callable $handler
      */
@@ -877,7 +877,7 @@ class AMQPChannel extends AbstractChannel
     /**
      * Rejects one or several received messages
      *
-     * @param int $delivery_tag
+     * @param int|string $delivery_tag
      * @param bool $multiple
      * @param bool $requeue
      */
@@ -890,7 +890,7 @@ class AMQPChannel extends AbstractChannel
     /**
      * Ends a queue consumer
      *
-     * @param string $consumer_tag
+     * @param int|string $consumer_tag
      * @param bool $nowait
      * @param bool $noreturn
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException if the specified operation timeout was exceeded
@@ -951,7 +951,7 @@ class AMQPChannel extends AbstractChannel
      * @link https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
      *
      * @param string $queue
-     * @param string $consumer_tag
+     * @param int|string $consumer_tag
      * @param bool $no_local
      * @param bool $no_ack
      * @param bool $exclusive
@@ -1317,7 +1317,7 @@ class AMQPChannel extends AbstractChannel
     /**
      * Rejects an incoming message
      *
-     * @param int $delivery_tag
+     * @param int|string $delivery_tag
      * @param bool $requeue
      */
     public function basic_reject($delivery_tag, $requeue)

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -513,7 +513,7 @@ abstract class AbstractConnection extends AbstractChannel
      * @param int $channel
      * @param array $method_sig
      * @param AMQPWriter|string $args
-     * @param null $pkt
+     * @param AMQPWriter|null $pkt
      */
     protected function send_channel_method_frame($channel, $method_sig, $args = '', $pkt = null)
     {
@@ -529,7 +529,7 @@ abstract class AbstractConnection extends AbstractChannel
      * @param array $method_sig
      * @param AMQPWriter|string $args
      * @param AMQPWriter|null $pkt
-     * @return AMQPWriter
+     * @return AMQPWriter|null
      */
     protected function prepare_channel_method_frame($channel, $method_sig, $args = '', $pkt = null)
     {

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -529,7 +529,7 @@ abstract class AbstractConnection extends AbstractChannel
      * @param array $method_sig
      * @param AMQPWriter|string $args
      * @param AMQPWriter|null $pkt
-     * @return AMQPWriter|null
+     * @return AMQPWriter
      */
     protected function prepare_channel_method_frame($channel, $method_sig, $args = '', $pkt = null)
     {


### PR DESCRIPTION
as per

    $delivery_tag = $reader->read_longlong();
    
which returns `int|string`, can always be both it seems

our reports were
```                                                                           
  192    Parameter #1 $delivery_tag of method PhpAmqpLib\Channel\AMQPChannel::basic_ack() expects int, string given.       
  203    Parameter #1 $delivery_tag of method PhpAmqpLib\Channel\AMQPChannel::basic_reject() expects int, string given.    
```