### PR TITLE
feat(heartbeat): add support for lazy connections

### DIFF
--- a/PhpAmqpLib/Connection/Heartbeat/AbstractSignalHeartbeatSender.php
+++ b/PhpAmqpLib/Connection/Heartbeat/AbstractSignalHeartbeatSender.php
@@ -16,6 +16,11 @@ abstract class AbstractSignalHeartbeatSender
     protected $connection;
 
     /**
+     * @var bool
+     */
+    protected $wasActive = false;
+
+    /**
      * @param AbstractConnection $connection
      * @throws AMQPRuntimeException
      */
@@ -61,6 +66,15 @@ abstract class AbstractSignalHeartbeatSender
     protected function handleSignal(int $interval): void
     {
         if (!$this->connection) {
+            return;
+        }
+
+        // Support for lazy connections
+        if (!$this->wasActive && $this->connection->isConnected()) {
+            $this->wasActive = true;
+        }
+
+        if (!$this->wasActive) {
             return;
         }
 

--- a/PhpAmqpLib/Connection/Heartbeat/PCNTLHeartbeatSender.php
+++ b/PhpAmqpLib/Connection/Heartbeat/PCNTLHeartbeatSender.php
@@ -18,10 +18,6 @@ final class PCNTLHeartbeatSender extends AbstractSignalHeartbeatSender
             throw new AMQPRuntimeException('Unable to re-register heartbeat sender');
         }
 
-        if (!$this->connection->isConnected()) {
-            throw new AMQPRuntimeException('Unable to register heartbeat sender, connection is not active');
-        }
-
         $timeout = $this->connection->getHeartbeat();
 
         if ($timeout > 0) {

--- a/PhpAmqpLib/Connection/Heartbeat/SIGHeartbeatSender.php
+++ b/PhpAmqpLib/Connection/Heartbeat/SIGHeartbeatSender.php
@@ -41,9 +41,6 @@ final class SIGHeartbeatSender extends AbstractSignalHeartbeatSender
             throw new AMQPRuntimeException('Unable to re-register heartbeat sender');
         }
 
-        if (!$this->connection->isConnected()) {
-            throw new AMQPRuntimeException('Unable to register heartbeat sender, connection is not active');
-        }
         $timeout = $this->connection->getHeartbeat();
 
         if ($timeout > 0) {

--- a/tests/Functional/Connection/Heartbeat/SIGHeartbeatSenderTest.php
+++ b/tests/Functional/Connection/Heartbeat/SIGHeartbeatSenderTest.php
@@ -54,18 +54,6 @@ class SIGHeartbeatSenderTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function register_should_fail_with_closed_connection()
-    {
-        $this->expectException(AMQPRuntimeException::class);
-        $this->expectExceptionMessage('Unable to register heartbeat sender, connection is not active');
-
-        $this->connection->close();
-        $this->sender->register();
-    }
-
-    /**
-     * @test
-     */
     public function register_should_fail_after_unregister()
     {
         $this->expectException(AMQPRuntimeException::class);


### PR DESCRIPTION
Make heartbeat sender work with lazy connections, more info in #1099 
fix #1099 