### PR TITLE
Fix conection_create method typo in tests

### DIFF
--- a/tests/Functional/AbstractConnectionTest.php
+++ b/tests/Functional/AbstractConnectionTest.php
@@ -14,7 +14,7 @@ abstract class AbstractConnectionTest extends TestCaseCompat
 {
     public static $blocked = false;
 
-    protected function conection_create(
+    protected function connection_create(
         string $type = 'stream',
         string $host = HOST,
         int $port = PORT,
@@ -68,7 +68,7 @@ abstract class AbstractConnectionTest extends TestCaseCompat
      */
     protected function channel_create($connectionType, $options = [])
     {
-        $connection = $this->conection_create($connectionType, HOST, PORT, $options);
+        $connection = $this->connection_create($connectionType, HOST, PORT, $options);
         $channel = $connection->channel();
         $this->assertTrue($channel->is_open());
 

--- a/tests/Functional/Bug/Bug256Test.php
+++ b/tests/Functional/Bug/Bug256Test.php
@@ -29,12 +29,12 @@ class Bug256Test extends AbstractConnectionTest
 
     protected function setUpCompat()
     {
-        $this->connection = $this->conection_create('socket');
+        $this->connection = $this->connection_create('socket');
         $this->channel = $this->connection->channel();
 
         $this->channel->exchange_declare($this->exchangeName, 'direct', false, true, false);
 
-        $this->connection2 = $this->conection_create('stream');
+        $this->connection2 = $this->connection_create('stream');
         $this->channel2 = $this->connection->channel();
 
         list($this->queueName, ,) = $this->channel2->queue_declare();

--- a/tests/Functional/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Functional/Connection/AMQPStreamConnectionTest.php
@@ -14,7 +14,7 @@ class AMQPStreamConnectionTest extends AbstractConnectionTest
      */
     public function connection_select_blocking_wo_timeout(): void
     {
-        $connection = $this->conection_create('stream');
+        $connection = $this->connection_create('stream');
 
         $start = microtime(true);
         ChannelWaitTest::deferSignal(1);

--- a/tests/Functional/Connection/ConnectionClosedTest.php
+++ b/tests/Functional/Connection/ConnectionClosedTest.php
@@ -40,7 +40,7 @@ class ConnectionClosedTest extends AbstractConnectionTest
             'keepalive' => $keepalive,
         );
         /** @var AbstractConnection $connection */
-        $connection = $this->conection_create(
+        $connection = $this->connection_create(
             $type,
             $proxy->getHost(),
             $proxy->getPort(),
@@ -84,7 +84,7 @@ class ConnectionClosedTest extends AbstractConnectionTest
     {
         $proxy = $this->create_proxy();
 
-        $connection = $this->conection_create(
+        $connection = $this->connection_create(
             $type,
             $proxy->getHost(),
             $proxy->getPort()
@@ -234,7 +234,7 @@ class ConnectionClosedTest extends AbstractConnectionTest
         $timeout = 1;
         $proxy = $this->create_proxy();
         /** @var AbstractConnection $connection */
-        $connection = $this->conection_create(
+        $connection = $this->connection_create(
             $type,
             $proxy->getHost(),
             $proxy->getPort(),

--- a/tests/Functional/Connection/ConnectionCreationTest.php
+++ b/tests/Functional/Connection/ConnectionCreationTest.php
@@ -64,7 +64,7 @@ class ConnectionCreationTest extends AbstractConnectionTest
         $writer->write_short($broker); // broker heartbeat
         $args = new AMQPBufferReader($writer->getvalue());
 
-        $connection = $this->conection_create('stream', HOST, PORT, ['heartbeat' => $client]);
+        $connection = $this->connection_create('stream', HOST, PORT, ['heartbeat' => $client]);
         $method->invoke($connection, $args);
         self::assertEquals($expected, $connection->getHeartbeat());
     }

--- a/tests/Functional/Connection/ConnectionUnresponsiveTest.php
+++ b/tests/Functional/Connection/ConnectionUnresponsiveTest.php
@@ -24,7 +24,7 @@ class ConnectionUnresponsiveTest extends AbstractConnectionTest
     public function must_throw_exception_on_completely_blocked_connection($type)
     {
         self::$blocked = false;
-        $connection = $this->conection_create($type);
+        $connection = $this->connection_create($type);
         $channel = $connection->channel();
         $this->assertTrue($channel->is_open());
         $this->queue_bind($channel, $exchange_name = 'test_exchange_broken', $queue_name);
@@ -65,7 +65,7 @@ class ConnectionUnresponsiveTest extends AbstractConnectionTest
         $connection = null;
         $exception = null;
         try {
-            $connection = $this->conection_create(
+            $connection = $this->connection_create(
                 $type,
                 $proxy->getHost(),
                 $proxy->getPort(),

--- a/tests/Functional/Connection/Heartbeat/PCNTLHeartbeatSenderTest.php
+++ b/tests/Functional/Connection/Heartbeat/PCNTLHeartbeatSenderTest.php
@@ -26,7 +26,7 @@ class PCNTLHeartbeatSenderTest extends AbstractConnectionTest
 
     protected function setUpCompat()
     {
-        $this->connection = $this->conection_create(
+        $this->connection = $this->connection_create(
             'stream',
             HOST,
             PORT,

--- a/tests/Functional/Connection/Heartbeat/SIGHeartbeatSenderTest.php
+++ b/tests/Functional/Connection/Heartbeat/SIGHeartbeatSenderTest.php
@@ -29,7 +29,7 @@ class SIGHeartbeatSenderTest extends AbstractConnectionTest
 
     protected function setUpCompat()
     {
-        $this->connection = $this->conection_create(
+        $this->connection = $this->connection_create(
             'stream',
             HOST,
             PORT,

--- a/tests/Functional/Connection/Heartbeat/SignalHeartbeatTest.php
+++ b/tests/Functional/Connection/Heartbeat/SignalHeartbeatTest.php
@@ -36,7 +36,7 @@ class SignalHeartbeatTest extends AbstractConnectionTest
 
     protected function setUpCompat()
     {
-        $this->connection = $this->conection_create(
+        $this->connection = $this->connection_create(
             'stream',
             HOST,
             PORT,

--- a/tests/Functional/Connection/SSLConnectionTest.php
+++ b/tests/Functional/Connection/SSLConnectionTest.php
@@ -17,7 +17,7 @@ class SSLConnectionTest extends AbstractConnectionTest
     public function secure_connection_default_params($options)
     {
         $port = $options['port'] ?? 5671;
-        $connection = $this->conection_create('ssl', HOST, $port, $options);
+        $connection = $this->connection_create('ssl', HOST, $port, $options);
         self::assertTrue($connection->isConnected());
         $channel = $connection->channel();
         self::assertTrue($channel->is_open());


### PR DESCRIPTION
`rename conection_create` to `connection_crease` defined and used in tests