### PR TITLE
Trigger ssl_protocol deprecation when it is really not null and not AMQPConnectionConfig instance

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -89,11 +89,11 @@ jobs:
       run: php ./tests/wait_broker.php
 
     - name: PHPUnit tests
-      run: ./vendor/bin/phpunit
+      run: ./vendor/bin/phpunit -d memory_limit=512M
       if: matrix.coverage == 'none'
 
     - name: PHPUnit tests + coverage
-      run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
+      run: ./vendor/bin/phpunit -d memory_limit=512M --coverage-clover=coverage.xml
       if: matrix.coverage != 'none'
 
     - name: Upload Codecov coverage

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -45,7 +45,7 @@ class AMQPStreamConnection extends AbstractConnection
         $ssl_protocol = null,
         ?AMQPConnectionConfig $config = null
     ) {
-        if (func_num_args() === 17 || ($ssl_protocol !== null && $ssl_protocol instanceof AMQPConnectionConfig === false)) {
+        if ($ssl_protocol !== null && $ssl_protocol instanceof AMQPConnectionConfig === false) {
             trigger_error(
                 '$ssl_protocol parameter is deprecated, use stream_context_set_option($context, \'ssl\', \'crypto_method\', $ssl_protocol) instead (see https://www.php.net/manual/en/function.stream-socket-enable-crypto.php for possible values)',
                 E_USER_DEPRECATED

--- a/tests/Unit/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Unit/Connection/AMQPStreamConnectionTest.php
@@ -38,9 +38,11 @@ class AMQPStreamConnectionTest extends TestCase
 
     /**
      * @test
+     * Generate deprecation warning if ssl_protocol is set
      */
     public function trigger_deprecation_is_ssl_protocl_set(): void
     {
+        // this is a workaround for deprecated PHPUnit functions
         set_error_handler(
             static function ($errno, $errstr) {
                 restore_error_handler();
@@ -76,6 +78,7 @@ class AMQPStreamConnectionTest extends TestCase
 
     /**
      * @test
+     * Generate deprecation warning if ssl_protocol is set with named parameters
      */
     public function trigger_deprecation_is_ssl_protocl_set_with_named_params(): void
     {
@@ -83,6 +86,7 @@ class AMQPStreamConnectionTest extends TestCase
             $this->markTestSkipped('Named parameters are available in PHP 8.0+');
         }
 
+        // this is a workaround for deprecated PHPUnit functions
         set_error_handler(
             static function ($errno, $errstr) {
                 restore_error_handler();

--- a/tests/Unit/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Unit/Connection/AMQPStreamConnectionTest.php
@@ -2,17 +2,19 @@
 
 namespace PhpAmqpLib\Tests\Unit\Connection;
 
+use InvalidArgumentException;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class AMQPStreamConnectionTest extends TestCase
 {
     /**
      * @test
      */
-    public function channel_rpc_timeout_should_be_invalid_if_greater_than_read_write_timeout()
+    public function channel_rpc_timeout_should_be_invalid_if_greater_than_read_write_timeout(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('channel RPC timeout must not be greater than I/O read-write timeout');
 
         new AMQPStreamConnection(
@@ -31,6 +33,77 @@ class AMQPStreamConnectionTest extends TestCase
             false,
             0,
             5.0
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function trigger_deprecation_is_ssl_protocl_set(): void
+    {
+        set_error_handler(
+            static function ($errno, $errstr) {
+                restore_error_handler();
+                throw new RuntimeException($errstr, $errno);
+            },
+            E_USER_DEPRECATED
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            '$ssl_protocol parameter is deprecated, use stream_context_set_option($context, \'ssl\', \'crypto_method\', $ssl_protocol) instead (see https://www.php.net/manual/en/function.stream-socket-enable-crypto.php for possible values)'
+        );
+
+        new AMQPStreamConnection(
+            HOST,
+            PORT,
+            USER,
+            PASS,
+            VHOST,
+            false,
+            'AMQPLAIN',
+            null,
+            'en_US',
+            3.0,
+            3.0,
+            null,
+            false,
+            0,
+            3.0,
+            'test_ssl_protocol'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function trigger_deprecation_is_ssl_protocl_set_with_named_params(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Named parameters are available in PHP 8.0+');
+        }
+
+        set_error_handler(
+            static function ($errno, $errstr) {
+                restore_error_handler();
+                throw new RuntimeException($errstr, $errno);
+            },
+            E_USER_DEPRECATED
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            '$ssl_protocol parameter is deprecated, use stream_context_set_option($context, \'ssl\', \'crypto_method\', $ssl_protocol) instead (see https://www.php.net/manual/en/function.stream-socket-enable-crypto.php for possible values)'
+        );
+
+        new AMQPStreamConnection(
+            host: HOST,
+            port: PORT,
+            user: USER,
+            password: PASS,
+            vhost: VHOST,
+            channel_rpc_timeout: 3.0,
+            ssl_protocol: 'test_ssl_protocol'
         );
     }
 }


### PR DESCRIPTION
As for PHP 8.0+ when using named params, func_num_args always return number of all params, because php de-facto inserts default values for that variables. This always generates deprecation warning.
In this PR I've deleted check for arguments number and leave only check for not null or AMQPConnectionConfig instance. That's enough for triggering deprecation.