### PR TITLE
unified configuration class and factory for all kinds of connection

### DIFF
--- a/PhpAmqpLib/Connection/AMQPConnectionConfig.php
+++ b/PhpAmqpLib/Connection/AMQPConnectionConfig.php
@@ -1,0 +1,470 @@
+<?php
+
+namespace PhpAmqpLib\Connection;
+
+use InvalidArgumentException;
+use PhpAmqpLib\Wire;
+
+/**
+ * @since 3.2.0
+ */
+final class AMQPConnectionConfig
+{
+    public const AUTH_PLAIN = 'PLAIN';
+    public const AUTH_AMQPPLAIN = 'AMQPLAIN';
+    public const IO_TYPE_STREAM = 'stream';
+    public const IO_TYPE_SOCKET = 'socket';
+
+    /** @var string */
+    private $ioType = self::IO_TYPE_STREAM;
+
+    /** @var bool */
+    private $isLazy = true;
+
+    /** @var string */
+    private $host = '127.0.0.1';
+
+    /** @var int */
+    private $port = 5672;
+
+    /** @var string */
+    private $user = 'guest';
+
+    /** @var string */
+    private $password = 'guest';
+
+    /** @var string */
+    private $vhost = '/';
+
+    /** @var bool */
+    private $insist = false;
+
+    /** @var string */
+    private $loginMethod = self::AUTH_AMQPPLAIN;
+
+    /** @var string */
+    private $locale = 'en_US';
+
+    /** @var float */
+    private $connectionTimeout = 3.0;
+
+    /** @var float */
+    private $readTimeout = 3.0;
+
+    /** @var float */
+    private $writeTimeout = 3.0;
+
+    /** @var float */
+    private $channelRPCTimeout = 0.0;
+
+    /** @var int */
+    private $heartbeat = 0;
+
+    /** @var bool */
+    private $keepalive = false;
+
+    /** @var bool */
+    private $isSecure = false;
+
+    /** @var string */
+    private $networkProtocol = 'tcp';
+
+    /** @var resource|null */
+    private $streamContext;
+
+    /** @var bool */
+    private $dispatchSignals = true;
+
+    /** @var string */
+    private $amqpProtocol = Wire\Constants091::VERSION;
+
+    /**
+     * Whether to use strict AMQP0.9.1 field types. RabbitMQ does not support that.
+     * @var bool
+     */
+    private $protocolStrictFields = false;
+
+    /** @var string|null */
+    private $sslCaCert;
+
+    /** @var string|null */
+    private $sslCert;
+
+    /** @var string|null */
+    private $sslKey;
+
+    /** @var bool|null */
+    private $sslVerify;
+
+    /** @var bool|null */
+    private $sslVerifyName;
+
+    /** @var string|null */
+    private $sslPassPhrase;
+
+    /** @var string|null */
+    private $sslCiphers;
+
+    /**
+     * Output all networks packets for debug purposes.
+     * @var bool
+     */
+    private $debugPackets = false;
+
+    public function getIoType(): string
+    {
+        return $this->ioType;
+    }
+
+    /**
+     * Set which IO type will be used, stream or socket.
+     * @param string $ioType
+     */
+    public function setIoType(string $ioType): void
+    {
+        if ($ioType !== self::IO_TYPE_STREAM && $ioType !== self::IO_TYPE_SOCKET) {
+            throw new InvalidArgumentException('IO type can be either "stream" or "socket"');
+        }
+        $this->ioType = $ioType;
+    }
+
+    public function isLazy(): bool
+    {
+        return $this->isLazy;
+    }
+
+    public function setIsLazy(bool $isLazy): void
+    {
+        $this->isLazy = $isLazy;
+    }
+
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    public function setHost(string $host): void
+    {
+        $this->host = $host;
+    }
+
+    public function getPort(): int
+    {
+        return $this->port;
+    }
+
+    public function setPort(int $port): void
+    {
+        if ($port <= 0) {
+            throw new InvalidArgumentException('Port number must be greater than 0');
+        }
+        $this->port = $port;
+    }
+
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    public function setUser(string $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): void
+    {
+        $this->password = $password;
+    }
+
+    public function getVhost(): string
+    {
+        return $this->vhost;
+    }
+
+    public function setVhost(string $vhost): void
+    {
+        self::assertStringNotEmpty($vhost, 'vhost');
+        $this->vhost = $vhost;
+    }
+
+    public function isInsist(): bool
+    {
+        return $this->insist;
+    }
+
+    public function setInsist(bool $insist): void
+    {
+        $this->insist = $insist;
+    }
+
+    public function getLoginMethod(): string
+    {
+        return $this->loginMethod;
+    }
+
+    public function setLoginMethod(string $loginMethod): void
+    {
+        if ($loginMethod !== self::AUTH_PLAIN && $loginMethod !== self::AUTH_AMQPPLAIN) {
+            throw new InvalidArgumentException('Unknown login method: ' . $loginMethod);
+        }
+        $this->loginMethod = $loginMethod;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $locale): void
+    {
+        self::assertStringNotEmpty($locale, 'locale');
+        $this->locale = $locale;
+    }
+
+    public function getConnectionTimeout(): float
+    {
+        return $this->connectionTimeout;
+    }
+
+    public function setConnectionTimeout(float $connectionTimeout): void
+    {
+        $this->connectionTimeout = $connectionTimeout;
+    }
+
+    public function getReadTimeout(): float
+    {
+        return $this->readTimeout;
+    }
+
+    public function setReadTimeout(float $readTimeout): void
+    {
+        self::assertGreaterOrEq($readTimeout, 0, 'read timeout');
+        $this->readTimeout = $readTimeout;
+    }
+
+    public function getWriteTimeout(): float
+    {
+        return $this->writeTimeout;
+    }
+
+    public function setWriteTimeout(float $writeTimeout): void
+    {
+        self::assertGreaterOrEq($writeTimeout, 0, 'write timeout');
+        $this->writeTimeout = $writeTimeout;
+    }
+
+    public function getChannelRPCTimeout(): float
+    {
+        return $this->channelRPCTimeout;
+    }
+
+    public function setChannelRPCTimeout(float $channelRPCTimeout): void
+    {
+        self::assertGreaterOrEq($channelRPCTimeout, 0, 'channel RPC timeout');
+        $this->channelRPCTimeout = $channelRPCTimeout;
+    }
+
+    public function getHeartbeat(): int
+    {
+        return $this->heartbeat;
+    }
+
+    public function setHeartbeat(int $heartbeat): void
+    {
+        self::assertGreaterOrEq($heartbeat, 0, 'heartbeat');
+        $this->heartbeat = $heartbeat;
+    }
+
+    public function isKeepalive(): bool
+    {
+        return $this->keepalive;
+    }
+
+    public function setKeepalive(bool $keepalive): void
+    {
+        $this->keepalive = $keepalive;
+    }
+
+    public function isSecure(): bool
+    {
+        return $this->isSecure;
+    }
+
+    public function setIsSecure(bool $isSecure): void
+    {
+        $this->isSecure = $isSecure;
+    }
+
+    public function getNetworkProtocol(): string
+    {
+        return $this->networkProtocol;
+    }
+
+    public function setNetworkProtocol(string $networkProtocol): void
+    {
+        self::assertStringNotEmpty($networkProtocol, 'network protocol');
+        $this->networkProtocol = $networkProtocol;
+    }
+
+    /**
+     * @return resource|null
+     */
+    public function getStreamContext()
+    {
+        return $this->streamContext;
+    }
+
+    /**
+     * @param resource|null $streamContext
+     */
+    public function setStreamContext($streamContext): void
+    {
+        if ($streamContext === null) {
+            $this->streamContext = null;
+            return;
+        }
+
+        if (!is_resource($streamContext) || get_resource_type($streamContext) !== 'stream-context') {
+            throw new InvalidArgumentException('Resource must be valid stream context');
+        }
+        $this->streamContext = $streamContext;
+    }
+
+    public function isSignalsDispatchEnabled(): bool
+    {
+        return $this->dispatchSignals;
+    }
+
+    public function enableSignalDispatch(bool $dispatchSignals): void
+    {
+        $this->dispatchSignals = $dispatchSignals;
+    }
+
+    public function getAMQPProtocol(): string
+    {
+        return $this->amqpProtocol;
+    }
+
+    public function setAMQPProtocol(string $protocol): void
+    {
+        if ($protocol !== Wire\Constants091::VERSION && $protocol !== Wire\Constants080::VERSION) {
+            throw new InvalidArgumentException('AMQP protocol can be either "0.9.1" or "8.0"');
+        }
+        $this->amqpProtocol = $protocol;
+    }
+
+    public function isProtocolStrictFieldsEnabled(): bool
+    {
+        return $this->protocolStrictFields;
+    }
+
+    public function setProtocolStrictFields(bool $protocolStrictFields): void
+    {
+        $this->protocolStrictFields = $protocolStrictFields;
+    }
+
+    public function getSslCaCert(): ?string
+    {
+        return $this->sslCaCert;
+    }
+
+    public function setSslCaCert(?string $sslCaCert): void
+    {
+        $this->sslCaCert = $sslCaCert;
+    }
+
+    public function getSslCert(): ?string
+    {
+        return $this->sslCert;
+    }
+
+    public function setSslCert(?string $sslCert): void
+    {
+        $this->sslCert = $sslCert;
+    }
+
+    public function getSslKey(): ?string
+    {
+        return $this->sslKey;
+    }
+
+    public function setSslKey(?string $sslKey): void
+    {
+        $this->sslKey = $sslKey;
+    }
+
+    public function getSslVerify(): ?bool
+    {
+        return $this->sslVerify;
+    }
+
+    public function setSslVerify(?bool $sslVerify): void
+    {
+        $this->sslVerify = $sslVerify;
+    }
+
+    public function getSslVerifyName(): ?bool
+    {
+        return $this->sslVerifyName;
+    }
+
+    public function setSslVerifyName(?bool $sslVerifyName): void
+    {
+        $this->sslVerifyName = $sslVerifyName;
+    }
+
+    public function getSslPassPhrase(): ?string
+    {
+        return $this->sslPassPhrase;
+    }
+
+    public function setSslPassPhrase(?string $sslPassPhrase): void
+    {
+        $this->sslPassPhrase = $sslPassPhrase;
+    }
+
+    public function getSslCiphers(): ?string
+    {
+        return $this->sslCiphers;
+    }
+
+    public function setSslCiphers(?string $sslCiphers): void
+    {
+        $this->sslCiphers = $sslCiphers;
+    }
+
+    public function isDebugPackets(): bool
+    {
+        return $this->debugPackets;
+    }
+
+    public function setDebugPackets(bool $debugPackets): void
+    {
+        $this->debugPackets = $debugPackets;
+    }
+
+    private static function assertStringNotEmpty($value, string $param): void
+    {
+        $value = trim($value);
+        if (empty($value)) {
+            throw new InvalidArgumentException(sprintf('Parameter "%s" must be non empty string', $param));
+        }
+    }
+
+    /**
+     * @param int|float $value
+     * @param int $limit
+     * @param string $param
+     */
+    private static function assertGreaterOrEq($value, int $limit, string $param): void
+    {
+        if ($value < $limit) {
+            throw new InvalidArgumentException(sprintf('Parameter "%s" must be greater than zero', $param));
+        }
+    }
+}

