### PR TITLE
feat: add getProperties alias for PSR-2 compliance

### DIFF
--- a/PhpAmqpLib/Message/AMQPMessage.php
+++ b/PhpAmqpLib/Message/AMQPMessage.php
@@ -428,6 +428,16 @@ class AMQPMessage
     }
 
     /**
+     * Returns the properties content
+     *
+     * @return array
+     */
+    public function getProperties()
+    {
+        return $this->get_properties();
+    }
+
+    /**
      * Sets a property value
      *
      * @param string $name The property name (one of the property definition)


### PR DESCRIPTION
Following PSR-2 standards, method names must be declared in camelCase.