### PR TITLE
Fix deprecation warnings with PHP 8.4

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -45,6 +45,10 @@ jobs:
             phpseclib: '^3.0'
             composer: 'composer:v2'
             coverage: none
+          - php: '8.4'
+            phpseclib: '^3.0'
+            composer: 'composer:v2'
+            coverage: none
 
     name: PHP ${{ matrix.php }} + phpseclib ${{ matrix.phpseclib }}
     env:

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -182,7 +182,7 @@ abstract class AbstractConnection extends AbstractChannel
         $login_method = 'AMQPLAIN',
         $login_response = null,
         $locale = 'en_US',
-        AbstractIO $io = null,
+        ?AbstractIO $io = null,
         $heartbeat = 0,
         $connection_timeout = 0,
         $channel_rpc_timeout = 0.0,

--- a/PhpAmqpLib/Exception/AMQPTimeoutException.php
+++ b/PhpAmqpLib/Exception/AMQPTimeoutException.php
@@ -9,7 +9,7 @@ class AMQPTimeoutException extends \RuntimeException implements AMQPExceptionInt
      */
     private $timeout;
 
-    public function __construct($message = '', $timeout = 0, $code = 0, \Exception $previous = null)
+    public function __construct($message = '', $timeout = 0, $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->timeout = $timeout;

--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -114,7 +114,7 @@ abstract class AMQPAbstractCollection implements \Iterator, \ArrayAccess
      */
     protected $data = array();
 
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         if (!empty($data)) {
             $this->data = $this->encodeCollection($data);

--- a/PhpAmqpLib/Wire/AMQPArray.php
+++ b/PhpAmqpLib/Wire/AMQPArray.php
@@ -8,7 +8,7 @@ class AMQPArray extends AMQPAbstractCollection
     /**
      * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct(empty($data) ? null : array_values($data));
     }


### PR DESCRIPTION
Closes #1198 

This PR fixes a few deprecation warnings reported while using this library with PHP 8.4

Those warnings are related with implicit nullability in some typed function arguments. The solution involves explicitly marking them as nullable.

Additionally, I have added PHP 8.4 to the phpunit workflow matrix, to verify no more deprecation warnings were reported.