--- a/PhpAmqpLib/Connection/AMQPConnectionFactory.php
+++ b/PhpAmqpLib/Connection/AMQPConnectionFactory.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace PhpAmqpLib\Connection;
+
+use LogicException;
+
+/**
+ * @since 3.2.0
+ */
+class AMQPConnectionFactory
+{
+    public static function create(AMQPConnectionConfig $config): AbstractConnection
+    {
+        if ($config->getIoType() === AMQPConnectionConfig::IO_TYPE_STREAM) {
+            if ($config->isSecure()) {
+                if ($config->isLazy()) {
+                    $class = AMQPLazySSLConnection::class;
+                } else {
+                    $class = AMQPSSLConnection::class;
+                }
+
+                $connection = new $class(
+                    $config->getHost(),
+                    $config->getPort(),
+                    $config->getUser(),
+                    $config->getPassword(),
+                    $config->getVhost(),
+                    self::getSslOptions($config),
+                    [
+                        'insist' => $config->isInsist(),
+                        'login_method' => $config->getLoginMethod(),
+                        'locale' => $config->getLocale(),
+                        'connection_timeout' => $config->getConnectionTimeout(),
+                        'read_write_timeout' => self::getReadWriteTimeout($config),
+                        'keepalive' => $config->isKeepalive(),
+                        'heartbeat' => $config->getHeartbeat(),
+                    ],
+                    $config->getNetworkProtocol(),
+                    $config
+                );
+            } else {
+                if ($config->isLazy()) {
+                    $class = AMQPLazyConnection::class;
+                } else {
+                    $class = AMQPStreamConnection::class;
+                }
+                $connection = new $class(
+                    $config->getHost(),
+                    $config->getPort(),
+                    $config->getUser(),
+                    $config->getPassword(),
+                    $config->getVhost(),
+                    $config->isInsist(),
+                    $config->getLoginMethod(),
+                    null,
+                    $config->getLocale(),
+                    $config->getConnectionTimeout(),
+                    self::getReadWriteTimeout($config),
+                    $config->getStreamContext(),
+                    $config->isKeepalive(),
+                    $config->getHeartbeat(),
+                    $config->getChannelRPCTimeout(),
+                    $config->getNetworkProtocol(),
+                    $config
+                );
+            }
+        } else {
+            if ($config->isSecure()) {
+                throw new LogicException('The socket connection implementation does not support secure connections.');
+            }
+
+            if ($config->isLazy()) {
+                $class = AMQPLazySocketConnection::class;
+            } else {
+                $class = AMQPSocketConnection::class;
+            }
+            $connection = new $class(
+                $config->getHost(),
+                $config->getPort(),
+                $config->getUser(),
+                $config->getPassword(),
+                $config->getVhost(),
+                $config->isInsist(),
+                $config->getLoginMethod(),
+                null,
+                $config->getLocale(),
+                $config->getReadTimeout(),
+                $config->isKeepalive(),
+                $config->getWriteTimeout(),
+                $config->getHeartbeat(),
+                $config->getChannelRPCTimeout()
+            );
+        }
+
+        return $connection;
+    }
+
+    private static function getReadWriteTimeout(AMQPConnectionConfig $config): float
+    {
+        return min($config->getReadTimeout(), $config->getWriteTimeout());
+    }
+
+    /**
+     * @param AMQPConnectionConfig $config
+     * @return mixed[]
+     */
+    private static function getSslOptions(AMQPConnectionConfig $config): array
+    {
+        return array_filter([
+           'cafile' => $config->getSslCaCert(),
+           'local_cert' => $config->getSslCert(),
+           'local_pk' => $config->getSslKey(),
+           'verify_peer' => $config->getSslVerify(),
+           'verify_peer_name' => $config->getSslVerifyName(),
+           'passphrase' => $config->getSslPassPhrase(),
+           'ciphers' => $config->getSslCiphers(),
+        ], static function ($value) { return null !== $value; });
+    }
+}

