### PR TITLE
Upgrade toxiproxy, enable all tests on CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
       - name: Generate changelog

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ jobs:
     name: Regenerate phpDocumentator docs
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Setup Graphviz

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -55,8 +55,17 @@ jobs:
             RABBITMQ_SSL_KEYFILE: /src/tests/certs/server_key.pem
             RABBITMQ_SSL_VERIFY: verify_peer
             RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT: 0
+      proxy:
+        image: ghcr.io/shopify/toxiproxy:2.5.0
+        ports:
+          - 8474:8474
+          - 5673:5673
 
     name: PHP ${{ matrix.php }} + phpseclib ${{ matrix.phpseclib }}
+    env:
+      TOXIPROXY_HOST: localhost
+      TOXIPROXY_AMQP_TARGET: rabbitmq
+      TOXIPROXY_AMQP_PORT: 5673
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -82,11 +91,11 @@ jobs:
       run: php ./tests/wait_broker.php
 
     - name: PHPUnit tests
-      run: ./vendor/bin/phpunit --exclude-group proxy
+      run: ./vendor/bin/phpunit
       if: matrix.coverage == 'none'
 
     - name: PHPUnit tests + coverage
-      run: ./vendor/bin/phpunit --exclude-group proxy --coverage-clover=coverage.xml
+      run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
       if: matrix.coverage != 'none'
 
     - name: Upload Codecov coverage

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -68,7 +68,7 @@ jobs:
       TOXIPROXY_AMQP_PORT: 5673
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install PHP
       uses: shivammathur/setup-php@v2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
         - RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT=0
 
   proxy:
-    image: shopify/toxiproxy
+    image: ghcr.io/shopify/toxiproxy:2.5.0
     ports:
       - "8474:8474"
       - "5673:5673"

--- a/tests/Functional/AbstractConnectionTest.php
+++ b/tests/Functional/AbstractConnectionTest.php
@@ -79,8 +79,12 @@ abstract class AbstractConnectionTest extends TestCaseCompat
      */
     protected function create_proxy($name = 'amqp_connection')
     {
+        $host = trim(getenv('TOXIPROXY_AMQP_TARGET'));
+        if (empty($host)) {
+            $host = HOST;
+        }
         $proxy = new ToxiProxy($name, $this->get_toxiproxy_host());
-        $proxy->open(HOST, PORT, $this->get_toxiproxy_amqp_port());
+        $proxy->open($host, PORT, $this->get_toxiproxy_amqp_port());
 
         return $proxy;
     }


### PR DESCRIPTION
This will enable all connection stability tests using toxiproxy. Previously some tests were skipped on github actions CI.