### PR TITLE
Custom PCNTL Heartbeat Sender

### DIFF
--- a/PhpAmqpLib/Connection/Heartbeat/AbstractSignalHeartbeatSender.php
+++ b/PhpAmqpLib/Connection/Heartbeat/AbstractSignalHeartbeatSender.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace PhpAmqpLib\Connection\Heartbeat;
+
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Exception\AMQPRuntimeException;
+
+/**
+ * Manages pcntl-based heartbeat sending for a {@link AbstractConnection}.
+ */
+abstract class AbstractSignalHeartbeatSender
+{
+    /**
+     * @var AbstractConnection|null
+     */
+    protected $connection;
+
+    /**
+     * @param AbstractConnection $connection
+     * @throws AMQPRuntimeException
+     */
+    public function __construct(AbstractConnection $connection)
+    {
+        if (!$this->isSupported()) {
+            throw new AMQPRuntimeException('Signal-based heartbeat sender is unsupported');
+        }
+
+        $this->connection = $connection;
+    }
+
+    public function __destruct()
+    {
+        $this->unregister();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isSupported()
+    {
+        return extension_loaded('pcntl')
+               && function_exists('pcntl_async_signals')
+               && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true);
+    }
+
+    /**
+     * Starts the heartbeats
+     *
+     * @return void
+     */
+    abstract public function register();
+
+    /**
+     * Stops the heartbeats.
+     *
+     * @return void
+     */
+    abstract public function unregister();
+
+    /**
+     * Handles the heartbeat when a signal interrupt is received
+     *
+     * @param int $interval
+     * @return void
+     */
+    protected function handleSignal($interval)
+    {
+        if (!$this->connection) {
+            return;
+        }
+
+        if (!$this->connection->isConnected()) {
+            $this->unregister();
+            return;
+        }
+
+        if ($this->connection->isWriting()) {
+            return;
+        }
+
+        if (time() > ($this->connection->getLastActivity() + $interval)) {
+            $this->connection->checkHeartBeat();
+        }
+    }
+}

--- a/PhpAmqpLib/Connection/Heartbeat/PCNTLHeartbeatSender.php
+++ b/PhpAmqpLib/Connection/Heartbeat/PCNTLHeartbeatSender.php
@@ -2,47 +2,16 @@
 
 namespace PhpAmqpLib\Connection\Heartbeat;
 
-use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Exception\AMQPRuntimeException;
 
 /**
- * Manages pcntl-based heartbeat sending for a {@link AbstractConnection}.
+ * @see AbstractSignalHeartbeatSender
+ *
+ * This version of a signal based heartbeat sendler relies on using SIGALRM and uses the OS to trigger an alarm
+ * after a given time.
  */
