### PR TITLE
Split buffer and IO readers into separate classes

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -162,7 +162,7 @@ class AMQPChannel extends AbstractChannel
      *
      * @param AMQPReader $reader
      */
-    protected function channel_alert($reader)
+    protected function channel_alert(AMQPReader $reader): void
     {
         $reply_code = $reader->read_short();
         $reply_text = $reader->read_shortstr();
@@ -209,9 +209,9 @@ class AMQPChannel extends AbstractChannel
 
     /**
      * @param AMQPReader $reader
-     * @throws \PhpAmqpLib\Exception\AMQPProtocolChannelException
+     * @throws AMQPProtocolChannelException
      */
-    protected function channel_close($reader)
+    protected function channel_close(AMQPReader $reader): void
     {
         $reply_code = $reader->read_short();
         $reply_text = $reader->read_shortstr();
@@ -250,10 +250,7 @@ class AMQPChannel extends AbstractChannel
         ), false, $this->channel_rpc_timeout);
     }
 
-    /**
-     * @param AMQPReader $reader
-     */
-    protected function channel_flow($reader)
+    protected function channel_flow(AMQPReader $reader): void
     {
         $this->active = $reader->read_bit();
         $this->x_flow_ok($this->active);
@@ -268,11 +265,7 @@ class AMQPChannel extends AbstractChannel
         $this->send_method_frame(array($class_id, $method_id), $args);
     }
 
-    /**
-     * @param AMQPReader $reader
-     * @return bool
-     */
-    protected function channel_flow_ok($reader)
+    protected function channel_flow_ok(AMQPReader $reader): bool
     {
         return $reader->read_bit();
     }
@@ -348,7 +341,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPReader $reader
      * @return int
      */
