### PR TITLE
Throw connection exceptions on batch publish

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -1235,6 +1235,8 @@ class AMQPChannel extends AbstractChannel
             return;
         }
 
+        $this->checkConnection();
+
         /** @var AMQPWriter $pkt */
         $pkt = new AMQPWriter();
 
@@ -1265,7 +1267,6 @@ class AMQPChannel extends AbstractChannel
             }
         }
 
-        $this->checkConnection();
         $this->connection->write($pkt->getvalue());
         $this->batch_messages = array();
     }

--- a/tests/Unit/Channel/AMQPChannelTest.php
+++ b/tests/Unit/Channel/AMQPChannelTest.php
@@ -2,11 +2,13 @@
 
 namespace PhpAmqpLib\Tests\Unit\Channel;
 
+use PhpAmqpLib\Exception\AMQPChannelClosedException;
 use PhpAmqpLib\Exception\AMQPConnectionBlockedException;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Tests\Unit\Test\BufferIO;
 use PhpAmqpLib\Tests\Unit\Test\TestChannel;
 use PhpAmqpLib\Tests\Unit\Test\TestConnection;
+use PhpAmqpLib\Wire\AMQPWriter;
 use PHPUnit\Framework\TestCase;
 
 class AMQPChannelTest extends TestCase
@@ -35,6 +37,59 @@ class AMQPChannelTest extends TestCase
         $connection = new TestConnection('user', 'pass', '/', false, 'PLAIN', null, '', new BufferIO());
         $channel = new TestChannel($connection, 1);
         $channel->basic_consume(...$arguments);
+    }
+
+    /**
+     * @test
+     */
+    public function publish_batch_failed_connection(): void
+    {
+        $connection = new TestConnection('user', 'pass', '/', false, 'PLAIN', null, '', new BufferIO());
+
+        $channel = new TestChannel($connection, 1);
+        $channel->close_connection();
+
+        $message = new AMQPMessage();
+        $channel->batch_basic_publish($message, 'exchange', 'routing_key');
+
+        $this->expectException(AMQPChannelClosedException::class);
+        $this->expectExceptionMessage('Channel connection is closed.');
+
+        $channel->publish_batch();
+    }
+
+    /**
+     * @test
+     */
+    public function publish_batch_opened_connection(): void
+    {
+        $connection_mock = $this->getMockBuilder(TestConnection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prepare_content',
+                'prepare_channel_method_frame',
+                'write',
+            ])
+            ->getMock();
+
+        $channel = new TestChannel($connection_mock, 1);
+
+        $message = new AMQPMessage();
+        $writer = new AMQPWriter();
+
+        $channel->batch_basic_publish($message, 'exchange', 'routing_key');
+
+        $connection_mock->expects(self::once())
+            ->method('prepare_content');
+
+        $connection_mock->expects(self::once())
+            ->method('prepare_channel_method_frame')
+            ->willReturn($writer);
+
+        $connection_mock->expects(self::once())
+            ->method('write');
+
+        $channel->publish_batch();
     }
 
     public function basic_consume_invalid_arguments_provider()

--- a/tests/Unit/Channel/AMQPChannelTest.php
+++ b/tests/Unit/Channel/AMQPChannelTest.php
@@ -63,15 +63,22 @@ class AMQPChannelTest extends TestCase
      */
     public function publish_batch_opened_connection(): void
     {
-        $connection_mock = $this->getMockBuilder(TestConnection::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([
-                'prepare_content',
-                'prepare_channel_method_frame',
-                'write',
-            ])
-            ->getMock();
+        $mock_builder = $this->getMockBuilder(TestConnection::class)
+            ->disableOriginalConstructor();
 
+        $methods_to_mock = [
+            'prepare_content',
+            'prepare_channel_method_frame',
+            'write',
+        ];
+
+        if (!method_exists($mock_builder, 'onlyMethods')) {
+            $mock_builder->setMethods($methods_to_mock);
+        } else {
+            $mock_builder->onlyMethods($methods_to_mock);
+        }
+
+        $connection_mock = $mock_builder->getMock();
         $channel = new TestChannel($connection_mock, 1);
 
         $message = new AMQPMessage();

--- a/tests/Unit/Test/TestChannel.php
+++ b/tests/Unit/Test/TestChannel.php
@@ -27,4 +27,8 @@ class TestChannel extends AMQPChannel
         $this->auto_decode = $auto_decode;
         $this->channel_rpc_timeout = $channel_rpc_timeout;
     }
+
+    public function close_connection(): void {
+        $this->do_close();
+    }
 }


### PR DESCRIPTION
Hello,

in bulk publishing, the connection existence is not checked (PhpAmqpLib/Channel/AMQPChannel.php:1232 in publish_batch method) and therefore we can't catch proper exception, like for example AMQPChannelClosedException.

This sometimes happens when there is a delay between opening the connection and actual publishing and for example in the meantime connection was closed for any reason whatsoever.

Therefore, here is the suggestion to throw a proper exception already in the prepare_method_frame method, like it's done for send_method_frame method in the AbstractChannel class.
