### PR TITLE
PHP 8.1 ErrorException: stream_select()

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -342,7 +342,7 @@ class StreamIO extends AbstractIO
         $except = null;
 
         if ($sec === null && PHP_VERSION_ID >= 80100) {
-            $usec = null;
+            $usec = 0;
         }
 
         return stream_select($read, $write, $except, $sec, $usec);


### PR DESCRIPTION
Uncaught ErrorException: stream_select(): Passing null to parameter #5 ($microseconds) of type ?int is deprecated in vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/IO/StreamIO.php:348