### PR TITLE
Channel cannot be null

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -72,7 +72,7 @@ abstract class AbstractChannel
     /** @var MethodMap080|MethodMap091 */
     protected $methodMap;
 
-    /** @var int|null */
+    /** @var int */
     protected $channel_id;
 
     /** @var AMQPReader */


### PR DESCRIPTION
Phpstan confused that `channel_id` cannot be null in any way, because it has been set in constructor

```php
public function __construct(AbstractConnection $connection, $channel_id)
    {
        $this->connection = $connection;
        $this->channel_id = (int)$channel_id;
...
}
```