### PR TITLE
Allow set socket send buffer size

### DIFF
--- a/PhpAmqpLib/Connection/AMQPConnectionConfig.php
+++ b/PhpAmqpLib/Connection/AMQPConnectionConfig.php
@@ -72,6 +72,9 @@ final class AMQPConnectionConfig
     /** @var resource|null */
     private $streamContext;
 
+    /** @var int */
+    private $sendBufferSize = 0;
+
     /** @var bool */
     private $dispatchSignals = true;
 
@@ -338,6 +341,27 @@ final class AMQPConnectionConfig
             throw new InvalidArgumentException('Resource must be valid stream context');
         }
         $this->streamContext = $streamContext;
+    }
+
+    /**
+     * @return int
+     * @since 3.2.1
+     */
+    public function getSendBufferSize(): int
+    {
+        return $this->sendBufferSize;
+    }
+
+    /**
+     * Socket send buffer size. Set 0 to keep system default.
+     * @param int $sendBufferSize
+     * @return void
+     * @since 3.2.1
+     */
+    public function setSendBufferSize(int $sendBufferSize): void
+    {
+        self::assertGreaterOrEq($sendBufferSize, 0, 'sendBufferSize');
+        $this->sendBufferSize = $sendBufferSize;
     }
 
     public function isSignalsDispatchEnabled(): bool

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -45,7 +45,7 @@ class AMQPSocketConnection extends AbstractConnection
             throw new \InvalidArgumentException('channel RPC timeout must not be greater than I/O read timeout');
         }
 
-        $io = new SocketIO($host, $port, $read_timeout, $keepalive, $write_timeout, $heartbeat);
+        $io = new SocketIO($host, $port, $read_timeout, $keepalive, $write_timeout, $heartbeat, $config);
 
         parent::__construct(
             $user,

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -2,6 +2,7 @@
 
 namespace PhpAmqpLib\Wire\IO;
 
+use PhpAmqpLib\Connection\AMQPConnectionConfig;
 use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Exception\AMQPHeartbeatMissedException;
 use PhpAmqpLib\Exception\AMQPIOWaitException;
@@ -10,6 +11,9 @@ use PhpAmqpLib\Wire\AMQPWriter;
 abstract class AbstractIO
 {
     const BUFFER_SIZE = 8192;
+
+    /** @var null|AMQPConnectionConfig */
+    protected $config;
 
     /** @var string */
     protected $host;

--- a/tests/Functional/AbstractConnectionTest.php
+++ b/tests/Functional/AbstractConnectionTest.php
@@ -45,6 +45,7 @@ abstract class AbstractConnectionTest extends TestCaseCompat
         $config->setReadTimeout($timeout);
         $config->setWriteTimeout($timeout);
         $config->setConnectionTimeout($options['connectionTimeout'] ?? $timeout);
+        $config->setSendBufferSize(16384);
 
         $connection = AMQPConnectionFactory::create($config);
         $this->assertTrue($connection->isConnected());

--- a/tests/Unit/Wire/IO/SocketIOTest.php
+++ b/tests/Unit/Wire/IO/SocketIOTest.php
@@ -91,7 +91,7 @@ class SocketIOTest extends TestCase
         $property = new \ReflectionProperty(SocketIO::class, 'sock');
         $property->setAccessible(true);
 
-        $socket = new SocketIO('0.0.0.0', PORT, 0.1, 0.1, null, false, 0);
+        $socket = new SocketIO('0.0.0.0', PORT, 0.1, false, 0.1, 0);
         $property->setValue($socket, null);
 
         $socket->select(0, 0);


### PR DESCRIPTION
All data written to sockets goes to OS buffer at first, while the real network transfer happens only when buffer is full(?). Usually this approach is effective and improves transfer speeds a lot. But at the same time due that buffering PHP don't see if something goes wrong with the network. Some operating systems have 200-300kb buffer which can accommodate many data frames.

This PR allow set lower buffer size as compromise between speed and lost data amount on network issues.

By default we still use system defined buffer size, so no breaking changes introduced.