### PR TITLE
Update codecov action to latest version

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -100,7 +100,7 @@ jobs:
 
     - name: Upload Codecov coverage
       if: matrix.coverage != 'none'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: './coverage.xml'
         fail_ci_if_error: true


### PR DESCRIPTION
Codecov action v1 is not supported and does not work anymore.
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1

fix #1027 