### PR TITLE
fix: create a new exception for each warning in IO layer with reference to previous

### DIFF
--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -46,7 +46,7 @@ abstract class AbstractIO
     /** @var int|float */
     protected $last_write;
 
-    /** @var array<string, mixed>|null */
+    /** @var \ErrorException|null */
     protected $last_error;
 
     /** @var bool */
@@ -229,14 +229,10 @@ abstract class AbstractIO
 
     protected function throwOnError(): void
     {
-        if ($this->last_error !== null) {
-            throw new \ErrorException(
-                $this->last_error['errstr'],
-                0,
-                $this->last_error['errno'],
-                $this->last_error['errfile'],
-                $this->last_error['errline']
-            );
+        if ($this->last_error instanceof \ErrorException) {
+            $error = $this->last_error;
+            $this->last_error = null;
+            throw $error;
         }
     }
 
@@ -257,8 +253,8 @@ abstract class AbstractIO
     public function error_handler($errno, $errstr, $errfile, $errline): void
     {
         // throwing an exception in an error handler will halt execution
-        //   set the last error and continue
-        $this->last_error = compact('errno', 'errstr', 'errfile', 'errline');
+        // collect error continue
+        $this->last_error = new \ErrorException($errstr, $errno, 1, $errfile, $errline, $this->last_error);
     }
 
     protected function isPcntlSignalEnabled(): bool

--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -93,7 +93,7 @@ abstract class AbstractIO
             $result = $this->do_select($sec, $usec);
             $this->throwOnError();
         } catch (\ErrorException $e) {
-            throw new AMQPIOWaitException($e->getMessage(), $e->getCode(), $e);
+            throw new AMQPIOWaitException($e->getMessage(), $e->getCode(), $e->getPrevious());
         } finally {
             $this->restoreErrorHandler();
         }

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -92,7 +92,7 @@ class StreamIO extends AbstractIO
             );
             $this->throwOnError();
         } catch (\ErrorException $e) {
-            throw new AMQPIOException($e->getMessage());
+            throw new AMQPIOException($e->getMessage(), $e->getCode(), $e->getPrevious());
         } finally {
             $this->restoreErrorHandler();
         }
@@ -192,7 +192,7 @@ class StreamIO extends AbstractIO
                 $buffer = fread($this->sock, ($len - $read));
                 $this->throwOnError();
             } catch (\ErrorException $e) {
-                throw new AMQPDataReadException($e->getMessage(), $e->getCode(), $e);
+                throw new AMQPDataReadException($e->getMessage(), $e->getCode(), $e->getPrevious());
             } finally {
                 $this->restoreErrorHandler();
             }
@@ -451,7 +451,7 @@ class StreamIO extends AbstractIO
                 usleep(1e3);
             } while ($enabled === 0 && time() < $timeout_at);
         } catch (\ErrorException $exception) {
-            throw new AMQPIOException($exception->getMessage(), $exception->getCode(), $exception);
+            throw new AMQPIOException($exception->getMessage(), $exception->getCode(), $exception->getPrevious());
         } finally {
             $this->restoreErrorHandler();
         }

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -270,7 +270,7 @@ class StreamIO extends AbstractIO
                 }
                 $this->throwOnError();
             } catch (\ErrorException $e) {
-                $code = $this->last_error['errno'];
+                $code = $this->last_error->getCode();
                 $constants = SocketConstants::getInstance();
                 switch ($code) {
                     case $constants->SOCKET_EPIPE:


### PR DESCRIPTION
As described in #1181 , only last warning message is exposed making debugging more difficult.
After this change each warning will be stored as exception with reference to previous. Last one won't have $previous.

All errors(in reverse order) can be extracted by iterating recursively over previous exceptions:
```php
$previous = $exception;
do {
$messages[] = $previous->getMessage();
$previous = $exception->getPrevious();
} wihle ($previous !== null);
```

