### PR TITLE
Missing PHPDoc param in AbstractConnection constructor

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -174,6 +174,7 @@ abstract class AbstractConnection extends AbstractChannel
      * @param int $heartbeat
      * @param int|float $connection_timeout
      * @param int|float $channel_rpc_timeout
+     * @param \PhpAmqpLib\Connection\AMQPConnectionConfig | null $config
      * @throws \Exception
      */
     public function __construct(


### PR DESCRIPTION
Missed param PHPDoc in construct AbstractConnection for `?AMQPConnectionConfig $config = null`