### PR TITLE
Delay stream resource init

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -53,10 +53,6 @@ class StreamIO extends AbstractIO
         }
          */
 
-        if (!is_resource($context) || get_resource_type($context) !== 'stream-context') {
-            $context = stream_context_create();
-        }
-
         $this->host = $host;
         $this->port = $port;
         $this->connection_timeout = $connection_timeout;
@@ -67,15 +63,6 @@ class StreamIO extends AbstractIO
         $this->heartbeat = $heartbeat;
         $this->initial_heartbeat = $heartbeat;
         $this->canDispatchPcntlSignal = $this->isPcntlSignalEnabled();
-
-        stream_context_set_option($this->context, 'socket', 'tcp_nodelay', true);
-
-        $options = stream_context_get_options($this->context);
-        if (!empty($options['ssl']) && !isset($options['ssl']['crypto_method'])) {
-            if (!stream_context_set_option($this->context, 'ssl', 'crypto_method', STREAM_CRYPTO_METHOD_ANY_CLIENT)) {
-                throw new AMQPIOException("Can not set ssl.crypto_method stream context option");
-            }
-        }
     }
 
     /**
@@ -91,6 +78,7 @@ class StreamIO extends AbstractIO
             $this->port
         );
 
+        $this->setupContext();
         $this->setErrorHandler();
 
         try {
@@ -155,6 +143,22 @@ class StreamIO extends AbstractIO
         }
 
         $this->heartbeat = $this->initial_heartbeat;
+    }
+
+    private function setupContext(): void
+    {
+        if (!is_resource($this->context) || get_resource_type($this->context) !== 'stream-context') {
+            $this->context = stream_context_create();
+        }
+
+        stream_context_set_option($this->context, 'socket', 'tcp_nodelay', true);
+
+        $options = stream_context_get_options($this->context);
+        if (!empty($options['ssl']) && !isset($options['ssl']['crypto_method'])) {
+            if (!stream_context_set_option($this->context, 'ssl', 'crypto_method', STREAM_CRYPTO_METHOD_ANY_CLIENT)) {
+                throw new AMQPIOException("Can not set ssl.crypto_method stream context option");
+            }
+        }
     }
 
     /**

--- a/tests/Functional/AbstractConnectionTest.php
+++ b/tests/Functional/AbstractConnectionTest.php
@@ -21,8 +21,9 @@ abstract class AbstractConnectionTest extends TestCaseCompat
         array $options = array()
     ): AbstractConnection {
         $timeout = $options['timeout'] ?? 1;
+        $lazy = $options['lazy'] ?? false;
         $config = new AMQPConnectionConfig();
-        $config->setIsLazy(false);
+        $config->setIsLazy($lazy);
         if ($type === 'ssl') {
             $config->setIoType(AMQPConnectionConfig::IO_TYPE_STREAM);
             $config->setIsSecure(true);
@@ -49,7 +50,9 @@ abstract class AbstractConnectionTest extends TestCaseCompat
         $config->setSendBufferSize(16384);
 
         $connection = AMQPConnectionFactory::create($config);
-        $this->assertTrue($connection->isConnected());
+        if (!$lazy) {
+            $this->assertTrue($connection->isConnected());
+        }
 
         return $connection;
     }

--- a/tests/Functional/Connection/ConnectionResourceLeakTest.php
+++ b/tests/Functional/Connection/ConnectionResourceLeakTest.php
@@ -26,7 +26,7 @@ class ConnectionResourceLeakTest extends AbstractConnectionTest
             $connections[] = $connection;
         }
 
-        self::assertSame($max, $this->getResourcesCount() - $previousNumberOfResources);
+        self::assertSame(0, $this->getResourcesCount() - $previousNumberOfResources);
     }
 
     private function getResourcesCount(): int

--- a/tests/Functional/Connection/ConnectionResourceLeakTest.php
+++ b/tests/Functional/Connection/ConnectionResourceLeakTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Functional\Connection;
+
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Tests\Functional\AbstractConnectionTest;
+
+/**
+ * @group connection
+ */
+class ConnectionResourceLeakTest extends AbstractConnectionTest
+{
+    /**
+     * @test
+     */
+    public function too_many_resources_after_close()
+    {
+        $max = 2000;
+        $connections = [];
+        $previousNumberOfResources = $this->getResourcesCount();
+
+        foreach (range(1, $max) as $i) {
+            /** @var AbstractConnection $connection */
+            $connection = $this->connection_create('stream', HOST, PORT, ['lazy' => true]);
+            $connection->close();
+            $connections[] = $connection;
+        }
+
+        self::assertSame($max, $this->getResourcesCount() - $previousNumberOfResources);
+    }
+
+    private function getResourcesCount(): int
+    {
+        return count(get_resources('stream-context'));
+    }
+
+}


### PR DESCRIPTION
Move stream context initialization from constructor to method `connect()`. This will make creation of lazy connection faster.

Based on #1151 and has less references to stream context if none is provided via constructor.

Possibly solves #1152 , but no confirmation yet.