-    protected function access_request_ok($reader)
+    protected function access_request_ok(AMQPReader $reader): int
     {
         $this->default_ticket = $reader->read_short();
 
@@ -694,7 +687,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPReader $reader
      * @return string[]
      */
-    protected function queue_declare_ok($reader)
+    protected function queue_declare_ok(AMQPReader $reader)
     {
         $queue = $reader->read_shortstr();
         $message_count = $reader->read_long();
@@ -741,9 +734,9 @@ class AMQPChannel extends AbstractChannel
      * Confirms deletion of a queue
      *
      * @param AMQPReader $reader
-     * @return string
+     * @return int|string
      */
-    protected function queue_delete_ok($reader)
+    protected function queue_delete_ok(AMQPReader $reader)
     {
         return $reader->read_long();
     }
@@ -777,9 +770,9 @@ class AMQPChannel extends AbstractChannel
      * Confirms a queue purge
      *
      * @param AMQPReader $reader
-     * @return string
+     * @return int|string
      */
-    protected function queue_purge_ok($reader)
+    protected function queue_purge_ok(AMQPReader $reader)
     {
         return $reader->read_long();
     }
@@ -802,7 +795,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPReader $reader
      * @throws AMQPRuntimeException
      */
-    protected function basic_ack_from_server(AMQPReader $reader)
+    protected function basic_ack_from_server(AMQPReader $reader): void
     {
         $delivery_tag = $reader->read_longlong();
         $multiple = (bool) $reader->read_bit();
@@ -823,7 +816,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPReader $reader
      * @throws AMQPRuntimeException
      */
-    protected function basic_nack_from_server($reader)
+    protected function basic_nack_from_server(AMQPReader $reader): void
     {
         $delivery_tag = $reader->read_longlong();
         $multiple = (bool) $reader->read_bit();
@@ -937,7 +930,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPReader $reader
      * @return string
      */
-    protected function basic_cancel_ok($reader)
+    protected function basic_cancel_ok(AMQPReader $reader): string
     {
         $consumerTag = $reader->read_shortstr();
         unset($this->callbacks[$consumerTag]);
@@ -1027,7 +1020,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPReader $reader
      * @return string
      */
-    protected function basic_consume_ok($reader)
+    protected function basic_consume_ok(AMQPReader $reader): string
     {
         return $reader->read_shortstr();
     }
@@ -1038,7 +1031,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPReader $reader
      * @param AMQPMessage $message
      */
-    protected function basic_deliver($reader, $message)
+    protected function basic_deliver(AMQPReader $reader, AMQPMessage $message): void
     {
         $consumer_tag = $reader->read_shortstr();
         $delivery_tag = $reader->read_longlong();
@@ -1092,7 +1085,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPMessage $message
      * @return AMQPMessage
      */
-    protected function basic_get_ok($reader, $message)
+    protected function basic_get_ok(AMQPReader $reader, AMQPMessage $message): AMQPMessage
     {
         $delivery_tag = $reader->read_longlong();
         $redelivered = $reader->read_bit();
@@ -1344,7 +1337,7 @@ class AMQPChannel extends AbstractChannel
      * @param AMQPReader $reader
      * @param AMQPMessage $message
      */
-    protected function basic_return($reader, $message)
+    protected function basic_return(AMQPReader $reader, AMQPMessage $message)
     {
         $callback = $this->basic_return_callback;
         if (!is_callable($callback)) {

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -72,7 +72,7 @@ abstract class AbstractConnection extends AbstractChannel
     /** @var string */
     protected $known_hosts;
 
-    /** @var null|AMQPReader */
+    /** @var null|Wire\AMQPIOReader */
     protected $input;
 
     /** @var string */
@@ -114,10 +114,10 @@ abstract class AbstractConnection extends AbstractChannel
     /** @var bool Maintain connection status */
     protected $is_connected = false;
 
-    /** @var \PhpAmqpLib\Wire\IO\AbstractIO */
+    /** @var AbstractIO */
     protected $io;
 
-    /** @var \PhpAmqpLib\Wire\AMQPReader */
+    /** @var Wire\AMQPBufferReader */
     protected $wait_frame_reader;
 
     /** @var callable Handles connection blocking from the server */
@@ -201,7 +201,7 @@ abstract class AbstractConnection extends AbstractChannel
         // save the params for the use of __clone
         $this->construct_params = func_get_args();
 
-        $this->wait_frame_reader = new AMQPReader(null);
+        $this->wait_frame_reader = new Wire\AMQPBufferReader('');
         $this->vhost = $vhost;
         $this->insist = $insist;
         $this->login_method = $login_method;
@@ -256,7 +256,7 @@ abstract class AbstractConnection extends AbstractChannel
                 // The connection object itself is treated as channel 0
                 parent::__construct($this, 0);
 
-                $this->input = new AMQPReader(null, $this->io);
+                $this->input = new Wire\AMQPIOReader($this->io);
 
                 $this->write($this->constants->getHeader());
                 // assume frame was sent successfully, used in $this->wait_channel()
@@ -591,7 +591,7 @@ abstract class AbstractConnection extends AbstractChannel
 
         try {
             // frame_type + channel_id + size
-            $this->wait_frame_reader->reuse(
+            $this->wait_frame_reader->reset(
                 $this->input->read(AMQPReader::OCTET + AMQPReader::SHORT + AMQPReader::LONG)
             );
 
@@ -603,7 +603,7 @@ abstract class AbstractConnection extends AbstractChannel
             $size = $this->wait_frame_reader->read_long();
 
             // payload + ch
-            $this->wait_frame_reader->reuse($this->input->read(AMQPReader::OCTET + (int) $size));
+            $this->wait_frame_reader->reset($this->input->read(AMQPReader::OCTET + (int) $size));
 
             $payload = $this->wait_frame_reader->read($size);
             $ch = $this->wait_frame_reader->read_octet();
@@ -963,7 +963,7 @@ abstract class AbstractConnection extends AbstractChannel
     }
 
     /**
-     * @return \PhpAmqpLib\Wire\IO\AbstractIO
+     * @return AbstractIO
      * @deprecated
      */
     public function getIO()

--- a/PhpAmqpLib/Wire/AMQPBufferReader.php
+++ b/PhpAmqpLib/Wire/AMQPBufferReader.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace PhpAmqpLib\Wire;
+
+use PhpAmqpLib\Exception\AMQPDataReadException;
+
+class AMQPBufferReader extends AMQPReader
+{
+    /**
+     * @var string
+     */
+    private $buffer;
+
+    /**
+     * @var int
+     */
+    private $length;
+
+    public function __construct(string $buffer)
+    {
+        $this->buffer = $buffer;
+        $this->length = mb_strlen($buffer, 'ASCII');
+    }
+
+    public function close(): void
+    {
+    }
+
+    /**
+     * Resets the object from the injected param
+     *
+     * Used to not need to create a new AMQPBufferReader instance every time.
+     * when we can just pass a string and reset the object state.
+     * NOTE: since we are working with strings we don't need to pass an AbstractIO
+     *       or a timeout.
+     *
+     * @param string $str
+     */
+    public function reset(string $str): void
+    {
+        $this->buffer = $str;
+        $this->length = mb_strlen($this->buffer, 'ASCII');
+        $this->offset = 0;
+        $this->resetCounters();
+    }
+
+    protected function rawread(int $n): string
+    {
+        if ($this->length < $n) {
+            throw new AMQPDataReadException(sprintf(
+                                                'Error reading data. Requested %s bytes while string buffer has only %s',
+                                                $n,
+                                                $this->length
+                                            ));
+        }
+
+        $res = mb_substr($this->buffer, 0, $n, 'ASCII');
+        $this->buffer = mb_substr($this->buffer, $n, null, 'ASCII');
+        $this->length -= $n;
+        $this->offset += $n;
+
+        return $res;
+    }
+
+}

--- a/PhpAmqpLib/Wire/AMQPByteStream.php
+++ b/PhpAmqpLib/Wire/AMQPByteStream.php
@@ -4,10 +4,20 @@ namespace PhpAmqpLib\Wire;
 
 use PhpAmqpLib\Helper\BigInteger;
 
-class AbstractClient
+abstract class AMQPByteStream
 {
+    public const BIT = 1;
+    public const OCTET = 1;
+    public const SHORTSTR = 1;
+    public const SHORT = 2;
+    public const LONG = 4;
+    public const SIGNED_LONG = 4;
+    public const READ_PHP_INT = 4; // use READ_ to avoid possible clashes with PHP
+    public const LONGLONG = 8;
+    public const TIMESTAMP = 8;
+
     /** @var bool */
-    const PLATFORM_64BIT = PHP_INT_SIZE === 8;
+    protected const PLATFORM_64BIT = PHP_INT_SIZE === 8;
 
     /** @var BigInteger[][] */
     protected static $bigIntegers = array();

--- a/PhpAmqpLib/Wire/AMQPIOReader.php
+++ b/PhpAmqpLib/Wire/AMQPIOReader.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace PhpAmqpLib\Wire;
+
+use PhpAmqpLib\Exception\AMQPDataReadException;
+use PhpAmqpLib\Exception\AMQPIOException;
+use PhpAmqpLib\Exception\AMQPNoDataException;
+use PhpAmqpLib\Exception\AMQPTimeoutException;
+use PhpAmqpLib\Helper\MiscHelper;
+use PhpAmqpLib\Wire\IO\AbstractIO;
+use RuntimeException;
+
+class AMQPIOReader extends AMQPReader
+{
+    /** @var AbstractIO */
+    private $io;
+
+    /** @var int|float|null */
+    protected $timeout;
+
+    public function __construct(AbstractIO $io, $timeout = 0)
+    {
+        $this->io = $io;
+        $this->timeout = $timeout;
+    }
+
+    public function close(): void
+    {
+        $this->io->close();
+    }
+
+    /**
+     * @return float|int|mixed|null
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * Sets the timeout (second)
+     *
+     * @param int|float|null $timeout
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
+    }
+
+    /**
+     * @param int $n
+     * @return string
+     * @throws RuntimeException
+     * @throws AMQPDataReadException|AMQPNoDataException|AMQPIOException
+     */
+    protected function rawread(int $n): string
+    {
+        $res = '';
+        while (true) {
+            $this->wait();
+            try {
+                $res = $this->io->read($n);
+                break;
+            } catch (AMQPTimeoutException $e) {
+                if ($this->getTimeout() > 0) {
+                    throw $e;
+                }
+            }
+        }
+        $this->offset += $n;
+
+        return $res;
+    }
+
+    /**
+     * Waits until some data is retrieved from the socket.
+     *
+     * AMQPTimeoutException can be raised if the timeout is set
+     *
+     * @throws \PhpAmqpLib\Exception\AMQPTimeoutException when timeout is set and no data received
+     * @throws \PhpAmqpLib\Exception\AMQPNoDataException when no data is ready to read from IO
+     */
+    protected function wait()
+    {
+        $timeout = $this->timeout;
+        if (null === $timeout) {
+            // timeout=null just poll state and return instantly
+            $sec = 0;
+            $usec = 0;
+        } elseif ($timeout > 0) {
+            list($sec, $usec) = MiscHelper::splitSecondsMicroseconds($this->getTimeout());
+        } else {
+            // wait indefinitely for data if timeout=0
+            $sec = null;
+            $usec = 0;
+        }
+
+        $result = $this->io->select($sec, $usec);
+
+        if ($result === 0) {
+            if ($timeout > 0) {
+                throw new AMQPTimeoutException(sprintf(
+                                                   'The connection timed out after %s sec while awaiting incoming data',
+                                                   $timeout
+                                               ));
+            } else {
+                throw new AMQPNoDataException('No data is ready to read');
+            }
+        }
+    }
+}

--- a/PhpAmqpLib/Wire/AMQPWriter.php
+++ b/PhpAmqpLib/Wire/AMQPWriter.php
@@ -6,7 +6,7 @@ use PhpAmqpLib\Exception\AMQPInvalidArgumentException;
 use PhpAmqpLib\Exception\AMQPOutOfRangeException;
 use PhpAmqpLib\Helper\BigInteger;
 
-class AMQPWriter extends AbstractClient
+class AMQPWriter extends AMQPByteStream
 {
     /** @var string */
     protected $out = '';

--- a/tests/Unit/Message/AMQPMessageTest.php
+++ b/tests/Unit/Message/AMQPMessageTest.php
@@ -4,7 +4,7 @@ namespace PhpAmqpLib\Tests\Unit\Message;
 
 use PhpAmqpLib\Exception\AMQPEmptyDeliveryTagException;
 use PhpAmqpLib\Message\AMQPMessage;
-use PhpAmqpLib\Wire\AMQPReader;
+use PhpAmqpLib\Wire\AMQPBufferReader;
 use PHPUnit\Framework\TestCase;
 
 class AMQPMessageTest extends TestCase
@@ -15,11 +15,11 @@ class AMQPMessageTest extends TestCase
      */
     public function serialize_properties(array $expected, array $properties)
     {
-        $reader = new AMQPReader(null);
+        $reader = new AMQPBufferReader('');
         $message = new AMQPMessage('', $properties);
 
         $encodedData = $message->serialize_properties();
-        $reader->reuse($encodedData);
+        $reader->reset($encodedData);
         $message->load_properties($reader);
         $props = $message->get_properties();
 

--- a/tests/Unit/Test/TestConnection.php
+++ b/tests/Unit/Test/TestConnection.php
@@ -3,7 +3,7 @@
 namespace PhpAmqpLib\Tests\Unit\Test;
 
 use PhpAmqpLib\Connection\AbstractConnection;
-use PhpAmqpLib\Wire\AMQPReader;
+use PhpAmqpLib\Wire\AMQPBufferReader;
 
 class TestConnection extends AbstractConnection
 {
@@ -26,7 +26,7 @@ class TestConnection extends AbstractConnection
     public function setIsBlocked($blocked = true)
     {
         if ($blocked) {
-            $this->connection_blocked(new AMQPReader(hex2bin('0120')));
+            $this->connection_blocked(new AMQPBufferReader(hex2bin('0120')));
         } else {
             $this->connection_unblocked();
         }

--- a/tests/Unit/Wire/AMQPReaderTest.php
+++ b/tests/Unit/Wire/AMQPReaderTest.php
@@ -3,7 +3,7 @@
 namespace PhpAmqpLib\Tests\Unit\Wire;
 
 use PhpAmqpLib\Wire;
-use PhpAmqpLib\Wire\AMQPReader;
+use PhpAmqpLib\Wire\AMQPBufferReader;
 use PhpAmqpLib\Tests\TestCaseCompat;
 use PhpAmqpLib\Wire\AMQPAbstractCollection;
 
@@ -27,7 +27,7 @@ class AMQPReaderTest extends TestCaseCompat
             'snowman' => ['x', "\x26\x03"]
         ];
         $data = hex2bin('0000000f07736e6f776d616e78000000022603');
-        $reader = new AMQPReader($data);
+        $reader = new AMQPBufferReader($data);
         $parsed = $reader->read_table();
         $this->assertEquals($expected, $parsed);
     }
@@ -35,7 +35,7 @@ class AMQPReaderTest extends TestCaseCompat
     public function test32bitSignedIntegerOverflow()
     {
         $data = hex2bin('0000000080000000');
-        $reader = new AMQPReader($data);
+        $reader = new AMQPBufferReader($data);
         $parsed = $reader->read_signed_longlong();
         if (PHP_INT_SIZE === 8) {
             $this->assertIsInt($parsed);
@@ -49,7 +49,7 @@ class AMQPReaderTest extends TestCaseCompat
     public function test64bitUnsignedIntegerOverflow()
     {
         $data = hex2bin(str_repeat('f', 16));
-        $reader = new AMQPReader($data);
+        $reader = new AMQPBufferReader($data);
         $parsed = $reader->read_longlong();
         $this->assertIsString($parsed);
         $this->assertEquals('18446744073709551615', $parsed);
@@ -58,13 +58,13 @@ class AMQPReaderTest extends TestCaseCompat
     public function testDecodeFloatingPointValues()
     {
         $data = hex2bin('3a83126f');
-        $reader = new AMQPReader($data);
+        $reader = new AMQPBufferReader($data);
         $parsed = $reader->read_value(AMQPAbstractCollection::T_FLOAT);
         self::assertIsFloat($parsed);
         self::assertEquals(0.0010000000474974513, $parsed);
 
         $data = hex2bin('3feff7ced916872b');
-        $reader = new AMQPReader($data);
+        $reader = new AMQPBufferReader($data);
         $parsed = $reader->read_value(AMQPAbstractCollection::T_DOUBLE);
         self::assertIsFloat($parsed);
         self::assertEquals(0.999, $parsed);

--- a/tests/Unit/WireTest.php
+++ b/tests/Unit/WireTest.php
@@ -5,7 +5,7 @@ namespace PhpAmqpLib\Tests\Unit;
 use PhpAmqpLib\Tests\TestCaseCompat;
 use PhpAmqpLib\Wire\AMQPAbstractCollection;
 use PhpAmqpLib\Wire\AMQPArray;
-use PhpAmqpLib\Wire\AMQPReader;
+use PhpAmqpLib\Wire\AMQPBufferReader;
 use PhpAmqpLib\Wire\AMQPTable;
 use PhpAmqpLib\Wire\AMQPWriter;
 
@@ -297,7 +297,7 @@ class WireTest extends TestCaseCompat
         $w = new AMQPWriter();
         $w->write_array($d);
 
-        $r = new AMQPReader($w->getvalue());
+        $r = new AMQPBufferReader($w->getvalue());
         $rd = $r->read_array();
 
         $this->assertEquals($d, $rd);
@@ -336,7 +336,7 @@ class WireTest extends TestCaseCompat
             )
         );
 
-        $r = new AMQPReader($w->getvalue());
+        $r = new AMQPBufferReader($w->getvalue());
 
         //type casting - thanks to ancient phpunit on travis
         $this->assertEquals(
@@ -387,7 +387,7 @@ class WireTest extends TestCaseCompat
         $w = new AMQPWriter();
         $w->write_table($d);
 
-        $r = new AMQPReader($w->getvalue());
+        $r = new AMQPBufferReader($w->getvalue());
         $rd = $r->read_table();
 
         $this->assertEquals($d, $rd);
@@ -429,7 +429,7 @@ class WireTest extends TestCaseCompat
             )
         );
 
-        $r = new AMQPReader($w->getvalue());
+        $r = new AMQPBufferReader($w->getvalue());
 
         //type casting - thanks to ancient phpunit on travis
         $this->assertEquals(
@@ -649,7 +649,7 @@ class WireTest extends TestCaseCompat
             $writer->{$write_method}($value);
         }
 
-        $reader = new AMQPReader($writer->getvalue());
+        $reader = new AMQPBufferReader($writer->getvalue());
         if ($reflection) {
             $m = new \ReflectionMethod($reader, $read_method);
             $m->setAccessible(true);


### PR DESCRIPTION
This will split AMQPReader into two separate classes, each for different type of input, either buffer or IO layer. Resolves long standing TODO and makes code cleaner, more understandable.

Also add missing type hints.

No functional or breaking changes. Only internal refactoring.