### PR TITLE
Update GHA to use latest RabbitMQ

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -6,7 +6,7 @@ jobs:
   run:
     runs-on: 'ubuntu-latest'
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - php: '7.1'
@@ -43,9 +43,7 @@ jobs:
             coverage: none
     services:
       rabbitmq:
-        # 3.8.10 and later versions has enabled TLSv1.3 by default which is not supported by PHP images
-        # TLSv1.3 can be disabled by using configuration file, but not environment variables
-        image: rabbitmq:3.8.9-management
+        image: rabbitmq:3.11-management
         ports:
           - 5671:5671
           - 5672:5672
@@ -54,11 +52,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}:/src
         env:
-            RABBITMQ_SSL_CACERTFILE: /src/tests/certs/ca_certificate.pem
-            RABBITMQ_SSL_CERTFILE: /src/tests/certs/server_certificate.pem
-            RABBITMQ_SSL_KEYFILE: /src/tests/certs/server_key.pem
-            RABBITMQ_SSL_VERIFY: verify_peer
-            RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT: 0
+          RABBITMQ_CONFIG_FILE: /src/tests/rabbitmq.conf
       proxy:
         image: ghcr.io/shopify/toxiproxy:2.5.0
         ports:
@@ -85,7 +79,7 @@ jobs:
     - name: Check PHP info
       run: php tests/phpinfo.php
 
-    - name: Start broker service
+    - name: Re-start broker service to pick up rabbitmq.conf
       run: docker restart ${{ job.services.rabbitmq.id }}
 
     - name: Composer install

--- a/tests/rabbitmq.conf
+++ b/tests/rabbitmq.conf
@@ -1,0 +1,15 @@
+listeners.tcp.default = 5672
+listeners.ssl.default = 5671
+
+management.tcp.port = 15672
+management.ssl.port = 15671
+
+ssl_options.certfile   = /src/tests/certs/server_certificate.pem
+ssl_options.keyfile    = /src/tests/certs/server_key.pem
+ssl_options.cacertfile = /src/tests/certs/ca_certificate.pem
+ssl_options.verify = verify_peer
+ssl_options.fail_if_no_peer_cert = false
+
+management.ssl.certfile   = /src/tests/certs/server_certificate.pem
+management.ssl.keyfile    = /src/tests/certs/server_key.pem
+management.ssl.cacertfile = /src/tests/certs/ca_certificate.pem


### PR DESCRIPTION
Uses a `rabbitmq.conf` file rather than env vars