### PR TITLE
Fix PHP 8.5 deprecation in basic_consume when consumer_tag is null

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -1024,7 +1024,9 @@ class AMQPChannel extends AbstractChannel
             ), false, $this->channel_rpc_timeout);
         }
 
-        $this->callbacks[$consumer_tag] = $callback;
+        if ($consumer_tag !== null) {
+            $this->callbacks[$consumer_tag] = $callback;
+        }
 
         return $consumer_tag;
     }


### PR DESCRIPTION
The `wait()` method can return `null` (e.g. when the while loop in `AbstractChannel::wait()` exits without dispatching). In `basic_consume`, this null value is then used as an array offset:

```php
$this->callbacks[$consumer_tag] = $callback;
```

This triggers the PHP 8.5 deprecation:

```
Deprecated: Using null as an array offset is deprecated, use an empty string instead
```

This adds a null check before using `$consumer_tag` as an array key.