### PR TITLE
Fix PHP 8.5 deprecation when not specifying a `$channel_id` when opening a channel

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -719,7 +719,7 @@ abstract class AbstractConnection extends AbstractChannel
         if (!$this->is_connected) {
             $this->connect();
         }
-        if (isset($this->channels[$channel_id])) {
+        if ($channel_id !== null && isset($this->channels[$channel_id])) {
             return $this->channels[$channel_id];
         }
 


### PR DESCRIPTION
> Deprecated: Using null as an array offset is deprecated, use an empty string instead

Since a `null` channel ID means that a channel ID is automatically selected, there can never be a cached channel within the `$this->channels` array. We thus skip the lookup entirely in these cases to be explicit about what is happening.