### PR TITLE
tests: declare durable queues so the suite runs on RabbitMQ 4.3+

### DIFF
--- a/tests/Functional/AbstractConnectionTest.php
+++ b/tests/Functional/AbstractConnectionTest.php
@@ -60,7 +60,7 @@ abstract class AbstractConnectionTest extends TestCaseCompat
     protected function queue_bind(AMQPChannel $channel, $exchange_name, &$queue_name)
     {
         $channel->exchange_declare($exchange_name, AMQPExchangeType::DIRECT);
-        list($queue_name, ,) = $channel->queue_declare();
+        list($queue_name, ,) = $channel->queue_declare('', false, true);
         $channel->queue_bind($queue_name, $exchange_name, $queue_name);
     }
 

--- a/tests/Functional/Bug/Bug256Test.php
+++ b/tests/Functional/Bug/Bug256Test.php
@@ -37,7 +37,7 @@ class Bug256Test extends AbstractConnectionTest
         $this->connection2 = $this->connection_create('stream');
         $this->channel2 = $this->connection->channel();
 
-        list($this->queueName, ,) = $this->channel2->queue_declare();
+        list($this->queueName, ,) = $this->channel2->queue_declare('', false, true);
         $this->channel2->queue_bind($this->queueName, $this->exchangeName, $this->queueName);
     }
 

--- a/tests/Functional/Bug/Bug40Test.php
+++ b/tests/Functional/Bug/Bug40Test.php
@@ -32,8 +32,8 @@ class Bug40Test extends TestCaseCompat
         $this->channel2 = $this->connection->channel();
 
         $this->channel->exchange_declare($this->exchangeName, 'direct', false, false, false);
-        list($this->queueName1, ,) = $this->channel->queue_declare();
-        list($this->queueName2, ,) = $this->channel->queue_declare();
+        list($this->queueName1, ,) = $this->channel->queue_declare('', false, true);
+        list($this->queueName2, ,) = $this->channel->queue_declare('', false, true);
         $this->channel->queue_bind($this->queueName1, $this->exchangeName, $this->queueName1);
         $this->channel->queue_bind($this->queueName2, $this->exchangeName, $this->queueName2);
     }

--- a/tests/Functional/Channel/ChannelConsumeTest.php
+++ b/tests/Functional/Channel/ChannelConsumeTest.php
@@ -10,7 +10,7 @@ class ChannelConsumeTest extends ChannelTestCase
     public function basic_consume_same_tag_throws_exception()
     {
         $this->expectException(\InvalidArgumentException::class);
-        list($queue, ,) = $this->channel->queue_declare();
+        list($queue, ,) = $this->channel->queue_declare('', false, true);
         $consumerTag = $this->channel->basic_consume($queue, '');
         $this->channel->basic_consume($queue, $consumerTag);
     }

