### PR TITLE
Remove composer:1 tests from CI

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,39 +15,27 @@ jobs:
         include:
           - php: '7.2'
             phpseclib: '^2.0'
-            composer: 'composer:v1'
             coverage: none
           - php: '7.3'
             phpseclib: '^3.0'
-            composer: 'composer:v1'
             coverage: none
           - php: '7.4'
             phpseclib: '^3.0'
-            composer: 'composer:v1'
-            coverage: none
-          - php: '7.4'
-            phpseclib: '^3.0'
-            composer: 'composer:v2'
             coverage: 'xdebug'
           - php: '8.0'
             phpseclib: '^3.0'
-            composer: 'composer:v2'
             coverage: none
           - php: '8.1'
             phpseclib: '^3.0'
-            composer: 'composer:v2'
             coverage: none
           - php: '8.2'
             phpseclib: '^3.0'
-            composer: 'composer:v2'
             coverage: none
           - php: '8.3'
             phpseclib: '^3.0'
-            composer: 'composer:v2'
             coverage: none
           - php: '8.4'
             phpseclib: '^3.0'
-            composer: 'composer:v2'
             coverage: none
 
     name: PHP ${{ matrix.php }} + phpseclib ${{ matrix.phpseclib }}
@@ -67,7 +55,6 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        tools: ${{ matrix.composer }}
         extensions: bcmath, curl, dom, mbstring, pcntl, sockets, xml
         coverage: ${{ matrix.coverage }}
 


### PR DESCRIPTION
Composer 1 support has been shut down in Packagist:

> Warning from https://repo.packagist.org: Support for Composer 1 has been
> shutdown on September 1st 2025. You should upgrade to Composer 2. See
> https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/