### PR TITLE
Widen `AMQPStreamConnection`'s `$ssl_protocol` parameter to accept `AMQPConnectionConfig`

### DIFF
--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -22,7 +22,7 @@ class AMQPStreamConnection extends AbstractConnection
      * @param bool $keepalive
      * @param int $heartbeat
      * @param float $channel_rpc_timeout
-     * @param string|null $ssl_protocol @deprecated
+     * @param string|AMQPConnectionConfig|null $ssl_protocol @deprecated
      * @param AMQPConnectionConfig|null $config
      * @throws \Exception
      */


### PR DESCRIPTION
Resolves #1136.

This PR simply widens the type of the parameter, but potentially renaming it to `$ssl_options_or_config` is wise while this is yet to be removed?