### PR TITLE
Trigger ssl_protocol deprecation when it is really not null and not AMQPConnectionConfig instance

### DIFF
--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -45,7 +45,7 @@ class AMQPStreamConnection extends AbstractConnection
         $ssl_protocol = null,
         ?AMQPConnectionConfig $config = null
     ) {
-        if (func_num_args() === 17 || ($ssl_protocol !== null && $ssl_protocol instanceof AMQPConnectionConfig === false)) {
+        if ($ssl_protocol !== null && $ssl_protocol instanceof AMQPConnectionConfig === false) {
             trigger_error(
                 '$ssl_protocol parameter is deprecated, use stream_context_set_option($context, \'ssl\', \'crypto_method\', $ssl_protocol) instead (see https://www.php.net/manual/en/function.stream-socket-enable-crypto.php for possible values)',
                 E_USER_DEPRECATED

--- a/tests/Unit/Connection/AMQPStreamConnectionTest.php
+++ b/tests/Unit/Connection/AMQPStreamConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpAmqpLib\Tests\Unit\Connection;
 
+use InvalidArgumentException;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PHPUnit\Framework\TestCase;
 
@@ -10,9 +11,9 @@ class AMQPStreamConnectionTest extends TestCase
     /**
      * @test
      */
-    public function channel_rpc_timeout_should_be_invalid_if_greater_than_read_write_timeout()
+    public function channel_rpc_timeout_should_be_invalid_if_greater_than_read_write_timeout(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('channel RPC timeout must not be greater than I/O read-write timeout');
 
         new AMQPStreamConnection(
@@ -32,5 +33,45 @@ class AMQPStreamConnectionTest extends TestCase
             0,
             5.0
         );
+    }
+
+    /**
+     * @test
+     * Generate deprecation warning if ssl_protocol is set
+     */
+    public function trigger_deprecation_is_ssl_protocol_set(): void
+    {
+        $deprecationMessage = '';
+        $deprecationCode = '';
+        set_error_handler(
+            static function ($errno, $errstr) use (&$deprecationMessage, &$deprecationCode) {
+                $deprecationMessage = $errstr;
+                $deprecationCode = $errno;
+            },
+            E_USER_DEPRECATED
+        );
+
+        new AMQPStreamConnection(
+            HOST,
+            PORT,
+            USER,
+            PASS,
+            VHOST,
+            false,
+            'AMQPLAIN',
+            null,
+            'en_US',
+            3.0,
+            3.0,
+            null,
+            false,
+            0,
+            3.0,
+            'test_ssl_protocol'
+        );
+
+        restore_error_handler();
+        $this->assertEquals(E_USER_DEPRECATED, $deprecationCode);
+        $this->assertEquals('$ssl_protocol parameter is deprecated, use stream_context_set_option($context, \'ssl\', \'crypto_method\', $ssl_protocol) instead (see https://www.php.net/manual/en/function.stream-socket-enable-crypto.php for possible values)', $deprecationMessage);
     }
 }


### PR DESCRIPTION
As for PHP 8.0+ when using named params, func_num_args always return number of all params, because php de-facto inserts default values for that variables. This always generates deprecation warning.
In this PR I've deleted check for arguments number and leave only check for not null or AMQPConnectionConfig instance. That's enough for triggering deprecation.
For not named arguments nothing changes