### PR TITLE
fix deprecation notice from stream_select() on PHP8.1

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -337,11 +337,15 @@ abstract class AbstractConnection extends AbstractChannel
     }
 
     /**
-     * @param int $sec
+     * @param int|null $sec
      * @param int $usec
-     * @return mixed
+     * @return int
+     * @throws AMQPIOException
+     * @throws AMQPRuntimeException
+     * @throws AMQPConnectionClosedException
+     * @throws AMQPRuntimeException
      */
-    public function select($sec, $usec = 0)
+    public function select(?int $sec, int $usec = 0): int
     {
         try {
             return $this->io->select($sec, $usec);
@@ -413,7 +417,7 @@ abstract class AbstractConnection extends AbstractChannel
 
     /**
      * @return int
-     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws AMQPRuntimeException
      */
     public function get_free_channel_id()
     {
@@ -562,7 +566,7 @@ abstract class AbstractConnection extends AbstractChannel
      * @return array
      * @throws \Exception
      * @throws \PhpAmqpLib\Exception\AMQPTimeoutException
-     * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws AMQPRuntimeException
      */
     protected function wait_frame($timeout = 0)
     {

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -74,12 +74,12 @@ abstract class AbstractIO
 
     /**
      * @param int|null $sec
-     * @param int|null $usec
+     * @param int $usec
      * @return int
      * @throws \PhpAmqpLib\Exception\AMQPIOException
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
      */
-    public function select($sec, $usec)
+    public function select(?int $sec, int $usec = 0)
     {
         $this->check_heartbeat();
         $this->set_error_handler();
@@ -104,11 +104,11 @@ abstract class AbstractIO
 
     /**
      * @param int|null $sec
-     * @param int|null $usec
+     * @param int $usec
      * @return int|bool
      * @throws AMQPConnectionClosedException
      */
-    abstract protected function do_select($sec, $usec);
+    abstract protected function do_select(?int $sec, int $usec);
 
     /**
      * Set ups the connection.

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -239,7 +239,7 @@ class SocketIO extends AbstractIO
     /**
      * @inheritdoc
      */
-    protected function do_select($sec, $usec)
+    protected function do_select(?int $sec, int $usec)
     {
         if (!is_resource($this->sock) && !is_a($this->sock, \Socket::class)) {
             $this->sock = null;

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -330,7 +330,7 @@ class StreamIO extends AbstractIO
     /**
      * @inheritdoc
      */
-    protected function do_select($sec, $usec)
+    protected function do_select(?int $sec, int $usec)
     {
         if ($this->sock === null || !is_resource($this->sock)) {
             $this->sock = null;
@@ -342,7 +342,7 @@ class StreamIO extends AbstractIO
         $except = null;
 
         if ($sec === null && PHP_VERSION_ID >= 80100) {
-            $usec = null;
+            $usec = 0;
         }
 
         return stream_select($read, $write, $except, $sec, $usec);

--- a/tests/Functional/Channel/ChannelWaitTest.php
+++ b/tests/Functional/Channel/ChannelWaitTest.php
@@ -161,10 +161,10 @@ class ChannelWaitTest extends TestCase
         return $factory;
     }
 
-    protected function deferSignal($delay = 1)
+    public static function deferSignal($delay = 1)
     {
         if (!extension_loaded('pcntl')) {
-            $this->markTestSkipped('pcntl extension is not available');
+            self::markTestSkipped('pcntl extension is not available');
         }
         pcntl_signal(SIGTERM, function () {
         });

--- a/tests/Functional/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Functional/Connection/AMQPStreamConnectionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Connection;
+
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+use PhpAmqpLib\Tests\Functional\Channel\ChannelWaitTest;
+
+class AMQPStreamConnectionTest extends AbstractConnectionTest
+{
+    /**
+     * @test
+     * @group connection
+     * @covers \PhpAmqpLib\Wire\IO\StreamIO::select()
+     */
+    public function connection_select_blocking_wo_timeout(): void
+    {
+        error_reporting(E_ALL);
+        ini_set('display_errors', 1);
+        $connection = $this->conection_create('stream');
+
+        $start = microtime(true);
+        ChannelWaitTest::deferSignal(1);
+        $result = $connection->select(null);
+        $took = microtime(true) - $start;
+
+        self::assertEquals(0, $result);
+        self::assertGreaterThanOrEqual(.9, $took);
+    }
+}

--- a/tests/Unit/Test/BufferIO.php
+++ b/tests/Unit/Test/BufferIO.php
@@ -36,7 +36,7 @@ class BufferIO extends AbstractIO
     /**
      * @inheritDoc
      */
-    protected function do_select($sec, $usec)
+    protected function do_select(?int $sec, int $usec)
     {
         return !feof($this->buffer);
     }


### PR DESCRIPTION
There was an attempt to fix this issue, but something was changed in PHP internals since latest release candidate(RC).

Also, I add type hints for related internal methods and one public method. Tests, to check whether we still can block indefinitly until a new message appears.