### PR TITLE
Only call fwrite() if select() said the fd is ready.

### DIFF
--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -186,9 +186,11 @@ class SocketIO extends AbstractIO
         while ($written < $len) {
             $this->setErrorHandler();
             try {
-                $this->select_write();
-                $buffer = mb_substr($data, $written, self::BUFFER_SIZE, 'ASCII');
-                $result = socket_write($this->sock, $buffer);
+                $result = 0;
+                if ($this->select_write()) {
+                    $buffer = mb_substr($data, $written, self::BUFFER_SIZE, 'ASCII');
+                    $result = socket_write($this->sock, $buffer);
+                }
                 $this->throwOnError();
             } catch (\ErrorException $e) {
                 $code = socket_last_error($this->sock);

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -251,9 +251,11 @@ class StreamIO extends AbstractIO
             // http://comments.gmane.org/gmane.comp.encryption.openssl.user/4361
             try {
                 // check stream and prevent from high CPU usage
-                $this->select_write();
-                $buffer = mb_substr($data, $written, self::BUFFER_SIZE, 'ASCII');
-                $result = fwrite($this->sock, $buffer);
+                $result = 0;
+                if ($this->select_write()) {
+                    $buffer = mb_substr($data, $written, self::BUFFER_SIZE, 'ASCII');
+                    $result = fwrite($this->sock, $buffer);
+                }
                 $this->throwOnError();
             } catch (\ErrorException $e) {
                 $code = $this->last_error['errno'];


### PR DESCRIPTION
The current code calls fwrite() even when select_write() returns 0, ie when the write is expected to fail with EAGAIN (Resource temporarily unavailable). This happens if the TCP transmit buffer is full.
In real life I have seen select() return 0 and fwrite() succeeds anyway - I guess some room became available between the two calls.
But at one point fwrite() *will* fail with EAGAIN - and then an AMQPIOException occurs.

With the proposed changes fwrite() will not result in EAGAIN. Instead the result is an AMQPTimeoutException if the fd is still blocking after $this->write_timeout.

(See https://github.com/php-amqplib/php-amqplib/discussions/1131 for a question about how the timeout should be calculated).

I don't know if this change should include any new tests.

I have used `rabbitmqctl set_vm_memory_high_watermark 0`on the RabbitMQ server to force the EAGAIN error when testing this issue.