### PR TITLE
Add $restart_syscalls = true explicitly when calling pcntl_signal to avoid crashing SQL Server connections

### DIFF
--- a/PhpAmqpLib/Connection/Heartbeat/PCNTLHeartbeatSender.php
+++ b/PhpAmqpLib/Connection/Heartbeat/PCNTLHeartbeatSender.php
@@ -95,6 +95,6 @@ final class PCNTLHeartbeatSender
             }
 
             pcntl_alarm($interval);
-        });
+        }, true);
     }
 }


### PR DESCRIPTION
We are having issues when using `PCNTLHeartbeatSender` to send heartbeat with signals. When our program is currently executing an SQL query with SQL Server and the signal occurs, it crashes the connection to SQL. This behavior has been reported in a few issues on github :

https://github.com/microsoft/msphpsql/issues/885
https://github.com/php/php-src/pull/3717
https://github.com/microsoft/msphpsql/issues/1242

The problem is also that when registering a signal with `pcntl_signal`, the third parameter (`$restart_syscalls`) has a default value set to `true` BUT, while not documented on PHP website, if the signal is SIGALRM and the parameter is not specified (we would think it would be true), PHP forces it to be false. However, if $restart_syscalls is explicitly passed when calling `pcntl_signal` it really get set to true in PHP source: 

	/* If restart_syscalls was not explicitly specified and the signal is SIGALRM, then default
	 * restart_syscalls to false. PHP used to enforce that restart_syscalls is false for SIGALRM,
	 * so we keep this differing default to reduce the degree of BC breakage. */
	if (restart_syscalls_is_null && signo == SIGALRM) {
		restart_syscalls = 0;
	}

https://github.com/php/php-src/blob/107997e58e922aadc6d5bd6777d42f52034f2ae6/ext/pcntl/pcntl.c#L977-L982