### PR TITLE
drop support for PHP7.1

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,10 +9,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - php: '7.1'
-            phpseclib: '^2.0'
-            composer: 'composer:v1'
-            coverage: none
           - php: '7.2'
             phpseclib: '^2.0'
             composer: 'composer:v1'

--- a/PhpAmqpLib/Connection/AMQPConnectionConfig.php
+++ b/PhpAmqpLib/Connection/AMQPConnectionConfig.php
@@ -341,15 +341,10 @@ final class AMQPConnectionConfig
         $this->isSecure = $isSecure;
 
         if ($this->isSecure) {
-            if (PHP_VERSION_ID >= 70200) {
-                $this->setNetworkProtocol('tls');
-            } else {
-                $this->setNetworkProtocol('ssl');
-            }
-
+            $this->networkProtocol = 'tls';
             $this->sslCryptoMethod = STREAM_CRYPTO_METHOD_ANY_CLIENT;
         } else {
-            $this->setNetworkProtocol('tcp');
+            $this->networkProtocol = 'tcp';
             $this->sslCryptoMethod = null;
         }
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ image: Visual Studio 2017
 environment:
   matrix:
   - dependencies: current
-    PHP_VERSION: 7.1
-  - dependencies: current
     PHP_VERSION: 7.2
   - dependencies: highest
     PHP_VERSION: 7.3

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     ],
     "require": {
-        "php": "^7.1||^8.0",
+        "php": "^7.2||^8.0",
         "ext-sockets": "*",
         "ext-mbstring": "*",
         "phpseclib/phpseclib": "^2.0|^3.0"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-cli
+FROM php:7.2-cli
 
 RUN apt update && \
     apt -qy install git unzip zlib1g-dev libzip-dev


### PR DESCRIPTION
According to packagist stats[1], PHP7.1 share is less than 1.5%. I think it is time to drop support for it and get rid of some workarounds. Probably we can go further in next minor versions as PHP8.3 is comming and we don't want to have a long list of supported versions.

Minimum required version now is 7.2

[1] https://stitcher.io/blog/php-version-stats-july-2023