### PR TITLE
Fix a typo in ChannelConsumeTest method name

### DIFF
--- a/tests/Functional/Channel/ChannelConsumeTest.php
+++ b/tests/Functional/Channel/ChannelConsumeTest.php
@@ -7,7 +7,7 @@ class ChannelConsumeTest extends ChannelTestCase
     /**
      * @test
      */
-    public function basic_consume_same_tag_thros_exception()
+    public function basic_consume_same_tag_throws_exception()
     {
         $this->expectException(\InvalidArgumentException::class);
         list($queue, ,) = $this->channel->queue_declare();


### PR DESCRIPTION
Fix a typo in the method name 
`basic_consume_same_tag_thros_exception`, renaming it to `basic_consume_same_tag_throws_exception`