### PR TITLE
fix: Deprecate implicitly nullable types

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -182,7 +182,7 @@ abstract class AbstractConnection extends AbstractChannel
         $login_method = 'AMQPLAIN',
         $login_response = null,
         $locale = 'en_US',
-        AbstractIO $io = null,
+        ?AbstractIO $io = null,
         $heartbeat = 0,
         $connection_timeout = 0,
         $channel_rpc_timeout = 0.0,

--- a/PhpAmqpLib/Exception/AMQPTimeoutException.php
+++ b/PhpAmqpLib/Exception/AMQPTimeoutException.php
@@ -9,7 +9,7 @@ class AMQPTimeoutException extends \RuntimeException implements AMQPExceptionInt
      */
     private $timeout;
 
-    public function __construct($message = '', $timeout = 0, $code = 0, \Exception $previous = null)
+    public function __construct($message = '', $timeout = 0, $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->timeout = $timeout;

--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -114,7 +114,7 @@ abstract class AMQPAbstractCollection implements \Iterator, \ArrayAccess
      */
     protected $data = array();
 
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (!empty($data)) {
             $this->data = $this->encodeCollection($data);

--- a/PhpAmqpLib/Wire/AMQPArray.php
+++ b/PhpAmqpLib/Wire/AMQPArray.php
@@ -8,7 +8,7 @@ class AMQPArray extends AMQPAbstractCollection
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct(empty($data) ? null : array_values($data));
     }


### PR DESCRIPTION
This pull request explicitly flags all nullable parameter. 

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types