### PR TITLE
Fix deprecation warning

### DIFF
--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -45,7 +45,7 @@ class AMQPStreamConnection extends AbstractConnection
         $ssl_protocol = null,
         ?AMQPConnectionConfig $config = null
     ) {
-        if (func_num_args() === 17 || ($ssl_protocol !== null && $ssl_protocol instanceof AMQPConnectionConfig === false)) {
+        if ($ssl_protocol !== null && $ssl_protocol instanceof AMQPConnectionConfig === false) {
             trigger_error(
                 '$ssl_protocol parameter is deprecated, use stream_context_set_option($context, \'ssl\', \'crypto_method\', $ssl_protocol) instead (see https://www.php.net/manual/en/function.stream-socket-enable-crypto.php for possible values)',
                 E_USER_DEPRECATED


### PR DESCRIPTION
func_num_args() === 17 is always true because the optional arguments