### PR TITLE
AMQP Exception marker interface is for `Throwable` types

### DIFF
--- a/PhpAmqpLib/Exception/AMQPExceptionInterface.php
+++ b/PhpAmqpLib/Exception/AMQPExceptionInterface.php
@@ -2,6 +2,8 @@
 
 namespace PhpAmqpLib\Exception;
 
-interface AMQPExceptionInterface
+use Throwable;
+
+interface AMQPExceptionInterface extends Throwable
 {
 }


### PR DESCRIPTION
This change fixes downstream `catch` mechanisms' type soundness, which rely on a `class-string<Throwable>` being used.