### PR TITLE
fix: throw exception on stream_socket_enable_crypto() warning

### DIFF
--- a/tests/Unit/Connection/AMQPConnectionConfigTest.php
+++ b/tests/Unit/Connection/AMQPConnectionConfigTest.php
@@ -50,7 +50,6 @@ class AMQPConnectionConfigTest extends TestCase
     public function secure_with_incorrect_crypto_method()
     {
         $this->expectException(AMQPIOException::class);
-        $this->expectExceptionMessage('Can not enable crypto');
 
         $cert_dir = realpath(__DIR__ . "/../../certs");
         $config = new AMQPConnectionConfig();


### PR DESCRIPTION
This fixes 2 issues introduced in version 3.6.0:
* all warnings from function `stream_socket_enable_crypto()` are ignored and it's not good, because they provide valueable info about wrong SSL options or peer validation issues. Any consequent call to that method makes no sense since handshake is failed and connection is not useable at all.
* no proper check for function return value -  according to docs, function returns 0 _if there isn't enough data and you should try again_, _false if negotiation has failed_, but that is not checked and loop continues without any delay until timeout is reached