### PR TITLE
AMQPConnectionClosedException is never thrown from checkConnection()

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -1558,7 +1558,6 @@ class AMQPChannel extends AbstractChannel
 
     /**
      * @throws AMQPChannelClosedException
-     * @throws AMQPConnectionClosedException
      * @throws AMQPConnectionBlockedException
      */
     private function checkConnection()


### PR DESCRIPTION
Hi,
This is a minor update to make the doc block of `checkConnection()` more accurate.