--- a/PhpAmqpLib/Connection/AMQPLazyConnection.php
+++ b/PhpAmqpLib/Connection/AMQPLazyConnection.php
@@ -41,6 +41,7 @@ class AMQPLazyConnection extends AMQPStreamConnection
      * @param string[] $options
      * @return self
      * @throws \Exception
+     * @deprecated Use ConnectionFactory
      */
     public static function create_connection($hosts, $options = array())
     {

--- a/PhpAmqpLib/Connection/AMQPLazySSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPLazySSLConnection.php
@@ -41,6 +41,7 @@ class AMQPLazySSLConnection extends AMQPSSLConnection
      * @param string[] $options
      * @return self
      * @throws \Exception
+     * @deprecated Use ConnectionFactory
      */
     public static function create_connection($hosts, $options = array())
     {

--- a/PhpAmqpLib/Connection/AMQPLazySocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPLazySocketConnection.php
@@ -44,6 +44,7 @@ class AMQPLazySocketConnection extends AMQPSocketConnection
      * @param string[] $options
      * @return self
      * @throws \Exception
+     * @deprecated Use ConnectionFactory
      */
     public static function create_connection($hosts, $options = array())
     {

--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -13,6 +13,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
      * @param array $ssl_options
      * @param array $options
      * @param string $ssl_protocol
+     * @param AMQPConnectionConfig|null $config
      */
     public function __construct(
         $host,
@@ -22,7 +23,8 @@ class AMQPSSLConnection extends AMQPStreamConnection
         $vhost = '/',
         $ssl_options = array(),
         $options = array(),
-        $ssl_protocol = 'ssl'
+        $ssl_protocol = 'ssl',
+        ?AMQPConnectionConfig $config = null
     ) {
         $ssl_context = empty($ssl_options) ? null : $this->createSslContext($ssl_options);
         parent::__construct(
@@ -41,10 +43,14 @@ class AMQPSSLConnection extends AMQPStreamConnection
             isset($options['keepalive']) ? $options['keepalive'] : false,
             isset($options['heartbeat']) ? $options['heartbeat'] : 0,
             isset($options['channel_rpc_timeout']) ? $options['channel_rpc_timeout'] : 0.0,
-            $ssl_protocol
+            $ssl_protocol,
+            $config
         );
     }
 
+    /**
+     * @deprecated Use ConnectionFactory
+     */
     public static function try_create_connection($host, $port, $user, $password, $vhost, $options)
     {
         $ssl_options = isset($options['ssl_options']) ? $options['ssl_options'] : [];

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -21,6 +21,7 @@ class AMQPSocketConnection extends AbstractConnection
      * @param int $write_timeout
      * @param int $heartbeat
      * @param float $channel_rpc_timeout
+     * @param AMQPConnectionConfig|null $config
      * @throws \Exception
      */
     public function __construct(
@@ -37,7 +38,8 @@ class AMQPSocketConnection extends AbstractConnection
         $keepalive = false,
         $write_timeout = 3,
         $heartbeat = 0,
-        $channel_rpc_timeout = 0.0
+        $channel_rpc_timeout = 0.0,
+        ?AMQPConnectionConfig $config = null
     ) {
         if ($channel_rpc_timeout > $read_timeout) {
             throw new \InvalidArgumentException('channel RPC timeout must not be greater than I/O read timeout');
@@ -56,10 +58,14 @@ class AMQPSocketConnection extends AbstractConnection
             $io,
             $heartbeat,
             max($read_timeout, $write_timeout),
-            $channel_rpc_timeout
+            $channel_rpc_timeout,
+            $config
         );
     }
 
+    /**
+     * @deprecated Use ConnectionFactory
+     */
     protected static function try_create_connection($host, $port, $user, $password, $vhost, $options)
     {
         $insist = isset($options['insist']) ?

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -23,6 +23,7 @@ class AMQPStreamConnection extends AbstractConnection
      * @param int $heartbeat
      * @param float $channel_rpc_timeout
      * @param string|null $ssl_protocol
+     * @param AMQPConnectionConfig|null $config
      */
     public function __construct(
         $host,
@@ -40,7 +41,8 @@ class AMQPStreamConnection extends AbstractConnection
         $keepalive = false,
         $heartbeat = 0,
         $channel_rpc_timeout = 0.0,
-        $ssl_protocol = null
+        $ssl_protocol = null,
+        ?AMQPConnectionConfig $config = null
     ) {
         if ($channel_rpc_timeout > $read_write_timeout) {
             throw new \InvalidArgumentException('channel RPC timeout must not be greater than I/O read-write timeout');
@@ -68,13 +70,17 @@ class AMQPStreamConnection extends AbstractConnection
             $io,
             $heartbeat,
             $connection_timeout,
-            $channel_rpc_timeout
+            $channel_rpc_timeout,
+            $config
         );
 
         // save the params for the use of __clone, this will overwrite the parent
         $this->construct_params = func_get_args();
     }
 
+    /**
+     * @deprecated Use ConnectionFactory
+     */
     protected static function try_create_connection($host, $port, $user, $password, $vhost, $options)
     {
         $insist = isset($options['insist']) ?

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -129,6 +129,9 @@ abstract class AbstractConnection extends AbstractChannel
     /** @var int Connection timeout value*/
     protected $connection_timeout ;
 
+    /** @var AMQPConnectionConfig|null */
+    protected $config;
+
     /**
      * Circular buffer to speed up prepare_content().
      * Max size limited by $prepare_content_cache_max_size.
@@ -184,10 +187,15 @@ abstract class AbstractConnection extends AbstractChannel
         AbstractIO $io = null,
         $heartbeat = 0,
         $connection_timeout = 0,
-        $channel_rpc_timeout = 0.0
+        $channel_rpc_timeout = 0.0,
+        ?AMQPConnectionConfig $config = null
     ) {
         if (is_null($io)) {
             throw new \InvalidArgumentException('Argument $io cannot be null');
+        }
+
+        if ($config) {
+            $this->config = clone $config;
         }
 
         // save the params for the use of __clone
@@ -312,6 +320,9 @@ abstract class AbstractConnection extends AbstractChannel
      */
     public function __clone()
     {
+        if ($this->config) {
+            $this->config = clone $this->config;
+        }
         call_user_func_array(array($this, '__construct'), $this->construct_params);
     }
 


### PR DESCRIPTION
The aim of this PR is to put all connection configuration options into one object and reuse it for all kind of connections. Having this, we can improve several things:
- get rid of long argument list in each connection class
- unify default values
- deprecate global constants - once defined, they cannot be changed
- useable in applications with dependency injection(DI)

For now, previous approach takes precendence. Class arguments and global constants over connection config. This wil be canged in next major version.