### PR TITLE
Channel method for continuous message consumption

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -975,6 +975,15 @@ abstract class AbstractConnection extends AbstractChannel
     }
 
     /**
+     * @return float
+     * @since 3.2.0
+     */
+    public function getReadTimeout(): float
+    {
+        return $this->io->getReadTimeout();
+    }
+
+    /**
      * Handles connection blocked notifications
      *
      * @param AMQPReader $args

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -20,10 +20,10 @@ abstract class AbstractIO
     /** @var int|float */
     protected $connection_timeout;
 
-    /** @var int|float */
+    /** @var float */
     protected $read_timeout;
 
-    /** @var int|float */
+    /** @var float */
     protected $write_timeout;
 
     /** @var int */
@@ -161,6 +161,11 @@ abstract class AbstractIO
     public function getLastActivity()
     {
         return max($this->last_read, $this->last_write);
+    }
+
+    public function getReadTimeout(): float
+    {
+        return $this->read_timeout;
     }
 
     /**

--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -32,8 +32,8 @@ class SocketIO extends AbstractIO
     ) {
         $this->host = $host;
         $this->port = $port;
-        $this->read_timeout = $read_timeout;
-        $this->write_timeout = $write_timeout ?: $read_timeout;
+        $this->read_timeout = (float)$read_timeout;
+        $this->write_timeout = (float)($write_timeout ?: $read_timeout);
         $this->heartbeat = $heartbeat;
         $this->initial_heartbeat = $heartbeat;
         $this->keepalive = $keepalive;

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -58,8 +58,8 @@ class StreamIO extends AbstractIO
         $this->host = $host;
         $this->port = $port;
         $this->connection_timeout = $connection_timeout;
-        $this->read_timeout = $read_write_timeout;
-        $this->write_timeout = $read_write_timeout;
+        $this->read_timeout = (float)$read_write_timeout;
+        $this->write_timeout = (float)$read_write_timeout;
         $this->context = $context;
         $this->keepalive = $keepalive;
         $this->heartbeat = $heartbeat;

--- a/demo/amqp_consumer.php
+++ b/demo/amqp_consumer.php
@@ -80,6 +80,4 @@ function shutdown($channel, $connection)
 register_shutdown_function('shutdown', $channel, $connection);
 
 // Loop as long as the channel has callbacks registered
-while ($channel->is_consuming()) {
-    $channel->wait();
-}
+$channel->consume();

--- a/demo/amqp_consumer_exclusive.php
+++ b/demo/amqp_consumer_exclusive.php
@@ -81,6 +81,4 @@ function shutdown($channel, $connection)
 register_shutdown_function('shutdown', $channel, $connection);
 
 // Loop as long as the channel has callbacks registered
-while ($channel->is_consuming()) {
-    $channel->wait();
-}
+$channel->consume();

--- a/demo/amqp_consumer_fanout_1.php
+++ b/demo/amqp_consumer_fanout_1.php
@@ -78,6 +78,4 @@ function shutdown($channel, $connection)
 register_shutdown_function('shutdown', $channel, $connection);
 
 // Loop as long as the channel has callbacks registered
-while ($channel->is_consuming()) {
-    $channel->wait();
-}
+$channel->consume();

--- a/demo/amqp_consumer_fanout_2.php
+++ b/demo/amqp_consumer_fanout_2.php
@@ -78,6 +78,4 @@ function shutdown($channel, $connection)
 register_shutdown_function('shutdown', $channel, $connection);
 
 // Loop as long as the channel has callbacks registered
-while ($channel->is_consuming()) {
-    $channel->wait();
-}
+$channel->consume();

--- a/demo/amqp_consumer_pcntl_heartbeat.php
+++ b/demo/amqp_consumer_pcntl_heartbeat.php
@@ -68,6 +68,4 @@ function shutdown($channel, $connection)
 
 register_shutdown_function('shutdown', $channel, $connection);
 
-while ($channel->is_consuming()) {
-    $channel->wait();
-}
+$channel->consume();

--- a/demo/basic_nack.php
+++ b/demo/basic_nack.php
@@ -54,6 +54,4 @@ function shutdown($channel, $connection)
 register_shutdown_function('shutdown', $channel, $connection);
 
 // Loop as long as the channel has callbacks registered
-while ($channel->is_consuming()) {
-    $channel->wait();
-}
+$channel->consume();

--- a/demo/delayed_message.php
+++ b/demo/delayed_message.php
@@ -83,6 +83,4 @@ function shutdown($channel, $connection)
 register_shutdown_function('shutdown', $channel, $connection);
 
 // Loop as long as the channel has callbacks registered
-while ($channel->is_consuming()) {
-    $channel->wait();
-}
+$channel->consume();


### PR DESCRIPTION
This is a simple and very convenient method for endless consume loop. It does all neccessary things like handling no-data exceptions and picking correct polling timeout according to read timeout and heartbeat.

This loop can be stopped by Unix signal or using method `stopConsume()`.

Fix #458 