-final class PCNTLHeartbeatSender
+final class PCNTLHeartbeatSender extends AbstractSignalHeartbeatSender
 {
-    /**
-     * @var AbstractConnection|null
-     */
-    private $connection;
-
-    /**
-     * @param AbstractConnection $connection
-     * @throws AMQPRuntimeException
-     */
-    public function __construct(AbstractConnection $connection)
-    {
-        if (!$this->isSupported()) {
-            throw new AMQPRuntimeException('Signal-based heartbeat sender is unsupported');
-        }
-
-        $this->connection = $connection;
-    }
-
-    public function __destruct()
-    {
-        $this->unregister();
-    }
-
-    /**
-     * @return bool
-     */
-    private function isSupported()
-    {
-        return extension_loaded('pcntl')
-               && function_exists('pcntl_async_signals')
-               && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true);
-    }
-
     public function register()
     {
         if (!$this->connection) {
@@ -76,25 +45,10 @@ final class PCNTLHeartbeatSender
     private function registerListener($interval)
     {
         pcntl_signal(SIGALRM, function () use ($interval) {
-            if (!$this->connection) {
-                return;
-            }
-
-            if (!$this->connection->isConnected()) {
-                $this->unregister();
-                return;
-            }
-
-            if ($this->connection->isWriting()) {
+            $this->handleSignal($interval);
+            if ($this->connection) {
                 pcntl_alarm($interval);
-                return;
             }
-
-            if (time() > ($this->connection->getLastActivity() + $interval)) {
-                $this->connection->checkHeartBeat();
-            }
-
-            pcntl_alarm($interval);
         });
     }
 }

--- a/PhpAmqpLib/Connection/Heartbeat/SIGHeartbeatSender.php
+++ b/PhpAmqpLib/Connection/Heartbeat/SIGHeartbeatSender.php
@@ -1,0 +1,116 @@
+<?php
+namespace PhpAmqpLib\Connection\Heartbeat;
+
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Exception\AMQPRuntimeException;
+
+/**
+ * Manages pcntl-based heartbeat sending for a {@link AbstractConnection}.
+ * Unlike PCNTLHeartbeatSender, does not require the use of `SIGALRM` as the signal.
+ * Any signal can be used. Default is `SIGUSR1`
+ */
+final class SIGHeartbeatSender
+{
+    /**
+     * @var AbstractConnection
+     */
+    private $connection;
+
+    private $signal;
+
+    private $childPid;
+
+    /**
+     * @param AbstractConnection $connection
+     * @throws AMQPRuntimeException
+     */
+    public function __construct(AbstractConnection $connection, $signal = SIGUSR1)
+    {
+        if (!$this->isSupported()) {
+            throw new AMQPRuntimeException('Signal-based heartbeat sender is unsupported');
+        }
+
+        $this->signal = $signal;
+        $this->connection = $connection;
+    }
+
+    public function __destruct()
+    {
+        $this->unregister();
+    }
+
+    /**
+     * @return bool
+     */
+    private function isSupported()
+    {
+        return extension_loaded('pcntl')
+               && function_exists('pcntl_async_signals')
+               && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true);
+    }
+
+    public function register()
+    {
+        if (!$this->connection) {
+            throw new AMQPRuntimeException('Unable to re-register heartbeat sender');
+        }
+
+        if (!$this->connection->isConnected()) {
+            throw new AMQPRuntimeException('Unable to register heartbeat sender, connection is not active');
+        }
+        $timeout = $this->connection->getHeartbeat();
+
+        if ($timeout > 0) {
+            $interval = ceil($timeout / 2);
+            $this->registerListener($interval);
+        }
+    }
+
+    public function unregister()
+    {
+        $this->connection = null;
+        // restore default signal handler
+        pcntl_signal($this->signal, SIG_IGN);
+        if ($this->childPid) {
+            posix_kill($this->childPid, SIGKILL);
+        }
+        $this->childPid = null;
+    }
+
+    /**
+     * @param int $interval
+     */
+    private function registerListener($interval)
+    {
+        pcntl_async_signals(true);
+        $this->periodicAlarm($interval);
+        pcntl_signal($this->signal, function () use ($interval) {
+            if (!$this->connection || $this->connection->isWriting()) {
+                return;
+            }
+
+            if (!$this->connection->isConnected()) {
+                $this->unregister();
+                return;
+            }
+
+            if (time() > ($this->connection->getLastActivity() + $interval)) {
+                $this->connection->checkHeartBeat();
+            }
+        });
+    }
+
+    private function periodicAlarm($interval)
+    {
+        $parent = getmypid();
+        $pid = pcntl_fork();
+        if(!$pid) {
+            while (true){
+                sleep($interval);
+                posix_kill($parent, SIGUSR1);
+            }
+        } else {
+            $this->childPid = $pid;
+        }
+    }
+}

--- a/tests/Functional/Connection/Heartbeat/SIGHeartbeatSenderTest.php
+++ b/tests/Functional/Connection/Heartbeat/SIGHeartbeatSenderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace PhpAmqpLib\Tests\Functional\Connection\Heartbeat;
+
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Connection\Heartbeat\SIGHeartbeatSender;
+use PhpAmqpLib\Exception\AMQPRuntimeException;
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+
+/**
+ * @group connection
+ * @group signals
+ * @group sig
+ * @requires extension pcntl
+ * @requires PHP 7.1
+ */
+class SIGHeartbeatSenderTest extends AbstractConnectionTest
+{
+    /** @var AbstractConnection */
+    protected $connection;
+
+    /** @var SIGHeartbeatSender */
+    protected $sender;
+
+    /** @var int */
+    protected $heartbeatTimeout = 4;
+
+    protected $signal = SIGUSR1;
+
+    protected function setUpCompat()
+    {
+        $this->connection = $this->conection_create(
+            'stream',
+            HOST,
+            PORT,
+            ['timeout' => 3, 'heartbeat' => $this->heartbeatTimeout]
+        );
+        // try {
+            $this->sender = new SIGHeartbeatSender($this->connection, $this->signal);
+        // } catch (\Exception $exception) {
+        //     $this->markTestSkipped($exception->getMessage());
+        // }
+    }
+
+    protected function tearDownCompat()
+    {
+        if ($this->sender) {
+            $this->sender->unregister();
+        }
+        if ($this->connection) {
+            $this->connection->close();
+        }
+        $this->sender = null;
+        $this->connection = null;
+    }
+
+    /**
+     * @test
+     */
+    public function register_should_fail_with_closed_connection()
+    {
+        $this->expectException(AMQPRuntimeException::class);
+        $this->expectExceptionMessage('Unable to register heartbeat sender, connection is not active');
+
+        $this->connection->close();
+        $this->sender->register();
+    }
+
+    /**
+     * @test
+     */
+    public function register_should_fail_after_unregister()
+    {
+        $this->expectException(AMQPRuntimeException::class);
+        $this->expectExceptionMessage('Unable to re-register heartbeat sender');
+
+        $this->sender->unregister();
+        $this->sender->register();
+    }
+
+    /**
+     * @test
+     */
+    public function unregister_should_return_default_signal_handler()
+    {
+        $this->sender->register();
+        $this->sender->unregister();
+
+        self::assertEquals(SIG_IGN, pcntl_signal_get_handler($this->signal));
+    }
+
+    /**
+     * @test
+     */
+    public function heartbeat_should_interrupt_non_blocking_action()
+    {
+        $this->sender->register();
+
+        $timeLeft = $this->heartbeatTimeout;
+        $continuation = 0;
+        while ($timeLeft > 0) {
+            $timeLeft = sleep($timeLeft);
+            $continuation++;
+        }
+
+        self::assertEquals(2, $continuation);
+    }
+
+    /**
+     * @test
+     */
+    public function alarm_sig_should_be_registered_when_conn_is_writing()
+    {
+        $connection = $this->getMockBuilder(AbstractConnection::class)
+            ->setMethods(['isConnected', 'getHeartbeat', 'isWriting', 'getLastActivity'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $connection->expects($this->exactly(2))->method('isConnected')->willReturn(true);
+        $connection->expects($this->once())->method('getHeartbeat')->willReturn($this->heartbeatTimeout);
+        $connection->expects($this->exactly(2))
+            ->method('isWriting')
+            ->willReturnOnConsecutiveCalls(true, false);
+        $connection->expects($this->exactly(1))
+            ->method('getLastActivity')
+            ->willReturn(time() + 99);
+
+        $sender = new SIGHeartbeatSender($connection, $this->signal);
+        $sender->register();
+
+        $timeLeft = $this->heartbeatTimeout + 1;
+        while ($timeLeft > 0) {
+            $timeLeft = sleep($timeLeft);
+        }
+
+        $sender->unregister();
+    }
+}

--- a/tests/Functional/Connection/Heartbeat/SIGHeartbeatSenderTest.php
+++ b/tests/Functional/Connection/Heartbeat/SIGHeartbeatSenderTest.php
@@ -35,11 +35,8 @@ class SIGHeartbeatSenderTest extends AbstractConnectionTest
             PORT,
             ['timeout' => 3, 'heartbeat' => $this->heartbeatTimeout]
         );
-        // try {
-            $this->sender = new SIGHeartbeatSender($this->connection, $this->signal);
-        // } catch (\Exception $exception) {
-        //     $this->markTestSkipped($exception->getMessage());
-        // }
+
+        $this->sender = new SIGHeartbeatSender($this->connection, $this->signal);
     }
 
     protected function tearDownCompat()
@@ -116,7 +113,7 @@ class SIGHeartbeatSenderTest extends AbstractConnectionTest
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $connection->expects($this->exactly(2))->method('isConnected')->willReturn(true);
+        $connection->expects($this->exactly(3))->method('isConnected')->willReturn(true);
         $connection->expects($this->once())->method('getHeartbeat')->willReturn($this->heartbeatTimeout);
         $connection->expects($this->exactly(2))
             ->method('isWriting')


### PR DESCRIPTION
The existing `PCNTLHeartbeatSender` implementation uses `SIGALARM`
while convenient, for that use case, it also clashes with other libraries
that also want to use that same signal.

In our case, Laravel uses `SIGALARM` to define a timeout for job execution
on queue workers. Also a valid use case for it. But having both libraries
define their own signal handler for the same signal and overwrite each other's
alarm timeout makes a big mess where nothing works.

This allows defining a `pcntl_async_signals` handler that works with
a different signal than `SIGALARM`. The specific signal can be chosen at
construction time and is set to `SIGUSR1` by default.

The code uses `pcntl_fork` to create a separate process that sends the
chosen signal at regular intervals.