--- a/tests/Functional/Channel/DirectExchangeTest.php
+++ b/tests/Functional/Channel/DirectExchangeTest.php
@@ -47,7 +47,7 @@ class DirectExchangeTest extends ChannelTestCase
     public function basic_consume_foo()
     {
         $this->channel->exchange_declare($this->exchange->name, 'direct', false, false, false);
-        list($this->queue->name, ,) = $this->channel->queue_declare();
+        list($this->queue->name, ,) = $this->channel->queue_declare('', false, true);
         $this->channel->queue_bind($this->queue->name, $this->exchange->name, $this->queue->name);
 
         $this->message = (object) [

--- a/tests/Functional/Channel/HeadersExchangeTest.php
+++ b/tests/Functional/Channel/HeadersExchangeTest.php
@@ -24,13 +24,13 @@ class HeadersExchangeTest extends ChannelTestCase
      */
     public function consume_specific_headers()
     {
-        list($queue1) = $this->channel->queue_declare();
+        list($queue1) = $this->channel->queue_declare('', false, true);
         $this->channel->queue_bind($queue1, $this->exchange->name);
 
         $bindArguments = [
             'foo' => 'bar',
         ];
-        list($queue2) = $this->channel->queue_declare();
+        list($queue2) = $this->channel->queue_declare('', false, true);
         $this->channel->queue_bind($queue2, $this->exchange->name, '', false, new AMQPTable($bindArguments));
 
         // publish message without headers - should appear in 1st queue without filters

--- a/tests/Functional/Channel/TopicExchangeTest.php
+++ b/tests/Functional/Channel/TopicExchangeTest.php
@@ -61,7 +61,7 @@ class TopicExchangeTest extends ChannelTestCase
         $connection2 = new AMQPSocketConnection(HOST, PORT, USER, PASS, VHOST);
         $channel2 = $connection2->channel();
 
-        $channel2->queue_declare('tst.queue3');
+        $channel2->queue_declare('tst.queue3', false, true);
         $channel2->queue_bind('tst.queue3', $this->exchange->name, '#');
 
         $this->channel->basic_publish(new AMQPMessage('foo'), $this->exchange->name);

--- a/tests/Functional/Connection/Heartbeat/SignalHeartbeatTest.php
+++ b/tests/Functional/Connection/Heartbeat/SignalHeartbeatTest.php
@@ -45,7 +45,7 @@ class SignalHeartbeatTest extends AbstractConnectionTest
         $this->sender = new PCNTLHeartbeatSender($this->connection);
         $this->channel = $this->connection->channel();
         $this->channel->exchange_declare($this->exchangeName, 'direct', false, false, false);
-        list($this->queueName, ,) = $this->channel->queue_declare();
+        list($this->queueName, ,) = $this->channel->queue_declare('', false, true);
         $this->channel->queue_bind($this->queueName, $this->exchangeName, $this->queueName);
     }
 

--- a/tests/Functional/FileTransferTest.php
+++ b/tests/Functional/FileTransferTest.php
@@ -26,7 +26,7 @@ class FileTransferTest extends TestCaseCompat
         $this->connection = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
         $this->channel = $this->connection->channel();
         $this->channel->exchange_declare($this->exchangeName, 'direct', false, false, false);
-        list($this->queueName, ,) = $this->channel->queue_declare();
+        list($this->queueName, ,) = $this->channel->queue_declare('', false, true);
         $this->channel->queue_bind($this->queueName, $this->exchangeName, $this->queueName);
     }
 

--- a/tests/Functional/Message/AMQPMessageTest.php
+++ b/tests/Functional/Message/AMQPMessageTest.php
@@ -17,7 +17,7 @@ class AMQPMessageTest extends ChannelTestCase
     public function double_ack_throws_exception()
     {
         $sent = new AMQPMessage('test' . mt_rand());
-        list($queue) = $this->channel->queue_declare();
+        list($queue) = $this->channel->queue_declare('', false, true);
         $this->channel->basic_publish($sent, '', $queue);
 
         $received = $this->channel->basic_get($queue);
@@ -45,7 +45,7 @@ class AMQPMessageTest extends ChannelTestCase
     {
         $message = new AMQPMessage('test' . mt_rand());
         $confirmed = null;
-        list($queue) = $this->channel->queue_declare();
+        list($queue) = $this->channel->queue_declare('', false, true);
         $this->channel->set_ack_handler(
             function (AMQPMessage $message) use (&$confirmed) {
                 $confirmed = $message;

--- a/tests/Functional/ReconnectConnectionTest.php
+++ b/tests/Functional/ReconnectConnectionTest.php
@@ -136,7 +136,7 @@ class ReconnectConnectionTest extends TestCaseCompat
     {
         $this->channel = $this->connection->channel();
         $this->channel->exchange_declare($this->exchange, 'direct', false, false, false);
-        $this->channel->queue_declare($this->queue);
+        $this->channel->queue_declare($this->queue, false, true);
         $this->channel->queue_bind($this->queue, $this->exchange, $this->queue);
     }
 


### PR DESCRIPTION
Fixes #1241

RabbitMQ 4.3 flipped the `transient_nonexcl_queues` deprecated feature from `permitted_by_default` to `denied_by_default`, so the broker refuses non-durable, non-exclusive classic queues. `.ci/ubuntu/gha-setup.sh` pulls the unpinned `rabbitmq:management` tag, which now resolves to 4.3.x, and every functional test that declares a queue was taking `queue_declare()`'s defaults - `durable=false, exclusive=false`, exactly the combination that's refused. That's 32 errors on every PHP version in the matrix.

This turns `durable` on at the 14 call sites that needed it. Nothing else changes: the queues stay non-exclusive and keep `auto_delete`, so visibility and cleanup behave as before and only persistence differs.

**Why durable and not exclusive**

Declaring the queues exclusive also satisfies the broker, and I tried that first. It breaks the tests that deliberately destroy connections. An exclusive queue dies with its connection, which unbinds it, which auto-deletes the shared `test_exchange_broken` (`exchange_declare` defaults to `auto_delete=true`), and the next test then races that deletion and fails with `NOT_FOUND - no exchange 'test_exchange_broken'`. It's intermittent, which makes it worse. `durable` is also the smaller semantic change - `exclusive` alters both visibility and lifetime, `durable` only alters persistence.

**Verification**

| Broker | Deprecated features | Result |
|---|---|---|
| 4.3.5 | **nothing permitted** | `OK` - 864 tests, 1288 assertions, 0 failures |
| 3.13.7 | (as pinned by `docker-compose.yaml`) | `OK` - 864 tests, 1288 assertions, 0 failures |

Run three times in a row on 4.3.5 against a reused broker, so the second and third runs re-declared queues that already existed as durable. No `inequivalent arg` problems. `vendor/bin/phpcs` is clean.

Worth knowing for anyone testing this locally: if you already have a broker holding a *transient* `reconnect_queue` from before this change, your first run will hit `PRECONDITION_FAILED - inequivalent arg 'durable'`. `ReconnectConnectionTest::tearDownCompat` deletes the queue, so it sorts itself out after one run. CI never sees it because the broker is fresh every time.

**On the tests requirement**

CONTRIBUTING asks for tests with every patch and I can't really add one here, since the change *is* to the tests. The existing suite going from 32 errors to 0 against a strict broker is the only evidence this kind of change can offer.

**Deliberately not in this PR**

- Pinning the CI image, or adding a job against the newest broker with all deprecated features denied.
- `queue_declare()`'s own defaults, which is the user-facing half of this and needs a maintainer decision - discussed in the issue.
- `tests/rabbitmq.conf` and `docker-compose.yaml`'s `rabbitmq:3-management` pin.
- The pre-existing duplicate `listeners.tcp.default` / `listeners.ssl.default` block in `.ci/ubuntu/rabbitmq.conf`. Unrelated, and tidying it here would just muddy the diff.

If you'd rather have CI green in one line while you review this, `deprecated_features.permit.transient_nonexcl_queues = true` in `.ci/ubuntu/rabbitmq.conf` does it, and I can send that separately. It's a stopgap though, since RabbitMQ intends to remove the feature regardless of config.
