### PR TITLE
Fix wrong stream IO error code, improve write speed

### DIFF
--- a/PhpAmqpLib/Wire/IO/SocketIO.php
+++ b/PhpAmqpLib/Wire/IO/SocketIO.php
@@ -189,7 +189,12 @@ class SocketIO extends AbstractIO
             try {
                 $result = 0;
                 if ($this->select_write()) {
-                    $buffer = mb_substr($data, $written, self::BUFFER_SIZE, 'ASCII');
+                    // if data is smaller than buffer - no need to cut part of it
+                    if ($len <= self::BUFFER_SIZE) {
+                        $buffer = $data;
+                    } else {
+                        $buffer = mb_substr($data, $written, self::BUFFER_SIZE, 'ASCII');
+                    }
                     $result = socket_write($this->sock, $buffer);
                 }
                 $this->throwOnError();

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -265,16 +265,17 @@ class StreamIO extends AbstractIO
                 // check stream and prevent from high CPU usage
                 $result = 0;
                 if ($this->select_write()) {
-                    $buffer = mb_substr($data, $written, self::BUFFER_SIZE, 'ASCII');
+                    // if data is smaller than buffer - no need to cut part of it
+                    if ($len <= self::BUFFER_SIZE) {
+                        $buffer = $data;
+                    } else {
+                        $buffer = mb_substr($data, $written, self::BUFFER_SIZE, 'ASCII');
+                    }
                     $result = fwrite($this->sock, $buffer);
                 }
                 $this->throwOnError();
             } catch (\ErrorException $e) {
-                $code = 999;
-                if ($this->last_error != null)
-                {
-                    $code = $this->last_error->getCode();
-                }
+                $code = $e->getCode();
                 $constants = SocketConstants::getInstance();
                 switch ($code) {
                     case $constants->SOCKET_EPIPE:


### PR DESCRIPTION
This will fix workaround which was introduced in #1179. After latter PR, stream IO always reports exceptions with code `999`, which is not correct.

Also, -1 `mb_substr()` for data frames which are smaller than maximum buffer size, to improve write performance.