### PR TITLE
fix: Mark channels closed when connection is closed

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -207,9 +207,19 @@ class AMQPChannel extends AbstractChannel
         ), false, $this->channel_rpc_timeout);
     }
 
-    public function markClosed()
+    /**
+     * Closes a channel if no connection or a connection is closed
+     *
+     * @return bool
+     */
+    public function closeIfDisconnected(): bool
     {
+        if (!$this->connection || $this->connection->isConnected()) {
+            return false;
+        }
+
         $this->do_close();
+        return true;
     }
 
     /**

--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -207,6 +207,11 @@ class AMQPChannel extends AbstractChannel
         ), false, $this->channel_rpc_timeout);
     }
 
+    public function markClosed()
+    {
+        $this->do_close();
+    }
+
     /**
      * @param AMQPReader $reader
      * @throws AMQPProtocolChannelException

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -424,6 +424,7 @@ abstract class AbstractConnection extends AbstractChannel
         $this->frame_queue = new \SplQueue();
         $this->method_queue = [];
         $this->setIsConnected(false);
+        $this->markChannelsClosed();
         $this->close_input();
         $this->close_socket();
     }
@@ -1109,6 +1110,21 @@ abstract class AbstractConnection extends AbstractChannel
             } catch (\Exception $e) {
                 /* Ignore closing errors */
             }
+        }
+    }
+
+    /**
+     * Mark all available channels as closed
+     */
+    protected function markChannelsClosed()
+    {
+        foreach ($this->channels as $key => $channel) {
+            // channels[0] is this connection object, so don't close it yet
+            if ($key === 0) {
+                continue;
+            }
+
+            $channel->markClosed();
         }
     }
 

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -424,7 +424,7 @@ abstract class AbstractConnection extends AbstractChannel
         $this->frame_queue = new \SplQueue();
         $this->method_queue = [];
         $this->setIsConnected(false);
-        $this->markChannelsClosed();
+        $this->closeChannelsIfDisconnected();
         $this->close_input();
         $this->close_socket();
     }
@@ -1114,9 +1114,9 @@ abstract class AbstractConnection extends AbstractChannel
     }
 
     /**
-     * Mark all available channels as closed
+     * Closes all available channels if disconnected
      */
-    protected function markChannelsClosed()
+    protected function closeChannelsIfDisconnected()
     {
         foreach ($this->channels as $key => $channel) {
             // channels[0] is this connection object, so don't close it yet
@@ -1124,7 +1124,7 @@ abstract class AbstractConnection extends AbstractChannel
                 continue;
             }
 
-            $channel->markClosed();
+            $channel->closeIfDisconnected();
         }
     }
 

--- a/tests/Unit/Connection/AbstractConnectionTest.php
+++ b/tests/Unit/Connection/AbstractConnectionTest.php
@@ -2,9 +2,14 @@
 
 namespace PhpAmqpLib\Tests\Unit\Connection;
 
+use PhpAmqpLib\Channel\Frame;
+use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Connection\AMQPConnectionConfig;
 use PhpAmqpLib\Connection\AMQPConnectionFactory;
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Tests\Unit\Test\TestConnection;
+use PhpAmqpLib\Wire\IO\AbstractIO;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AbstractConnectionTest extends TestCase
@@ -38,5 +43,79 @@ class AbstractConnectionTest extends TestCase
         $property = $reflection->getProperty('login_response');
         $property->setAccessible(true);
         self::assertEquals($response, $property->getValue($connection));
+    }
+
+    /**
+     * @test
+     */
+    public function close_channels_if_disconnected(): void
+    {
+        $ioMock = $this->createMock(AbstractIO::class);
+        $config = new AMQPConnectionConfig();
+        $config->setIsLazy(false);
+
+        $args = [
+            $user = null,
+            $password = null,
+            $vhost = '/',
+            $insist = false,
+            $login_method = 'AMQPLAIN',
+            $login_response = null,
+            $locale = 'en_US',
+            $ioMock,
+            $heartbeat = 0,
+            $connectionTimeout = 0,
+            $channelRpcTimeout = 0.0,
+            $config
+        ];
+
+        /** @var MockObject&AbstractConnection $connection */
+        $connection = $this->getMockForAbstractClass(
+            AbstractConnection::class,
+            $args,
+            $mockClassName = '',
+            $callOriginalConstructor = true,
+            $callOriginalClone = true,
+            $callAutoload = true,
+            $mockedMethods = [
+                'connect',
+                'send_channel_method_frame',
+                'wait_channel',
+            ]
+        );
+
+        // Emulate channel.open_ok
+        $payload = pack('n2', 20, 11);
+        $connection
+            ->method('wait_channel')
+            ->willReturn(new Frame(
+                Frame::TYPE_METHOD,
+                1,
+                mb_strlen($payload),
+                $payload
+            ));
+        $newChannel = $connection->channel(1);
+        $this->assertTrue($newChannel->is_open());
+
+        // Emulate error to call do_close
+        $ioMock
+            ->expects($this->once())
+            ->method('select')
+            ->willThrowException(new AMQPConnectionClosedException('test'));
+        $ioMock
+            ->expects($this->once())
+            ->method('close');
+
+        $exception = null;
+        try {
+            $connection->select(3);
+        } catch (AMQPConnectionClosedException $exception) {
+        }
+
+        $this->assertInstanceOf(AMQPConnectionClosedException::class, $exception);
+        $this->assertEquals('test', $exception->getMessage());
+
+        // After do_close is called, channel must be inactive too
+        $this->assertFalse($newChannel->is_open());
     }
 }


### PR DESCRIPTION
### This PR fixes this situiation:
When a connection gets broken (Got AMQPConnectionClosedException) we need to mark all opened channels as closed OR it can lead to some bugs.

### Tested versions
- 3.7.0
- 3.7.1

### Warning
I added a new call to the `\PhpAmqpLib\Connection\AbstractConnection::do_close`, but I'm sure that it's the most proper way to fix this problem.

### Steps to reproduce:
```php
$connection = new \PhpAmqpLib\Connection\AMQPStreamConnection(
    $host,
    $port,
    $user,
    $pass,
);

$firstChannel = $connection->channel();
$secondChannel = $connection->channel();

$firstChannel->queue_declare('test');
$firstChannel->basic_consume('test', '', false, true, false, false, function (\PhpAmqpLib\Message\AMQPMessage $message) {
    $message->ack();
});
try {
    $firstChannel->wait();
    // Emulate closing: force close connection using management plugin
} catch (\PhpAmqpLib\Exception\AMQPConnectionClosedException $exception) {
    // We got AMQPChannelClosedException here
    var_dump($exception->getMessage() === 'CONNECTION_FORCED - Closed via management plugin(0, 0)'); 
    // Output: bool(true)
}

$connection->reconnect();
// Try to use old channel (expecting an exception AMQPChannelClosedException 'Channel connection is closed.')
$secondChannel->basic_publish(new \PhpAmqpLib\Message\AMQPMessage('test'), '', 'test');

try {
    // Try to get 
    $channelAfterReconnect = $connection->channel();
} catch (\PhpAmqpLib\Exception\AMQPConnectionClosedException $exception) {
    var_dump($exception->getMessage());
    // Output: string(47) "CHANNEL_ERROR - expected 'channel.open'(60, 40)"
}
```